### PR TITLE
feat(check): @efx/check standalone type-checker via @volar/kit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,15 +73,19 @@ compiler eats and converts into `h()` calls." Not the React thing.
   bare test-position identifiers → `h.peek()`. Smart-skip wrap.
 - **[`packages/language/`](./packages/language/AGENTS.md)** — the Volar
   `LanguagePlugin` describing `.efx` files (file id, virtual code,
-  source-map conversion, JSX region tagging). Bridges
-  `@efx/compiler` to Volar's contracts; consumed by `ts-plugin`
-  (and by future Volar-based tools).
+  source-map conversion, JSX region tagging). Shared by `ts-plugin`
+  and `check`; the only package that bridges `@efx/compiler` to
+  Volar's contracts.
 - **[`packages/ts-plugin/`](./packages/ts-plugin/AGENTS.md)** — Volar-
   based TypeScript Language Service plugin. Wraps the shared
   language plugin in a tsserver Proxy that adds `.efx`-aware
   go-to-def, find-references, JSX tag-pair highlights, and inlay
   hint filtering. Dual-file setup (`.efx` source + on-disk `.ts`
   for module resolution from non-`.efx` files).
+- **[`packages/check/`](./packages/check/AGENTS.md)** — standalone
+  CLI/programmatic type-checker built on `@volar/kit` plus the
+  shared language plugin. Replaces `tsc --noEmit` for `.efx`
+  projects without needing a tsserver process.
 - **[`packages/vite-plugin/`](./packages/vite-plugin/AGENTS.md)** — Vite
   dev integration. Compiles `.efx` on the fly, extends esbuild's
   include glob, rewrites `.efx` URLs with `?import` so strict-MIME

--- a/apps/demo/AGENTS.md
+++ b/apps/demo/AGENTS.md
@@ -24,16 +24,21 @@ they can be exercised in a browser side-by-side.
 
 For every `Counter.efx` there's a `Counter.ts` on disk. These are
 **the compiled output of `efx-compile` CLI** (in
-`packages/compiler`). They exist for two reasons:
+`packages/compiler`). They exist for **TypeScript module
+resolution**: `import { Counter } from "./Counter"` from a
+non-`.efx` file (e.g. `channels.test-d.ts`) resolves to
+`Counter.ts` — TS's resolver doesn't auto-try `.efx` even with
+`extraFileExtensions` declared. The
+[TS plugin](../../packages/ts-plugin/AGENTS.md) then rewrites
+go-to-def/find-references results back to `.efx`. See its
+"Dual-file setup" section.
 
