### PR TITLE
refactor(runtime): hand-write View union for concise hovers

### DIFF
--- a/packages/runtime/AGENTS.md
+++ b/packages/runtime/AGENTS.md
@@ -31,7 +31,7 @@ the editor margin. If you rename them, update the regex.
 | File | Purpose |
 |---|---|
 | `src/h.ts` | `h()` factory + `track`/`read`/`peek` reactivity-tracking machinery + `normalizeChild` (any child shape → `View`) |
-| `src/View.ts` | `View` IR (intermediate representation) — `Data.TaggedEnum` with 6 variants: `Text`, `Element`, `Fragment`, `Reactive`, `List`, `Empty`. The normalized DOM-materialization shape `mount` switches on. Plus `isView`, `VIEW_TAGS` |
+| `src/View.ts` | `View` IR (intermediate representation) — hand-written union of 6 named interfaces (`ViewText`, `ViewElement`, `ViewFragment`, `ViewReactive`, `ViewList`, `ViewEmpty`); constructors via `Data.taggedEnum<View>()`. The normalized DOM-materialization shape `mount` switches on. Plus `isView`, `VIEW_TAGS` |
 | `src/mount.ts` | DOM renderer. `buildDom(View, registry) → { node, cleanup }`, `mount(app, el)` |
 | `src/index.ts` | Public exports + `list`, `Fragment`, `EfxLive` |
 | `src/types/Fold.ts` | `ChildE`/`ChildR`/`FoldE`/`FoldR`/`TagE`/`TagR`/`TagProps` — the channel-fold conditional types |
@@ -94,6 +94,21 @@ produces DOM. Closed-for-now at 6 variants:
   source, swap rendered child on emit
 - `List { source: AtomRef.Collection, render }` — keyed reactive list
 - `Empty {}` — comment placeholder (used for `false`/`null` children)
+
+### Why hand-written interfaces (not `Data.TaggedEnum<{...}>`)
+
+`View` is declared as a union of named `interface`s, not as
+`Data.TaggedEnum<{ Text: {...}, Element: {...}, ... }>`. The
+shorthand form is more compact, but it runs every variant through
+`Types.Simplify`, which strips the `View` alias name and causes TS
+to inline the entire union in every hover (`Effect<{ _tag: "Text";
+... } | { _tag: "Element"; ... } | ..., never, never>` — roughly
+30 lines per component signature). Named interfaces anchor the
+alias, so hovers show the concise `Effect<View, never, never>`.
+
+Constructors still come from `Data.taggedEnum<View>()` — the
+runtime behavior is identical. Don't "simplify" this back to the
+inline form.
 
 ### Closed-for-now, not closed-forever
 

--- a/packages/runtime/src/View.ts
+++ b/packages/runtime/src/View.ts
@@ -4,25 +4,46 @@ import type { AtomRef } from "effect/unstable/reactivity"
 
 export type Props = Readonly<Record<string, unknown>>
 
-export type View = Data.TaggedEnum<{
-  Text: { readonly value: string }
-  Element: {
-    readonly tag: string
-    readonly props: Props
-    readonly children: ReadonlyArray<View>
-  }
-  Fragment: { readonly children: ReadonlyArray<View> }
-  Reactive: {
-    // Source can carry any value; mount() normalizes it into a View at render time.
-    readonly source: Atom.Atom<unknown> | AtomRef.ReadonlyRef<unknown>
-  }
-  List: {
-    readonly source: AtomRef.Collection<unknown>
-    // Returns View or Effect<View, never, never> — mount's valueToView coerces.
-    readonly render: (item: AtomRef.AtomRef<unknown>, index: number) => unknown
-  }
-  Empty: {}
-}>
+// Per-variant named interfaces — required so TS preserves the `View` alias
+// in hovers. `Data.TaggedEnum<{...}>` runs every variant through
+// `Types.Simplify`, which strips the alias and forces TS to inline the full
+// union everywhere `Effect<View, ...>` appears.
+export interface ViewText {
+  readonly _tag: "Text"
+  readonly value: string
+}
+export interface ViewElement {
+  readonly _tag: "Element"
+  readonly tag: string
+  readonly props: Props
+  readonly children: ReadonlyArray<View>
+}
+export interface ViewFragment {
+  readonly _tag: "Fragment"
+  readonly children: ReadonlyArray<View>
+}
+export interface ViewReactive {
+  readonly _tag: "Reactive"
+  // Source can carry any value; mount() normalizes it into a View at render time.
+  readonly source: Atom.Atom<unknown> | AtomRef.ReadonlyRef<unknown>
+}
+export interface ViewList {
+  readonly _tag: "List"
+  readonly source: AtomRef.Collection<unknown>
+  // Returns View or Effect<View, never, never> — mount's valueToView coerces.
+  readonly render: (item: AtomRef.AtomRef<unknown>, index: number) => unknown
+}
+export interface ViewEmpty {
+  readonly _tag: "Empty"
+}
+
+export type View =
+  | ViewText
+  | ViewElement
+  | ViewFragment
+  | ViewReactive
+  | ViewList
+  | ViewEmpty
 
 export const View = Data.taggedEnum<View>()
 


### PR DESCRIPTION
## Summary

- `View` is now a union of named per-variant interfaces (`ViewText`, `ViewElement`, ...) instead of `Data.TaggedEnum<{...}>`. The shorthand form runs every variant through `Types.Simplify`, which strips the `View` alias and forces TS to inline the full ~20-line union in every component hover.
- Hovers now show `Effect<View, never, never>` — matching what the demo's docstrings already promised.
- Constructors still come from `Data.taggedEnum<View>()`; runtime behavior is unchanged.
- Documented the invariant in `packages/runtime/AGENTS.md` so the form isn't "simplified" back.

### Before / after hover

```
// before
const Counter: (_props?: {}) => Effect.Effect<{
  readonly _tag: "Text";
  readonly value: string;
} | {
  readonly _tag: "Element";
  readonly tag: string;
  readonly props: Props;
  readonly children: ReadonlyArray<View>;
} | { ...4 more variants... }, never, never>

// after
const Counter: (_props?: {}) => Effect.Effect<View, never, never>
```

## Test plan

- [x] `pnpm -r typecheck` — runtime, compiler, vite-plugin pass. (ts-plugin errors pre-exist on `main`; unrelated.)
- [x] `pnpm -r test` — all green.
- [x] Demo `.d.ts` emission shows `Effect.Effect<View, never, never>` for component signatures.
- [x] Sanity-check hover in editor on `apps/demo/src/Counter.efx` after pulling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)