### PR TITLE
refactor: emit jsxRanges from compiler, drop ts-plugin regex scans

### DIFF
--- a/packages/compiler/AGENTS.md
+++ b/packages/compiler/AGENTS.md
@@ -8,10 +8,11 @@ TypeScript with every `<...>` expression rewritten as an
 brackets — they are gone before tsc, Vite, or any other downstream
 tool sees the file.
 
-Entry point: `transformEfx(source, filename) → { code, map }`.
+Entry point: `transformEfx(source, filename) → { code, map, jsxRanges }`.
 Used by `@efx/vite-plugin`, `@efx/ts-plugin`, and the `efx-compile`
 CLI (`src/cli.ts`, which writes sibling `.ts` files so plain `tsc`
-works without a plugin).
+works without a plugin). Vite and the CLI ignore `jsxRanges`; the
+TS plugin consumes it.
 
 ## Why Babel, not tsc/swc
 
@@ -116,6 +117,31 @@ If you add a new node kind to the emit (e.g., a future
 `h.something(...)` call from a new compiler rewrite), wrap its
 constructors in `copyLoc` against the source node they replace.
 
+## `jsxRanges` — source-side metadata for downstream tools
+
+Alongside `code` and `map`, the transform emits one `JsxRange` per
+`JSXElement` / `JSXFragment` the parser saw, in source order
+(pre-order: outer before nested). Each range carries:
+
+- `start` / `end` — the full node span (`<div>...</div>`)
+- `openingTag.start` / `.end` — the `<...>` part
+- `openingTag.nameStart` / `.nameEnd` — just the tag name span
+  (covers dotted names: `<Foo.Bar>` → name is `Foo.Bar`)
+- `closingTag` — same shape, omitted when `isSelfClosing`
+- Fragments (`kind: "fragment"`) have no name positions; their
+  `openingTag` is `<>`, `closingTag` is `</>`
+
+This exists so consumers (today: `@efx/ts-plugin`) don't have to
+re-discover JSX structure by regex-scanning the source or the
+compiled output. The Babel AST already knows these positions; we
+report them. Anti-pattern: anywhere in the workspace running a
+JSX-shaped regex against `.efx` content — they should consume
+`jsxRanges` instead.
+
+If you add a new compiler output shape (e.g. richer mappings,
+embedded codes), keep `jsxRanges` as a plain serializable array —
+the contract is structural, not class-based.
+
 ## Tests
 
 `src/transform.test.ts` — 28 cases via `vitest`. Coverage includes:
@@ -129,7 +155,9 @@ attributes, source maps. Run with `pnpm --filter @efx/compiler test`.
 - No reactivity wiring. `h.track`/`read`/`peek` live in
   `@efx/runtime`; the compiler only emits *calls* to them.
 - No source-map remapping for diagnostics. That's the
-  `@efx/ts-plugin` consumer's job.
+  `@efx/ts-plugin` consumer's job. We DO emit the source-side
+  `jsxRanges` it needs to classify positions; the actual mapping
+  decode (Babel VLQ → Volar `Mapping<CodeInformation>`) lives there.
 - No file watching, no caching. Pure function of `(source, filename)`.
   Callers cache.
 

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -1,1 +1,9 @@
-export { transformEfx, type TransformResult } from "./transform.ts"
+export {
+  transformEfx,
+  type TransformResult,
+  type JsxRange,
+  type JsxElementRange,
+  type JsxFragmentRange,
+  type NamedTagPosition,
+  type TagPosition,
+} from "./transform.ts"

--- a/packages/compiler/src/transform.test.ts
+++ b/packages/compiler/src/transform.test.ts
@@ -147,6 +147,78 @@ describe("runtime auto-imports", () => {
   })
 })
 