-1. Plain `tsc --noEmit` can type-check this workspace without the
-   TS Language Service plugin loaded.
-2. **TypeScript module resolution.** `import { Counter } from
-   "./Counter"` resolves to `Counter.ts` — TS's resolver doesn't
-   know about Volar's virtual files. The
-   [TS plugin](../../packages/ts-plugin/AGENTS.md) then rewrites
-   results back to `.efx`. See its "Dual-file setup" section for
-   why both files must exist.
+The `typecheck` script no longer needs the sibling `.ts` for
+diagnostics on the `.efx` files themselves —
+[`@efx/check`](../../packages/check/AGENTS.md) reads them through
+the LanguagePlugin. But cross-file imports from `.ts` files (like
+`channels.test-d.ts`) still need the sibling, which is why
+`pnpm typecheck` still runs `efx-compile` first.
 
 **Do not hand-edit `.ts` siblings of `.efx` files.** Edit the
 `.efx`; run `pnpm efx:compile` (or just `pnpm typecheck`, which

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -7,13 +7,14 @@
     "efx:compile": "node --experimental-strip-types ../../packages/compiler/src/cli.ts src",
     "dev": "vite",
     "build": "pnpm run efx:compile && vite build",
-    "typecheck": "pnpm run efx:compile && tsc --noEmit"
+    "typecheck": "pnpm run efx:compile && node --experimental-strip-types ../../packages/check/src/cli.ts"
   },
   "dependencies": {
     "@efx/runtime": "workspace:*",
     "effect": "4.0.0-beta.70"
   },
   "devDependencies": {
+    "@efx/check": "workspace:*",
     "@efx/compiler": "workspace:*",
     "@efx/ts-plugin": "workspace:*",
     "@efx/vite-plugin": "workspace:*",

--- a/packages/check/AGENTS.md
+++ b/packages/check/AGENTS.md
@@ -1,0 +1,129 @@
+# `@efx/check` — standalone type-checker for `.efx` projects
+
+Replaces `tsc --noEmit` for projects with `.efx` files. Wraps
+`@volar/kit`'s `createTypeScriptChecker` plus the shared
+`@efx/language` plugin, runs in-process, prints tsc-style
+diagnostics, exits non-zero on errors.
+
+Used in `apps/demo`'s `typecheck` script. Modeled on Astro's
+`astro-check` (see `refs/astro-language-tools/packages/astro-check`).
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `src/index.ts` | Programmatic API: `runCheck(options) → CheckResult`. Wires the language plugin + `volar-service-typescript` into a kit `TypeScriptChecker`, iterates root files, prints diagnostics. |
+| `src/cli.ts` | CLI entry. Minimal argv parser (`--tsconfig`, `--root`, `--help`), calls `runCheck`, prints summary, exits 0/1. |
+| `test/integration.mjs` | Smoke test: known-good fixture → 0 errors; inject broken `.efx` → expect TS2322 with `.efx` source position; cleanup → 0 errors again. |
+| `test/fixture/` | Minimal `.efx` project (tsconfig + `Good.efx`) used by the smoke test. Self-contained, no cross-file imports — keep it that way. |
+
+## Invocation
+
+Programmatic:
+
+```ts
+import { runCheck } from "@efx/check"
+const result = await runCheck({ cwd: "/path/to/project" })
+// result: { filesChecked: number, errors: number, warnings: number }
+```
+
+CLI:
+
+```bash
+efx-check                       # tsconfig auto-discovered from cwd
+efx-check --tsconfig path/tsconfig.json
+efx-check --root /some/project  # cwd override
+```
+
+In `apps/demo` the script wires it via `node --experimental-strip-types`
+because the workspace ships `.ts` source, not a built CLI. If
+`@efx/check` ever gets published, build an emitted CJS for the bin
+entry — `apps/demo`'s pattern won't work for external consumers.
+
+## Why kit, not vue-tsc-style tsc-wrapping
+
+Vue's `vue-tsc` monkey-patches `tsc`'s module resolver to inject
+its LanguagePlugin and has a retry loop for "extensions changed
+mid-run." Astro's `astro-check` does the kit-based approach. Both
+work; for this codebase the kit approach is much smaller and
+doesn't depend on internal tsc behavior.
+
+The runtime cost is similar: kit's `createTypeScriptChecker`
+constructs a real `ts.LanguageService` via Volar's
+`createLanguageServiceHost`, then we ask it for diagnostics
+per file. The same machinery the editor uses, minus the
+LSP protocol.
+
+## Behavior contract
+
+- **Files included**: whatever the resolved tsconfig's `include`
+  glob produces, expanded with `extraFileExtensions` (`.efx`
+  recognized). For demo: 6 `.efx` + 6 sibling `.ts` + 2 hand-written
+  `.ts` = 14 files. The sibling `.ts` count drops to 0 once Task #1
+  removes them.
+- **Diagnostics printed**: errors only by default (matching the
+  bare `tsc --noEmit` flow we replaced). Warnings and hints are
+  counted in `CheckResult` but not printed — `volar-service-typescript`
+  surfaces unused-import suggestions as warnings, and we don't
+  want to drown the output with them. Add a `--minimumSeverity`
+  flag when the astro-parity TODO ticket comes up.
+- **Exit code**: 0 if `result.errors === 0`, else 1. Warnings do
+  not fail. (`tsc` matches: warnings only fail with `noEmitOnError`
+  or `strict` flags that promote them.)
+
+## Coupling
+
+- **`@efx/language`** — provides `createEfxLanguagePlugin`. The
+  CLI instantiates it with `<URI>(uri => uri.fsPath)` because kit
+  uses `URI` as its script-id type.
+- **`@volar/kit`** — `createTypeScriptChecker`,
+  `createTypeScriptInferredChecker` (not currently used; would be
+  needed for "no tsconfig" mode).
+- **`volar-service-typescript`** — the LSP-style language service
+  plugins kit needs to actually produce diagnostics. Without these,
+  `linter.check(file)` returns nothing.
+
+## Anti-patterns
+
+- Don't print warnings/hints by default. The replacement flow's
+  expected baseline output is "Checked N files: 0 errors" — adding
+  warning noise breaks the "drop-in for tsc --noEmit" promise.
+  Make it opt-in via a flag when you wire severity filtering.
+- Don't add a watch loop that polls. `@volar/kit` exposes
+  `fileCreated/Updated/Deleted` callbacks; combine them with
+  `chokidar` (like astro-check does) when watch mode is built.
+- Don't add `runCheck` overloads or option types that diverge from
+  Astro's `check()` API beyond what's necessary. The astro-parity
+  TODO list in `src/cli.ts` is the design intent — if you add a
+  flag here, mirror the Astro name and semantics so future code
+  ports cleanly.
+- Don't depend on the existence of on-disk sibling `.ts` files
+  in this package's code. Today the demo provides them via
+  `efx-compile`, but Task #1 will remove that pattern and your
+  code should not break when it does.
+
+## Tests
+
+```
+pnpm --filter @efx/check test
+```
+
+Runs `test/integration.mjs` with `--experimental-strip-types`.
+The test is fast (~1 second) — no tsserver subprocess, just an
+in-process `runCheck` call against the fixture directory.
+
+If you change the fixture, make sure it remains self-contained
+(no cross-package imports). The fixture must compile-and-check
+cleanly with only the workspace `node_modules` resolution path.
+
+## Related context
+
+- Root [`AGENTS.md`](../../AGENTS.md) — why `.efx` files never
+  reach `tsc` directly.
+- [`@efx/language`](../language/AGENTS.md) — the LanguagePlugin
+  this package consumes.
+- [`apps/demo`](../../apps/demo/AGENTS.md) — typecheck script
+  wiring.
+- `refs/astro-language-tools/packages/astro-check/` — the model.
+  `AstroCheck` class in `refs/astro-language-tools/packages/language-server/src/check.ts`
+  is the richer surface to grow toward.

--- a/packages/check/package.json
+++ b/packages/check/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@efx/check",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "bin": {
+    "efx-check": "./src/cli.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "node --experimental-strip-types test/integration.mjs"
+  },
+  "dependencies": {
+    "@efx/language": "workspace:*",
+    "@volar/kit": "^2.4.28",
+    "@volar/language-service": "^2.4.28",
+    "volar-service-typescript": "^0.0.71",
+    "vscode-uri": "^3.1.0"
+  },
+  "peerDependencies": {
+    "typescript": "^5.7.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0"
+  }
+}

