### PR TITLE
fix(ts-plugin): resolve typecheck errors in findReferences proxy

### DIFF
--- a/packages/ts-plugin/src/service-proxy.ts
+++ b/packages/ts-plugin/src/service-proxy.ts
@@ -226,7 +226,7 @@ export const pluginFactory: ts.server.PluginModuleFactory = (modules) => {
               const result = (value as ts.LanguageService["findReferences"]).call(target, targetFile, targetPos)
               if (!result) return result
               // Deduplicate across ALL symbols, not per-symbol
-              const allRefs: Array<{ fileName: string; textSpan: ts.TextSpan } & Record<string, unknown>> = []
+              const allRefs: ts.ReferencedSymbolEntry[] = []
               const seen = new Set<string>()
               for (const symbol of result) {
                 for (const ref of symbol.references) {
@@ -240,6 +240,7 @@ export const pluginFactory: ts.server.PluginModuleFactory = (modules) => {
               }
               // Sort: definition first, then usages, then imports
               const firstSymbol = result[0]
+              if (!firstSymbol) return result
               const convertedDef = rewriteDefinitionInfo(firstSymbol.definition) ?? firstSymbol.definition
               // Check if ref is in an import statement by reading the line
               const isImportRef = (ref: { fileName: string; textSpan: ts.TextSpan }): boolean => {


### PR DESCRIPTION
## Summary

Resolve two pre-existing TypeScript errors in `@efx/ts-plugin/src/service-proxy.ts` that have been preventing `pnpm --filter @efx/ts-plugin typecheck` from going green. Both are in the `findReferences` LanguageService override.

- The `allRefs` array was typed as the intersection `{ fileName; textSpan } & Record<string, unknown>`, but `ReferencedSymbolEntry` (what we push into it) has no string index signature, so it never satisfied `Record<string, unknown>`. Use the nominal type `ts.ReferencedSymbolEntry[]` — that's what `findReferences` returns and what we hand back below.
- Under `noUncheckedIndexedAccess`, `result[0]` is `ReferencedSymbol | undefined`. Reading `firstSymbol.definition` without a guard was both a typecheck error and a latent runtime crash if `findReferences` ever returned an empty array. Bail to the original `result` when there's no first symbol.

## Test plan

- [ ] `pnpm --filter @efx/ts-plugin typecheck` → clean (was failing on `findReferences` lines)
- [ ] `pnpm --filter @efx/ts-plugin test` → all PASS (unchanged behavior at runtime since the empty-array case wasn't being hit in practice)
- [ ] No other packages affected

## Notes

`pnpm -r typecheck` will still fail after this PR on `src/source-map.ts` errors — those land in the follow-up `@efx/language` extraction PR where the file is moved and the equivalent fixes already live. Splitting them avoids touching `source-map.ts` here just to delete it next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)