+describe("jsxRanges output", () => {
+  const ranges = (src: string) => transformEfx(src, "test.efx").jsxRanges
+
+  const firstElement = (src: string) => {
+    const rs = ranges(src)
+    const r = rs[0]
+    if (!r || r.kind !== "element") throw new Error("expected first range to be element")
+    return r
+  }
+
+  it("single element records its full span and tag name positions", () => {
+    const src = `const x = <div>hi</div>`
+    const r = firstElement(src)
+    expect(src.slice(r.start, r.end)).toBe(`<div>hi</div>`)
+    expect(src.slice(r.openingTag.start, r.openingTag.end)).toBe(`<div>`)
+    expect(src.slice(r.openingTag.nameStart, r.openingTag.nameEnd)).toBe(`div`)
+    expect(r.isSelfClosing).toBe(false)
+    const closing = r.closingTag
+    if (!closing) throw new Error("expected closingTag")
+    expect(src.slice(closing.start, closing.end)).toBe(`</div>`)
+    expect(src.slice(closing.nameStart, closing.nameEnd)).toBe(`div`)
+  })
+
+  it("self-closing element has no closingTag and isSelfClosing=true", () => {
+    const src = `const x = <Foo bar={1} />`
+    const r = firstElement(src)
+    expect(r.isSelfClosing).toBe(true)
+    expect(r.closingTag).toBeUndefined()
+    expect(src.slice(r.openingTag.nameStart, r.openingTag.nameEnd)).toBe(`Foo`)
+  })
+
+  it("fragment records both <> and </> tag positions, no names", () => {
+    const src = `const x = <><span /></>`
+    const frag = ranges(src).find((r) => r.kind === "fragment")
+    if (!frag || frag.kind !== "fragment") throw new Error("expected fragment")
+    expect(src.slice(frag.openingTag.start, frag.openingTag.end)).toBe(`<>`)
+    expect(src.slice(frag.closingTag.start, frag.closingTag.end)).toBe(`</>`)
+  })
+
+  it("nested elements emit parent before children in source order", () => {
+    const src = `const x = <div><span>a</span></div>`
+    const rs = ranges(src)
+    expect(rs.length).toBe(2)
+    const [outer, inner] = rs
+    if (!outer || !inner) throw new Error("expected two ranges")
+    expect(outer.kind).toBe("element")
+    expect(inner.kind).toBe("element")
+    expect(src.slice(outer.start, outer.end)).toBe(`<div><span>a</span></div>`)
+    expect(src.slice(inner.start, inner.end)).toBe(`<span>a</span>`)
+  })
+
+  it("dotted member tag name covers the full Foo.Bar span", () => {
+    const src = `const x = <Foo.Bar />`
+    const r = firstElement(src)
+    expect(src.slice(r.openingTag.nameStart, r.openingTag.nameEnd)).toBe(`Foo.Bar`)
+  })
+
+  it("ranges are empty when there's no JSX", () => {
+    expect(ranges(`const x = 1`)).toEqual([])
+  })
+
+  it("ternary branches both produce ranges", () => {
+    const src = `const x = <div>{cond ? <a /> : <b />}</div>`
+    const tags = ranges(src)
+      .filter((r) => r.kind === "element")
+      .map((r) => src.slice(r.openingTag.nameStart, r.openingTag.nameEnd))
+    expect(tags).toContain("div")
+    expect(tags).toContain("a")
+    expect(tags).toContain("b")
+  })
+})
+
 describe("TypeScript syntax survives", () => {
   it("type annotations are preserved", () => {
     expect(compile(`const greet = (name: string) => <p>hi {name}</p>`))

--- a/packages/compiler/src/transform.ts
+++ b/packages/compiler/src/transform.ts
@@ -13,7 +13,50 @@ const generate: typeof _generate =
 export interface TransformResult {
   readonly code: string
   readonly map: object | null
+  readonly jsxRanges: ReadonlyArray<JsxRange>
 }
+
+/** Source-side span. All offsets are 0-based byte indices into the original `.efx` source. */
+export interface TagPosition {
+  readonly start: number
+  readonly end: number
+}
+
+/** Tag span carrying the name sub-range — `<Foo`'s "Foo" lives at `nameStart..nameEnd`. */
+export interface NamedTagPosition extends TagPosition {
+  readonly nameStart: number
+  readonly nameEnd: number
+}
+
+/** A `<Tag>...</Tag>` (or `<Tag />`) range. `closingTag` is `undefined` when `isSelfClosing`. */
+export interface JsxElementRange {
+  readonly kind: "element"
+  readonly start: number
+  readonly end: number
+  readonly isSelfClosing: boolean
+  readonly openingTag: NamedTagPosition
+  readonly closingTag?: NamedTagPosition
+}
+
+/** A `<>...</>` fragment range. Tags have no name positions. */
+export interface JsxFragmentRange {
+  readonly kind: "fragment"
+  readonly start: number
+  readonly end: number
+  readonly openingTag: TagPosition
+  readonly closingTag: TagPosition
+}
+
+/**
+ * Source-side metadata about a JSX node the compiler rewrote into an `h()` call.
+ * Emitted in pre-order: outermost node first, then nested children in source order.
+ *
+ * Consumed by `@efx/ts-plugin` to identify "inside-h()" positions, JSX punctuation,
+ * and tag-pair partners without re-parsing the source or scanning the compiled
+ * output with regex. The producer (Babel AST) has the exact positions; we report
+ * them so consumers don't have to recover them.
+ */
+export type JsxRange = JsxElementRange | JsxFragmentRange
 
 const PARSER_OPTIONS: ParserOptions = {
   sourceType: "module",
@@ -248,6 +291,52 @@ const ensureRuntimeImports = (program: t.Program, wantFragment: boolean): void =
   }
 }
 
+/**
+ * Build a JsxRange from a Babel AST node. Reads `start`/`end` from the parser —
+ * always set when the AST came from `@babel/parser` with positions enabled.
+ */
+const collectJsxRange = (node: t.JSXElement | t.JSXFragment): JsxRange => {
+  if (t.isJSXFragment(node)) {
+    return {
+      kind: "fragment",
+      start: node.start!,
+      end: node.end!,
+      openingTag: {
+        start: node.openingFragment.start!,
+        end: node.openingFragment.end!,
+      },
+      closingTag: {
+        start: node.closingFragment.start!,
+        end: node.closingFragment.end!,
+      },
+    }
+  }
+  const opening = node.openingElement
+  const closing = node.closingElement
+  const base: JsxElementRange = {
+    kind: "element",
+    start: node.start!,
+    end: node.end!,
+    isSelfClosing: opening.selfClosing,
+    openingTag: {
+      start: opening.start!,
+      end: opening.end!,
+      nameStart: opening.name.start!,
+      nameEnd: opening.name.end!,
+    },
+  }
+  if (!closing) return base
+  return {
+    ...base,
+    closingTag: {
+      start: closing.start!,
+      end: closing.end!,
+      nameStart: closing.name.start!,
+      nameEnd: closing.name.end!,
+    },
+  }
+}
+
 /** Transform a JSX element or fragment node into an h(...) call expression. */
 const transformJsxNode = (node: t.JSXElement | t.JSXFragment): t.CallExpression => {
   const tag: t.Expression = t.isJSXFragment(node)
@@ -281,6 +370,21 @@ export const transformEfx = (source: string, filename: string): TransformResult 
   const ast = parse(source, {
     ...PARSER_OPTIONS,
     sourceFilename: filename,
+  })
+
+  // Pre-pass: collect a JsxRange for every JSXElement/JSXFragment in source order.
+  // The rewrite pass below uses path.replaceWith, which only visits outermost JSX
+  // (nested children get rewritten recursively inside transformJsxNode and are no
+  // longer JSX nodes by the time Babel would visit them). Collecting separately
+  // beforehand is the cleanest way to see every node.
+  const jsxRanges: JsxRange[] = []
+  traverse(ast, {
+    JSXElement(path: NodePath<t.JSXElement>) {
+      jsxRanges.push(collectJsxRange(path.node))
+    },
+    JSXFragment(path: NodePath<t.JSXFragment>) {
+      jsxRanges.push(collectJsxRange(path.node))
+    },
   })
 
   let usedH = false
@@ -318,5 +422,6 @@ export const transformEfx = (source: string, filename: string): TransformResult 
   return {
     code: result.code,
     map: (result.map as object | null) ?? null,
+    jsxRanges,
   }
 }

--- a/packages/ts-plugin/AGENTS.md
+++ b/packages/ts-plugin/AGENTS.md
@@ -17,7 +17,7 @@ The whole file: `src/index.ts`. Read it with this map.
 
 | File | Purpose |
 |---|---|
-| `src/index.ts` | Everything — Volar language plugin, source-map conversion, JSX-tag-matching, proxy wrapper. ~750 LOC. |
+| `src/index.ts` | Everything — Volar language plugin, source-map conversion, JSX-tag-matching, proxy wrapper. ~650 LOC. |
 | `src/plugin.test.mjs` | Unit-style smoke checks on internal helpers. |
 | `test/integration.mjs` | tsserver-subprocess harness. The acceptance-level check that the plugin really works end-to-end. |
 | `build.mjs` | esbuild bundle producing `dist/index.cjs` (tsserver `require()`s the plugin as CJS). |
@@ -84,9 +84,16 @@ range, which language features apply. We model three regions
 | Inside an `h(...)` call (the JSX-compiled internals) | `noHighlightData` | `semantic.shouldHighlight: () => false` | Without this, cursor on tag name highlights every `h` identifier in the file. Hover/completions still work. |
 | JSX punctuation `<` `>` `/` | `structuralOnlyData` | `semantic: false`, `completion: false`, `navigation: false` | Cursor on `<` shouldn't navigate to `h`'s definition or highlight every `<` in the file. |
 
-`findHCallPositions(code)` does a regex+paren-depth scan to find
-every `h(...)` range. `jsxPunctuation` is a hard-coded set
-`{"<", ">", "/"}` consulted by source character.
+The decision is driven by `result.jsxRanges` from `@efx/compiler`:
+
+- "Inside an `h(...)` call" = source offset falls inside any
+  `JsxRange.start..end`. No regex scan of the compiled output.
+- JSX punctuation = source character is `<`/`>`/`/` AND the source
+  offset is inside an `openingTag` or `closingTag` span (so
+  `{a > b}` inside a JSX expression doesn't false-positive).
+
+The producer (Babel) already knows these positions exactly. We
+read them from `jsxRanges` rather than re-derive them.
 
 The mappings are also **deduplicated by source offset** (first
 mapping wins) and **lengths extend to the next mapping's source
@@ -112,12 +119,13 @@ Volar produces a working LanguageService. We then wrap it in a
     source offset via `compiledToSourceOffset`
 
 - **`getDocumentHighlights`** — `.efx`-only custom path. If the
-  cursor is on a JSX tag name (verified by `findJsxTagAtPosition`),
-  we run `findMatchingJsxTag` to find the partner (`<Foo>` ↔
-  `</Foo>`) and highlight just the names. Falls back to Volar's
-  default for anything else. The custom-regex matcher accounts
-  for nested same-name tags via a depth counter, and handles
-  self-closing forms (`<Foo />`).
+  cursor is on a JSX tag (anywhere on the brackets or name, but
+  not on attributes), `findJsxTagPair` walks `cache.jsxRanges` and
+  returns the matching opening↔closing name spans. Highlights just
+  the names. Babel paired the tags during parse; we don't depth-
+  count or regex-scan. Self-closing (`<Foo />`) and fragments
+  (`<>...</>`) return no pair. Falls back to Volar's default
+  outside JSX tags.
 
 - **`provideInlayHints`** — `.efx`-only filter. Volar gives us all
   hints including the h() parameter labels (`_tag`, `_props`,
@@ -183,6 +191,15 @@ deleting on-disk `.ts` files; module resolution depends on them.
   locations on emitted nodes. Without that, Babel's source map
   collapses everything to the start of the JSX expression, and
   go-to-definition lands on the wrong token.
+
+- **`@efx/compiler` `jsxRanges`** — `TransformResult.jsxRanges` is
+  load-bearing for two of this plugin's features: classifying
+  source positions as "inside h()" or "JSX punctuation" during
+  source-map conversion, and finding tag-pair partners for
+  document highlights. If the compiler ever stops emitting it
+  (e.g. swc swap), both features break silently. Cache the array
+  in `SourceMapCache` next to `mappings` so the proxy wrapper can
+  read it without re-running the compiler.
 
 ## Anti-patterns
 

--- a/packages/ts-plugin/src/index.ts
+++ b/packages/ts-plugin/src/index.ts
@@ -9,7 +9,7 @@
 import { createLanguageServicePlugin } from "@volar/typescript/lib/quickstart/createLanguageServicePlugin"
 import type { LanguagePlugin, VirtualCode, CodeInformation } from "@volar/language-core"
 import type { Mapping } from "@volar/source-map"
-import { transformEfx } from "@efx/compiler"
+import { transformEfx, type JsxRange } from "@efx/compiler"
 import { decode } from "@jridgewell/sourcemap-codec"
 import type * as ts from "typescript"
 
@@ -33,6 +33,7 @@ interface SourceMapCache {
   readonly source: string
   readonly compiled: string
   readonly mappings: Mapping<CodeInformation>[]
+  readonly jsxRanges: ReadonlyArray<JsxRange>
 }
 const sourceMapCache = new Map<string, SourceMapCache>()
 
@@ -52,12 +53,13 @@ const efxLanguagePlugin: LanguagePlugin<string> & { typescript: TypeScriptConfig
     const source = snapshot.getText(0, snapshot.getLength())
     const result = transformEfx(source, scriptId)
     const compiled = result.code
+    const jsxRanges = result.jsxRanges
 
     // Convert Babel source map to Volar mappings
-    const mappings = convertSourceMap(result.map, source, compiled)
+    const mappings = convertSourceMap(result.map, source, compiled, jsxRanges)
 
     // Cache source map data for offset conversion in definition results
-    sourceMapCache.set(scriptId, { source, compiled, mappings })
+    sourceMapCache.set(scriptId, { source, compiled, mappings, jsxRanges })
 
     const virtualCode: VirtualCode = {
       id: "efx-ts",
@@ -95,12 +97,14 @@ const efxLanguagePlugin: LanguagePlugin<string> & { typescript: TypeScriptConfig
 
 /**
  * Convert Babel's source map format to Volar's Mapping format.
- * Marks h() function parameter positions as non-semantic to hide inlay hints.
+ * Uses compiler-provided jsxRanges to mark JSX-derived positions as non-semantic
+ * (suppress inlay hints on h() internals, disable semantic on `<` `>` `/`).
  */
 function convertSourceMap(
   map: { mappings?: string } | null | undefined,
   source: string,
   generated: string,
+  jsxRanges: ReadonlyArray<JsxRange>,
 ): Mapping<CodeInformation>[] {
   if (!map?.mappings) {
     // No source map - create a simple 1:1 mapping
@@ -125,9 +129,6 @@ function convertSourceMap(
   const decoded = decode(map.mappings)
   const sourceLineStarts = computeLineStarts(source)
   const generatedLineStarts = computeLineStarts(generated)
-
-  // Find h() call positions in generated code to mark them as non-semantic (suppress inlay hints)
-  const hCallPositions = findHCallPositions(generated, generatedLineStarts)
 
   const mappings: Mapping<CodeInformation>[] = []
   const fullData: CodeInformation = {
@@ -157,8 +158,18 @@ function convertSourceMap(
     format: true,
   }
 
-  // JSX punctuation characters that map to h() structure - these should not be semantic
+  // JSX punctuation characters (`<`, `>`, `/`) only get the structural-only profile
+  // when they sit inside an opening/closing tag span — otherwise `{a > b}` inside
+  // a JSX expression would false-positive on `>`.
   const jsxPunctuation = new Set(["<", ">", "/"])
+  const insideJsxNode = (srcOffset: number): boolean =>
+    jsxRanges.some((r) => srcOffset >= r.start && srcOffset < r.end)
+  const insideTagPunctuationSpan = (srcOffset: number): boolean =>
+    jsxRanges.some((r) => {
+      if (srcOffset >= r.openingTag.start && srcOffset < r.openingTag.end) return true
+      if (r.closingTag && srcOffset >= r.closingTag.start && srcOffset < r.closingTag.end) return true
+      return false
+    })
 
   // Collect all segments, deduplicating by source offset (keep first/best match)
   const segmentsBySource = new Map<number, { genOffset: number; srcOffset: number; srcChar: string }>()
@@ -193,13 +204,12 @@ function convertSourceMap(
     // Length in source space: from this offset to the next (or 1 if last)
     const srcLength = nextSeg ? nextSeg.srcOffset - seg.srcOffset : 1
 
-    // Check if this position is inside an h() call (suppress inlay hints for h() internals)
-    const isInHCall = hCallPositions.some(
-      (pos) => seg.genOffset >= pos.start && seg.genOffset < pos.end
-    )
+    // Position is JSX-derived if its source offset falls inside any JSX node range.
+    const isInHCall = insideJsxNode(seg.srcOffset)
 
-    // JSX punctuation (< > /) maps to h() structure - fully disable semantic/nav
-    const isJsxPunctuation = jsxPunctuation.has(seg.srcChar)
+    // JSX punctuation (< > /) — only when actually inside a tag span, not e.g. {a > b}.
+    const isJsxPunctuation =
+      jsxPunctuation.has(seg.srcChar) && insideTagPunctuationSpan(seg.srcOffset)
 
     // Choose appropriate CodeInformation:
     // - JSX punctuation: structural only (no semantic, no navigation)
@@ -225,175 +235,67 @@ function convertSourceMap(
   return mappings
 }
 
+interface NameSpan {
+  readonly start: number
+  readonly length: number
+}
+
 /**
- * Find positions of h() calls in generated code.
- * Returns ranges from the 'h' identifier through the closing paren to suppress
- * semantic features (inlay hints, semantic tokens) for generated JSX internals.
+ * Given a cursor position in a `.efx` source, find the JSX tag at that position
+ * and its paired partner (opening↔closing). Returns name spans only; consumers
+ * highlight just the names, not the brackets.
+ *
+ * Backed by compiler-emitted `jsxRanges` — no source-text regex, no depth
+ * counting. Babel's parser already paired the tags; we read its work.
+ *
+ * Cursor positions that count as "on a tag":
+ *   - on the name (e.g. on `div` inside `<div>` or `</div>`)
+ *   - on the opening `<` / closing `>` / self-closing `/`
+ *   - NOT on attributes (e.g. inside `class="x"`)
+ *
+ * Fragments (`<>...</>`) have no names — skipped.
  */
-function findHCallPositions(
-  code: string,
-  _lineStarts: number[],
-): Array<{ start: number; end: number }> {
-  const positions: Array<{ start: number; end: number }> = []
-  // Match entire h(...) call to suppress all h() internal semantic features
-  const hCallRegex = /\bh\s*\(/g
-  let match
-  while ((match = hCallRegex.exec(code)) !== null) {
-    // Start from the 'h' identifier (important: Babel maps 'h' back to JSX source positions)
-    const start = match.index
-    // Find matching closing paren (accounting for nesting)
-    const parenPos = match.index + match[0].length - 1
-    let depth = 1
-    let end = parenPos + 1
-    while (end < code.length && depth > 0) {
-      const ch = code[end]
-      if (ch === "(") depth++
-      else if (ch === ")") depth--
-      end++
-    }
-    positions.push({ start, end })
-  }
-  return positions
-}
+function findJsxTagPair(
+  efxPath: string,
+  position: number,
+): { current: NameSpan; partner: NameSpan } | null {
+  const cache = sourceMapCache.get(efxPath)
+  if (!cache) return null
 
-interface JsxTag {
-  start: number          // Start of the full tag
-  length: number         // Length of the full tag
-  nameStart: number      // Start of just the tag name (for highlighting)
-  nameLength: number     // Length of just the tag name
-  name: string
-  isClosing: boolean
-  isSelfClosing: boolean
-}
+  for (const r of cache.jsxRanges) {
+    if (r.kind === "fragment") continue
 
-function findJsxTagAtPosition(content: string, position: number): JsxTag | null {
-  // Find if cursor is inside a JSX tag
-  // Look backwards for < and forwards for >
-  let tagStart = position
-  while (tagStart > 0 && content[tagStart] !== "<" && content[tagStart] !== ">") {
-    tagStart--
-  }
-  if (content[tagStart] !== "<") return null
+    // On the opening tag?
+    if (position >= r.openingTag.start && position < r.openingTag.end) {
+      const onName = position >= r.openingTag.nameStart && position < r.openingTag.nameEnd
+      const onLeadBracket = position < r.openingTag.nameStart // `<`
+      const onTrailBracket = position >= r.openingTag.end - 1 // `>`
+      const onSelfSlash = r.isSelfClosing && position === r.openingTag.end - 2 // `/`
+      if (!(onName || onLeadBracket || onTrailBracket || onSelfSlash)) continue
 
-  let tagEnd = position
-  while (tagEnd < content.length && content[tagEnd] !== ">") {
-    tagEnd++
-  }
-  if (tagEnd >= content.length) return null
-  tagEnd++ // Include the >
-
-  // Verify cursor is actually inside this tag
-  if (position < tagStart || position >= tagEnd) return null
-
-  const tagContent = content.slice(tagStart, tagEnd)
-  const isClosing = tagContent.startsWith("</")
-  const isSelfClosing = tagContent.endsWith("/>")
-
-  // Extract tag name and its position
-  const nameMatch = tagContent.match(isClosing ? /^(<\/\s*)([a-zA-Z][a-zA-Z0-9.]*)/i : /^(<\s*)([a-zA-Z][a-zA-Z0-9.]*)/i)
-  if (!nameMatch) return null
-
-  const nameStart = tagStart + nameMatch[1].length
-  const nameLength = nameMatch[2].length
-  const nameEnd = nameStart + nameLength
-
-  // Only match if cursor is on: < or </ or tag name or > or />
-  // Not on whitespace or attributes between name and >
-  const cursorOnBracket = position === tagStart || (isClosing && position === tagStart + 1)
-  const cursorOnName = position >= nameStart && position < nameEnd
-  const cursorOnClose = position === tagEnd - 1 || (isSelfClosing && position === tagEnd - 2)
-
-  if (!cursorOnBracket && !cursorOnName && !cursorOnClose) return null
-
-  return {
-    start: tagStart,
-    length: tagEnd - tagStart,
-    nameStart,
-    nameLength,
-    name: nameMatch[2],
-    isClosing,
-    isSelfClosing,
-  }
-}
-
-function findMatchingJsxTag(content: string, tag: JsxTag): JsxTag | null {
-  if (tag.isSelfClosing) return null
-
-  const tagName = tag.name
-  // Escape special regex chars in tag name (for components like Foo.Bar)
-  const escapedName = tagName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
-
-  // Collect all opening and closing tags of this name
-  const allTags: Array<{ pos: number; isOpening: boolean; isSelfClosing: boolean; end: number }> = []
-
-  // Find all opening tags: <tagName followed by whitespace, >, or />
-  const openingRegex = new RegExp(`<${escapedName}(?=[\\s>/>])`, "g")
-  let match
-  while ((match = openingRegex.exec(content)) !== null) {
-    // Check if self-closing by finding the closing > and checking for />
-    let closePos = match.index + match[0].length
-    let depth = 0
-    while (closePos < content.length) {
-      const ch = content[closePos]
-      if (ch === "{") depth++
-      else if (ch === "}") depth--
-      else if (depth === 0 && ch === ">") break
-      closePos++
-    }
-    const isSelf = closePos > 0 && content[closePos - 1] === "/"
-    allTags.push({ pos: match.index, isOpening: true, isSelfClosing: isSelf, end: closePos + 1 })
-  }
-
-  // Find all closing tags: </tagName>
-  const closingRegex = new RegExp(`</${escapedName}\\s*>`, "g")
-  while ((match = closingRegex.exec(content)) !== null) {
-    allTags.push({ pos: match.index, isOpening: false, isSelfClosing: false, end: match.index + match[0].length })
-  }
-
-  // Sort by position
-  allTags.sort((a, b) => a.pos - b.pos)
-
-  if (tag.isClosing) {
-    // Find matching opening tag before this position
-    let depth = 0
-    for (let i = allTags.length - 1; i >= 0; i--) {
-      const t = allTags[i]
-      if (t.pos >= tag.start) continue
-      if (t.isSelfClosing) continue
-
-      if (!t.isOpening) {
-        depth++
-      } else {
-        if (depth === 0) {
-          // Opening tag: <tagName - name starts after <
-          const nameStart = t.pos + 1
-          return { start: t.pos, length: t.end - t.pos, nameStart, nameLength: tagName.length, name: tagName, isClosing: false, isSelfClosing: false }
-        }
-        depth--
+      // Self-closing has no partner
+      if (r.isSelfClosing || !r.closingTag) return null
+      return {
+        current: nameSpanOf(r.openingTag),
+        partner: nameSpanOf(r.closingTag),
       }
     }
-  } else {
-    // Find matching closing tag after this position
-    let depth = 0
-    for (const t of allTags) {
-      if (t.pos <= tag.start) continue
-      if (t.isSelfClosing) continue
 
-      if (t.isOpening) {
-        depth++
-      } else {
-        if (depth === 0) {
-          // Closing tag: </tagName> - name starts after </
-          const nameStart = t.pos + 2
-          return { start: t.pos, length: t.end - t.pos, nameStart, nameLength: tagName.length, name: tagName, isClosing: true, isSelfClosing: false }
-        }
-        depth--
+    // On the closing tag?
+    if (r.closingTag && position >= r.closingTag.start && position < r.closingTag.end) {
+      return {
+        current: nameSpanOf(r.closingTag),
+        partner: nameSpanOf(r.openingTag),
       }
     }
   }
-
   return null
 }
+
+const nameSpanOf = (t: { nameStart: number; nameEnd: number }): NameSpan => ({
+  start: t.nameStart,
+  length: t.nameEnd - t.nameStart,
+})
 
 function computeLineStarts(text: string): number[] {
   const starts: number[] = [0]
@@ -585,33 +487,23 @@ const pluginFactory: ts.server.PluginModuleFactory = (modules) => {
                 )
               }
 
-              const content = ts.sys.readFile(fileName)
-              if (!content) {
-                return (value as ts.LanguageService["getDocumentHighlights"]).call(
-                  target, fileName, position, filesToSearch
-                )
-              }
-
-              // Don't highlight whitespace - return empty to avoid spurious matches
-              const charAtPos = content[position]
-              if (!charAtPos || /\s/.test(charAtPos)) {
+              // Whitespace at cursor → suppress; tsserver otherwise returns spurious empty hits
+              const cache = sourceMapCache.get(fileName)
+              const charAtPos = cache?.source[position]
+              if (charAtPos && /\s/.test(charAtPos)) {
                 return undefined
               }
 
-              // Check if cursor is on a JSX tag
-              const tagMatch = findJsxTagAtPosition(content, position)
-              if (tagMatch) {
-                const matchingTag = findMatchingJsxTag(content, tagMatch)
-                if (matchingTag) {
-                  // Highlight just the tag names, not the whole tags
-                  return [{
-                    fileName,
-                    highlightSpans: [
-                      { textSpan: { start: tagMatch.nameStart, length: tagMatch.nameLength }, kind: "reference" as ts.HighlightSpanKind },
-                      { textSpan: { start: matchingTag.nameStart, length: matchingTag.nameLength }, kind: "reference" as ts.HighlightSpanKind },
-                    ],
-                  }]
-                }
+              // JSX tag-pair highlight, backed by compiler jsxRanges
+              const pair = findJsxTagPair(fileName, position)
+              if (pair) {
+                return [{
+                  fileName,
+                  highlightSpans: [
+                    { textSpan: pair.current, kind: "reference" as ts.HighlightSpanKind },
+                    { textSpan: pair.partner, kind: "reference" as ts.HighlightSpanKind },
+                  ],
+                }]
               }
 
               // Fall back to default behavior


### PR DESCRIPTION
## Summary

- **`@efx/compiler`** now reports `jsxRanges` (source-side `JsxRange[]`) alongside `code` and `map`. Each range covers an element or fragment with sub-ranges for the opening/closing tags and tag names.
- **`@efx/ts-plugin`** consumes `jsxRanges` instead of doing three separate regex/string scans:
  - `findHCallPositions` (compiled-side `/\bh\s*\(/g` + paren matching) — deleted
  - `findJsxTagAtPosition` / `findMatchingJsxTag` (source-side regex + depth-counting tag-pair scanner) — deleted, replaced by a 40-line `findJsxTagPair` that reads from the cache
  - JSX punctuation check hardened: `{a > b}` inside a JSX expression no longer false-positives as a `>` bracket
- Net **−122 lines** in `ts-plugin/src/index.ts`. The compiler is the producer of synthetic `h()` calls; it now reports the source positions it transformed instead of leaving the consumer to re-derive them from text. Babel paired the tags during parse — we read its work.

Architectural inspiration: Vue's `VueCodeInformation` flags pattern, MDX-Analyzer's `createMdxLanguagePlugin` shape. Astro's duplicated `astro2tsx.ts` between ts-plugin and language-server is the anti-pattern this avoids when a second host appears.

## Test plan

- [x] `pnpm --filter @efx/compiler test` — 35/35 (28 → 35, +7 new cases for `jsxRanges`)
- [x] `pnpm --filter @efx/ts-plugin test` — integration tests unchanged from baseline (4 PASS, same 3 PARTIAL as before)
- [x] `pnpm -r typecheck` — 17 errors (all pre-existing `noUncheckedIndexedAccess` issues; down from 27 before this change)
- [x] `pnpm --filter @efx/demo typecheck` — clean (efx-compile + tsc)
- [x] Dev server + 4 probes pass: `probe.mjs` (Counter + UserPage), `probe-todos.mjs` (keyed list, DOM identity), `probe-liveuser.mjs` (Atom + AsyncResult), `probe-lifecycle.mjs` (Scope release on unmount)
- [x] `packages/compiler/AGENTS.md` and `packages/ts-plugin/AGENTS.md` updated to reflect the new contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)