--- a/packages/check/src/cli.ts
+++ b/packages/check/src/cli.ts
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+/**
+ * CLI for `@efx/check`.
+ *
+ *   efx-check                  # use tsconfig.json found from cwd
+ *   efx-check --tsconfig path  # explicit tsconfig.json
+ *   efx-check --root dir       # cwd override (resolved before --tsconfig)
+ *
+ * Exit code: 0 if no errors, 1 otherwise (warnings do not fail).
+ *
+ * Not yet implemented (astro-parity TODO):
+ *   - --watch              chokidar-based incremental check loop
+ *   - --minimumSeverity    filter what's printed
+ *   - --minimumFailingSeverity  control which severity bumps exit code
+ *   - colored output       kleur or similar
+ */
+import { runCheck } from "./index.ts"
+
+interface ParsedArgs {
+  root: string | undefined
+  tsconfig: string | undefined
+}
+
+function parseArgs(argv: ReadonlyArray<string>): ParsedArgs {
+  const out: ParsedArgs = { root: undefined, tsconfig: undefined }
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]
+    if (arg === "--tsconfig" || arg === "-p") {
+      out.tsconfig = argv[++i]
+    } else if (arg === "--root") {
+      out.root = argv[++i]
+    } else if (arg === "--help" || arg === "-h") {
+      printHelp()
+      process.exit(0)
+    } else {
+      console.error(`efx-check: unknown argument: ${arg}`)
+      printHelp()
+      process.exit(2)
+    }
+  }
+  return out
+}
+
+function printHelp(): void {
+  process.stdout.write(`efx-check — type-check an efx project via Volar
+
+Usage:
+  efx-check [--tsconfig <path>] [--root <dir>]
+
+Options:
+  --tsconfig, -p <path>   Path to tsconfig.json (relative to --root or absolute)
+  --root <dir>            Project root (defaults to cwd)
+  --help, -h              Show this help
+
+Exit codes:
+  0  no errors
+  1  errors found
+  2  usage error
+`)
+}
+
+const args = parseArgs(process.argv.slice(2))
+const checkOptions: { cwd?: string; tsconfig?: string } = {}
+if (args.root !== undefined) checkOptions.cwd = args.root
+if (args.tsconfig !== undefined) checkOptions.tsconfig = args.tsconfig
+const result = await runCheck(checkOptions)
+
+const fileLabel = result.filesChecked === 1 ? "file" : "files"
+process.stdout.write(
+  `\nChecked ${result.filesChecked} ${fileLabel}: ${result.errors} error${result.errors === 1 ? "" : "s"}` +
+    (result.warnings > 0 ? `, ${result.warnings} warning${result.warnings === 1 ? "" : "s"}` : "") +
+    "\n",
+)
+
+process.exit(result.errors > 0 ? 1 : 0)

--- a/packages/check/src/index.ts
+++ b/packages/check/src/index.ts
@@ -1,0 +1,93 @@
+import * as path from "node:path"
+import * as ts from "typescript"
+import * as kit from "@volar/kit"
+import { create as createTypeScriptServices } from "volar-service-typescript"
+import { URI } from "vscode-uri"
+import { createEfxLanguagePlugin } from "@efx/language"
+
+// LSP DiagnosticSeverity constants (stable wire protocol). `@volar/language-service`
+// re-exports the type but not the values, so we inline these to avoid pulling in
+// another package just for the enum.
+const SEVERITY_ERROR = 1
+const SEVERITY_WARNING = 2
+
+export interface CheckOptions {
+  /**
+   * Project root. Used to resolve tsconfig.json when `tsconfig` is unset.
+   * Defaults to `process.cwd()`.
+   */
+  cwd?: string
+  /**
+   * Path to tsconfig.json (absolute, or relative to `cwd`).
+   * If omitted, `ts.findConfigFile` is used starting from `cwd`.
+   */
+  tsconfig?: string
+}
+
+export interface CheckResult {
+  /** Number of root files inspected (including non-`.efx` TS files). */
+  filesChecked: number
+  /** Total error-severity diagnostics across all files. */
+  errors: number
+  /** Total warning-severity diagnostics. */
+  warnings: number
+}
+
+/**
+ * Type-check an efx project. Returns a summary; the printed output goes
+ * to stdout in tsc's standard "file:line:col - error TS####: message"
+ * format (via Volar kit's printErrors helper).
+ */
+export async function runCheck(options: CheckOptions = {}): Promise<CheckResult> {
+  const cwd = path.resolve(options.cwd ?? process.cwd())
+
+  const tsconfigPath = resolveTsconfig(cwd, options.tsconfig)
+  if (!tsconfigPath) {
+    throw new Error(
+      `No tsconfig.json found from ${cwd}. Pass --tsconfig <path> or run from a directory containing one.`,
+    )
+  }
+
+  // `@volar/kit` uses `URI` as the script-id type, so the plugin gets URIs
+  // and reduces them to filesystem paths for the compiler + cache.
+  const languagePlugin = createEfxLanguagePlugin<URI>((uri) => uri.fsPath)
+  const tsServices = createTypeScriptServices(ts)
+  const linter = kit.createTypeScriptChecker([languagePlugin], tsServices, tsconfigPath)
+
+  const fileNames = linter.getRootFileNames()
+  let errors = 0
+  let warnings = 0
+
+  for (const fileName of fileNames) {
+    const diagnostics = await linter.check(fileName)
+    if (diagnostics.length === 0) continue
+
+    // Match `tsc --noEmit` behaviour: only print error-severity diagnostics.
+    // Warnings/hints surfaced by volar-service-typescript (e.g. unused locals
+    // without `noUnusedLocals`) get counted but not printed by default.
+    // TODO(astro-parity): expose --minimumSeverity to control what prints.
+    const errorOnly = diagnostics.filter((d) => (d.severity ?? SEVERITY_ERROR) === SEVERITY_ERROR)
+    if (errorOnly.length > 0) {
+      const text = linter.printErrors(fileName, errorOnly, cwd)
+      if (text) {
+        process.stdout.write(text)
+        if (!text.endsWith("\n")) process.stdout.write("\n")
+      }
+    }
+
+    for (const d of diagnostics) {
+      const sev = d.severity ?? SEVERITY_ERROR
+      if (sev === SEVERITY_ERROR) errors += 1
+      else if (sev === SEVERITY_WARNING) warnings += 1
+    }
+  }
+
+  return { filesChecked: fileNames.length, errors, warnings }
+}
+
+function resolveTsconfig(cwd: string, supplied: string | undefined): string | undefined {
+  if (supplied) {
+    return path.isAbsolute(supplied) ? supplied : path.resolve(cwd, supplied)
+  }
+  return ts.findConfigFile(cwd, ts.sys.fileExists)
+}

--- a/packages/check/test/fixture/Good.efx
+++ b/packages/check/test/fixture/Good.efx
@@ -1,0 +1,6 @@
+export const greeting: string = "hello"
+export const count: number = 42
+
+export function add(a: number, b: number): number {
+  return a + b
+}

--- a/packages/check/test/fixture/tsconfig.json
+++ b/packages/check/test/fixture/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["**/*.ts", "**/*.efx"]
+}

--- a/packages/check/test/integration.mjs
+++ b/packages/check/test/integration.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+/**
+ * Smoke test for @efx/check.
+ *
+ *   1. runCheck against a known-good fixture → 0 errors.
+ *   2. Add a deliberately-broken .efx → runCheck reports the type error,
+ *      with source position pointing at the .efx file.
+ *   3. Remove the broken file → back to 0 errors.
+ *
+ * No tsserver subprocess; the check tool is invoked in-process.
+ */
+import { writeFileSync, unlinkSync, existsSync } from "node:fs"
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+import { runCheck } from "../src/index.ts"
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const fixtureDir = join(__dirname, "fixture")
+const brokenPath = join(fixtureDir, "Broken.efx")
+
+let failures = 0
+const expect = (condition, message) => {
+  if (condition) {
+    console.log(`  PASS: ${message}`)
+  } else {
+    console.error(`  FAIL: ${message}`)
+    failures += 1
+  }
+}
+
+// Capture stdout while runCheck runs — the test should be quiet on success,
+// noisy only when assertions fail.
+const captureStdout = async (fn) => {
+  const chunks = []
+  const originalWrite = process.stdout.write.bind(process.stdout)
+  process.stdout.write = (chunk) => {
+    chunks.push(typeof chunk === "string" ? chunk : chunk.toString())
+    return true
+  }
+  try {
+    const result = await fn()
+    return { result, output: chunks.join("") }
+  } finally {
+    process.stdout.write = originalWrite
+  }
+}
+
+const ensureClean = () => {
+  if (existsSync(brokenPath)) unlinkSync(brokenPath)
+}
+
+ensureClean()
+
+console.log("1. Known-good fixture should have 0 errors...")
+{
+  const { result, output } = await captureStdout(() => runCheck({ cwd: fixtureDir }))
+  expect(result.errors === 0, `expected 0 errors, got ${result.errors}`)
+  expect(result.filesChecked >= 1, `expected at least 1 file, got ${result.filesChecked}`)
+  if (result.errors !== 0) console.error("output was:\n" + output)
+}
+
+console.log("\n2. Inject Broken.efx with a type error → expect >=1 error pointing at Broken.efx...")
+writeFileSync(
+  brokenPath,
+  `const x: number = "wrong type"\nexport { x }\n`,
+)
+{
+  const { result, output } = await captureStdout(() => runCheck({ cwd: fixtureDir }))
+  expect(result.errors >= 1, `expected >=1 errors, got ${result.errors}`)
+  expect(output.includes("Broken.efx"), "diagnostic output should mention Broken.efx")
+  expect(output.includes("2322"), "diagnostic output should include TS2322 (not assignable)")
+  if (failures > 0 || process.env.EFX_CHECK_TEST_DEBUG) {
+    console.log("[captured output]\n" + output)
+  }
+}
+
+console.log("\n3. Remove Broken.efx → expect 0 errors again...")
+unlinkSync(brokenPath)
+{
+  const { result, output } = await captureStdout(() => runCheck({ cwd: fixtureDir }))
+  expect(result.errors === 0, `expected 0 errors after cleanup, got ${result.errors}`)
+  if (result.errors !== 0) console.error("output was:\n" + output)
+}
+
+ensureClean()
+
+if (failures > 0) {
+  console.error(`\n${failures} assertion(s) failed`)
+  process.exit(1)
+} else {
+  console.log("\nAll assertions passed")
+  process.exit(0)
+}

--- a/packages/check/tsconfig.json
+++ b/packages/check/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*.ts"]
+}

--- a/packages/language/AGENTS.md
+++ b/packages/language/AGENTS.md
@@ -5,11 +5,10 @@ how to identify them, how to produce the virtual TypeScript that
 tsc/Volar see, and how to translate offsets between source and
 generated code.
 
-Currently consumed by **`@efx/ts-plugin`**, which wraps it for
-tsserver (editor integration). The factory's host-agnostic shape
-exists so additional Volar-based tools (a standalone checker on
-`@volar/kit`, a CI linter, etc.) can share the same plugin without
-forking it.
+Shared by two consumers:
+
+- **`@efx/ts-plugin`** — wraps it for tsserver (editor integration).
+- **`@efx/check`** — wraps it for `@volar/kit` (standalone CLI).
 
 If you reach for the LanguagePlugin from a third place, you almost
 certainly want to depend on this package rather than copy it.
@@ -45,7 +44,7 @@ This means consumers can write:
 // tsserver (@efx/ts-plugin)
 createEfxLanguagePlugin<string>((s) => s)
 
-// kit (URI is the host's script-id type)
+// kit (@efx/check)
 createEfxLanguagePlugin<URI>((uri) => uri.fsPath)
 ```
 
@@ -103,9 +102,9 @@ authoritatively knows what's "h() machinery" vs. user code.
 ## The cache is process-local module state
 
 `virtual-code.ts` exports a module-level
-`Map<string, EfxVirtualCode>`. `@efx/ts-plugin` populates it
-through its `createVirtualCode` calls; the same package's
-service-proxy reads from it to do offset conversion in
+`Map<string, EfxVirtualCode>`. Both `@efx/ts-plugin` and
+`@efx/check` populate it from their `createVirtualCode` calls;
+ts-plugin's service-proxy reads from it to do offset conversion in
 definition/reference results.
 
 The instance Volar holds (as the return value of `createVirtualCode`)
@@ -116,9 +115,9 @@ that looks up the cache. Callers that already have the instance
 (e.g. ones that just called `getEfxVirtualCode` once) skip the
 extra lookup.
 
-In tsserver, the cache lives for the editor session. Any future
-non-tsserver consumer using this LanguagePlugin gets its own
-process-local cache — Map state is per-Node-process.
+In tsserver, the cache lives for the editor session. In
+`efx-check`'s CLI, the cache lives for the duration of the run.
+There's no cross-process sharing — Map state is per-Node-process.
 
 If `createVirtualCode` is called twice for the same `.efx` (rapid
 edits), the cache entry is overwritten with a fresh
@@ -130,14 +129,12 @@ persist until process exit; that's fine in practice.
 `EfxVirtualCode`'s constructor does NOT use TypeScript parameter
 properties (the `constructor(readonly x: T)` form). Fields are
 declared and assigned manually instead, because Node's
-`--experimental-strip-types` mode rejects parameter properties as
-non-type syntax — they desugar into runtime field assignments.
-This package is set up to be loadable by any future tool that runs
-`.ts` sources directly through Node's strip-types mode (a CLI
-checker, scripts, etc.), so we keep the constructor shape
-strip-types-safe. The class still uses readonly field declarations,
-just not the shorthand. Don't "tidy" this back to parameter
-properties without arranging for a build step.
+`--experimental-strip-types` mode — used by `@efx/check`'s CLI
+and its integration test, both of which load the package's `.ts`
+sources directly — rejects parameter properties as non-type
+syntax. The class still uses readonly field declarations, just
+not the shorthand. Don't "tidy" this back to parameter properties
+without arranging for a build step.
 
 ## Coupling to other packages
 
@@ -150,12 +147,8 @@ properties without arranging for a build step.
 ## Anti-patterns
 
 - Don't change `isMixedContent` back to `false` without also
-  ensuring any non-tsserver consumer (one that uses
-  `ts.parseJsonSourceFileConfigFileContent` with
-  `extraFileExtensions`) still enumerates `.efx` files. They won't;
-  you'll get a silent 0-files-checked instead of an error.
-  tsserver's plugin pathway uses `getExternalFiles` and is more
-  forgiving — testing the editor isn't enough.
+  ensuring kit-style consumers still enumerate `.efx` files. They
+  won't; you'll get a silent 0-files-checked instead of an error.
 - Don't add a fourth `CodeInformation` profile without studying
   how Vue's docs describe the interactions between
   `verification` / `completion` / `semantic` / `navigation` /
@@ -180,10 +173,12 @@ properties without arranging for a build step.
 
 ## Tests
 
-This package has no tests of its own. Its behavior is covered by
-`@efx/ts-plugin/test/integration.mjs` — that test exercises the
-LanguagePlugin through a real tsserver subprocess against the
-demo project.
+This package has no tests of its own. Its behavior is covered by:
+
+- `@efx/ts-plugin/test/integration.mjs` — exercises the LanguagePlugin
+  through a real tsserver subprocess.
+- `@efx/check/test/integration.mjs` — exercises it through
+  `@volar/kit`.
 
 If you find yourself needing finer-grained tests (e.g., for
 `convertSourceMap` edge cases), add a `src/source-map.test.ts`
@@ -197,3 +192,4 @@ way and you can copy their scripts.
 - [`@efx/compiler`](../compiler/AGENTS.md) — source location
   preservation and `JsxRange` emission this package depends on.
 - [`@efx/ts-plugin`](../ts-plugin/AGENTS.md) — tsserver consumer.
+- [`@efx/check`](../check/AGENTS.md) — kit consumer.

--- a/packages/ts-plugin/AGENTS.md
+++ b/packages/ts-plugin/AGENTS.md
@@ -28,9 +28,7 @@ for tsserver to `require()`.
 The LanguagePlugin itself (the Volar contract), `convertSourceMap`,
 the `EfxVirtualCode` class + module-level cache, and the three
 `CodeInformation` profiles live in
-[`@efx/language`](../language/AGENTS.md). That package is shaped
-to be host-agnostic, so a future non-tsserver Volar tool can
-consume it too.
+[`@efx/language`](../language/AGENTS.md) — shared with `@efx/check`.
 
 ## How it fits together
 
@@ -215,8 +213,8 @@ deleting on-disk `.ts` files; module resolution depends on them.
 - Don't switch `extraFileExtensions.scriptKind` /
   `extraFileExtensions.isMixedContent` /
   `getServiceScript.scriptKind` independently. They form a
-  contract with tsc that this plugin AND any future non-tsserver
-  Volar consumer of `@efx/language` both depend on. The current
+  contract with tsc that's load-bearing across both this plugin's
+  tsserver path and `@efx/check`'s kit path. The current
   combination (Deferred + isMixedContent: true + TS for the
   virtual code) is documented in
   [`@efx/language` AGENTS.md](../language/AGENTS.md#the-extrafileextensions-shape-is-load-bearing).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
         specifier: 4.0.0-beta.70
         version: 4.0.0-beta.70
     devDependencies:
+      '@efx/check':
+        specifier: workspace:*
+        version: link:../../packages/check
       '@efx/compiler':
         specifier: workspace:*
         version: link:../../packages/compiler
@@ -42,6 +45,28 @@ importers:
       vite:
         specifier: ^7.0.0
         version: 7.3.3(@types/node@25.9.1)(yaml@2.9.0)
+
+  packages/check:
+    dependencies:
+      '@efx/language':
+        specifier: workspace:*
+        version: link:../language
+      '@volar/kit':
+        specifier: ^2.4.28
+        version: 2.4.28(typescript@5.9.3)
+      '@volar/language-service':
+        specifier: ^2.4.28
+        version: 2.4.28
+      volar-service-typescript:
+        specifier: ^0.0.71
+        version: 0.0.71(@volar/language-service@2.4.28)
+      vscode-uri:
+        specifier: ^3.1.0
+        version: 3.1.0
+    devDependencies:
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
 
   packages/compiler:
     dependencies:
@@ -543,8 +568,16 @@ packages:
   '@vitest/utils@4.1.7':
     resolution: {integrity: sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==}
 
+  '@volar/kit@2.4.28':
+    resolution: {integrity: sha512-cKX4vK9dtZvDRaAzeoUdaAJEew6IdxHNCRrdp5Kvcl6zZOqb6jTOfk3kXkIkG3T7oTFXguEMt5+9ptyqYR84Pg==}
+    peerDependencies:
+      typescript: '*'
+
   '@volar/language-core@2.4.28':
     resolution: {integrity: sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==}
+
+  '@volar/language-service@2.4.28':
+    resolution: {integrity: sha512-Rh/wYCZJrI5vCwMk9xyw/Z+MsWxlJY1rmMZPsxUoJKfzIRjS/NF1NmnuEcrMbEVGja00aVpCsInJfixQTMdvLw==}
 
   '@volar/source-map@2.4.28':
     resolution: {integrity: sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==}
@@ -688,6 +721,11 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  semver@7.8.1:
+    resolution: {integrity: sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
@@ -719,6 +757,12 @@ packages:
   toml@4.1.1:
     resolution: {integrity: sha512-EBJnVBr3dTXdA89WVFoAIPUqkBjxPMwRqsfuo1r240tKFHXv3zgca4+NJib/h6TyvGF7vOawz0jGuryJCdNHrw==}
     engines: {node: '>=20'}
+
+  typesafe-path@0.2.2:
+    resolution: {integrity: sha512-OJabfkAg1WLZSqJAJ0Z6Sdt3utnbzr/jh+NAHoyWHJe8CMSy79Gm085094M9nvTPy22KzTVn5Zq5mbapCI/hPA==}
+
+  typescript-auto-import-cache@0.3.6:
+    resolution: {integrity: sha512-RpuHXrknHdVdK7wv/8ug3Fr0WNsNi5l5aB8MYYuXhq2UH5lnEB1htJ1smhtD5VeCsGr2p8mUDtd83LCQDFVgjQ==}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -812,6 +856,30 @@ packages:
         optional: true
       jsdom:
         optional: true
+
+  volar-service-typescript@0.0.71:
+    resolution: {integrity: sha512-yTtM/BVT6hoyEYnDtaCyAtNhdNeS/mhTTABlBOdw3NNiRBUin3IznFJpgfjer4c6RYopiPjjQjc9VFhxVl1mLw==}
+    peerDependencies:
+      '@volar/language-service': ~2.4.0
+    peerDependenciesMeta:
+      '@volar/language-service':
+        optional: true
+
+  vscode-jsonrpc@8.2.0:
+    resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
+    engines: {node: '>=14.0.0'}
+
+  vscode-languageserver-protocol@3.17.5:
+    resolution: {integrity: sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==}
+
+  vscode-languageserver-textdocument@1.0.12:
+    resolution: {integrity: sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==}
+
+  vscode-languageserver-types@3.17.5:
+    resolution: {integrity: sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==}
+
+  vscode-nls@5.2.0:
+    resolution: {integrity: sha512-RAaHx7B14ZU04EU31pT+rKz2/zSl7xMsfIZuo8pd+KZO6PXtQmpevpq3vxvWNcrGbdmhM/rr5Uw5Mz+NBfhVng==}
 
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
@@ -1129,9 +1197,25 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  '@volar/kit@2.4.28(typescript@5.9.3)':
+    dependencies:
+      '@volar/language-service': 2.4.28
+      '@volar/typescript': 2.4.28
+      typesafe-path: 0.2.2
+      typescript: 5.9.3
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.1.0
+
   '@volar/language-core@2.4.28':
     dependencies:
       '@volar/source-map': 2.4.28
+
+  '@volar/language-service@2.4.28':
+    dependencies:
+      '@volar/language-core': 2.4.28
+      vscode-languageserver-protocol: 3.17.5
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.1.0
 
   '@volar/source-map@2.4.28': {}
 
@@ -1307,6 +1391,8 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.4
       fsevents: 2.3.3
 
+  semver@7.8.1: {}
+
   siginfo@2.0.0: {}
 
   source-map-js@1.2.1: {}
@@ -1327,6 +1413,12 @@ snapshots:
   tinyrainbow@3.1.0: {}
 
   toml@4.1.1: {}
+
+  typesafe-path@0.2.2: {}
+
+  typescript-auto-import-cache@0.3.6:
+    dependencies:
+      semver: 7.8.1
 
   typescript@5.9.3: {}
 
@@ -1373,6 +1465,30 @@ snapshots:
       '@types/node': 25.9.1
     transitivePeerDependencies:
       - msw
+
+  volar-service-typescript@0.0.71(@volar/language-service@2.4.28):
+    dependencies:
+      path-browserify: 1.0.1
+      semver: 7.8.1
+      typescript-auto-import-cache: 0.3.6
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-nls: 5.2.0
+      vscode-uri: 3.1.0
+    optionalDependencies:
+      '@volar/language-service': 2.4.28
+
+  vscode-jsonrpc@8.2.0: {}
+
+  vscode-languageserver-protocol@3.17.5:
+    dependencies:
+      vscode-jsonrpc: 8.2.0
+      vscode-languageserver-types: 3.17.5
+
+  vscode-languageserver-textdocument@1.0.12: {}
+
+  vscode-languageserver-types@3.17.5: {}
+
+  vscode-nls@5.2.0: {}
 
   vscode-uri@3.1.0: {}
 


### PR DESCRIPTION
## Summary

A standalone CLI + programmatic type-checker for `.efx` projects, built on `@volar/kit`'s `createTypeScriptChecker` plus the shared `@efx/language` LanguagePlugin and `volar-service-typescript`. Runs in-process, prints tsc-style diagnostics with source positions in the `.efx` files, exits non-zero when errors are present. Replaces `tsc --noEmit` for `.efx` projects without requiring a tsserver process.

API:

```ts
import { runCheck } from "@efx/check"
const r = await runCheck({ cwd, tsconfig? })
// r: { filesChecked, errors, warnings }
```

CLI:

```
efx-check [--tsconfig <path>] [--root <dir>]
```

Modeled on Astro's `astro-check` (see `refs/astro-language-tools/packages/astro-check/`). The kit-based approach is significantly smaller than vue-tsc's tsc-monkey-patching pattern and doesn't depend on internal TypeScript behavior.

Wired into `apps/demo`'s `typecheck` script in place of `tsc --noEmit`. `efx-compile` still runs first because TS's module resolver doesn't auto-try `.efx` even with `extraFileExtensions` declared — cross-file imports from `channels.test-d.ts` still need on-disk sibling `.ts` files. Dropping that pre-step is the natural follow-up (see Notes).

Warnings and hints surfaced by `volar-service-typescript` (e.g. unused-import suggestions) are counted but not printed by default — the bare `tsc --noEmit` flow we replaced was silent on warnings, and we preserve that contract. There's a `TODO(astro-parity)` note in `src/index.ts` for a future `--minimumSeverity` flag plus watch mode (chokidar), severity-based exit gating, and colored output.

## Test plan

- [ ] `pnpm --filter @efx/check typecheck` → clean
- [ ] `pnpm --filter @efx/check test` → integration smoke test passes: known-good fixture → 0 errors; inject broken `.efx` → exactly one TS2322 with the right source position; cleanup → 0 errors
- [ ] `pnpm --filter @efx/demo typecheck` → "Checked 14 files: 0 errors", exit 0 (replaces the old `tsc --noEmit` path)
- [ ] Inject a deliberate `.ts`/`.efx` type error in `apps/demo/src/`, run `pnpm --filter @efx/demo typecheck` → exit 1 with the expected error printed
- [ ] `pnpm -r test` → all three suites pass (compiler, ts-plugin integration, check integration)

## Notes

- New AGENTS.md nodes (`packages/check/AGENTS.md`) and updates to root + `packages/language/AGENTS.md` + `packages/ts-plugin/AGENTS.md` + `apps/demo/AGENTS.md`.
- **Follow-up** worth filing: drop the on-disk sibling `.ts` files entirely. They're only needed because TS module resolution from `.ts` files doesn't pick up `.efx` even with `extraFileExtensions`. With `efx-check` now driving typecheck, the only remaining role of `efx-compile` is feeding tsc's resolver, which is awkward. Options: (a) emit `.d.ts` shims, (b) use TS path mapping, (c) accept it. Worth a design pass.
- `@efx/check` is currently consumed via `node --experimental-strip-types` rather than a built CLI binary. If we ever publish it externally, add an esbuild step (mirroring `@efx/ts-plugin/build.mjs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)