### PR TITLE
refactor(runtime): consolidate View coercion into coerce.ts

### DIFF
--- a/packages/runtime/AGENTS.md
+++ b/packages/runtime/AGENTS.md
@@ -30,10 +30,12 @@ the editor margin. If you rename them, update the regex.
 
 | File | Purpose |
 |---|---|
-| `src/h.ts` | `h()` factory + `track`/`read`/`peek` reactivity-tracking machinery + `normalizeChild` (any child shape → `View`) |
+| `src/h.ts` | `h()` factory + `track`/`read`/`peek` reactivity-tracking machinery. Re-exports `isAtomRef` from `coerce.ts` for back-compat |
+| `src/coerce.ts` | `coerceAsync` (any child shape → `Effect<View>`) and `coerceSync` (render-time emission → `View`). Internal; not re-exported from `index.ts`. Also owns `isAtomRef` / `ATOM_REF_TYPE_ID` |
 | `src/View.ts` | `View` IR (intermediate representation) — hand-written union of 6 named interfaces (`ViewText`, `ViewElement`, `ViewFragment`, `ViewReactive`, `ViewList`, `ViewEmpty`); constructors via `Data.taggedEnum<View>()`. The normalized DOM-materialization shape `mount` switches on. Plus `isView`, `VIEW_TAGS` |
 | `src/mount.ts` | DOM renderer. `buildDom(View, registry) → { node, cleanup }`, `mount(app, el)` |
 | `src/index.ts` | Public exports + `list`, `Fragment`, `EfxLive` |
+| `src/coerce.test.ts` | Vitest suite for `coerceAsync` / `coerceSync` (parity + the sync/async asymmetry pin) |
 | `src/types/Fold.ts` | `ChildE`/`ChildR`/`FoldE`/`FoldR`/`TagE`/`TagR`/`TagProps` — the channel-fold conditional types |
 | `src/types/Html.ts` | `IntrinsicProps`/`HtmlEventHandlers` — typed event handlers for HTML intrinsics |
 | `src/types/Fold.test-d.ts` | `expectTypeOf` matrix — every channel-fold shape |
@@ -83,9 +85,11 @@ it, every `<Row item={item} />` would erase `item`'s generic type to
 ## View IR
 
 The intermediate representation between "arbitrary JSX child value"
-and "DOM nodes." `normalizeChild` (in `h.ts`) coerces inputs to
-View; `buildDom` (in `mount.ts`) switches on the variant tag and
-produces DOM. Closed-for-now at 6 variants:
+and "DOM nodes." `coerceAsync` (in `coerce.ts`) coerces inputs to
+View at `h()` call time; `coerceSync` (also in `coerce.ts`) coerces
+render-time emissions from Reactive sources; `buildDom` (in
+`mount.ts`) switches on the variant tag and produces DOM. Closed-
+for-now at 6 variants:
 
 - `Text { value }` — plain text node
 - `Element { tag, props, children }` — DOM element
@@ -113,14 +117,13 @@ inline form.
 ### Closed-for-now, not closed-forever
 
 The current 6 variants cover everything we need to render. Adding
-a variant is a coordinated edit across three files:
+a variant is a coordinated edit across two files:
 
   - `buildDom` (mount.ts) — exhaustive `switch (view._tag)` forces
     a new case (TS will tell you)
-  - `valueToView` (mount.ts) — if the new variant can come out of
-    a `Reactive`'s emitted value
-  - `normalizeChild` (h.ts) — if it can also be authored directly
-    from JSX (vs. only constructed internally)
+  - `coerce.ts` — `coerceAsync` if it can be authored from JSX,
+    and/or `coerceSync` if it can be emitted from a Reactive
+    source. Often one of the two is enough.
 
 Channels are unaffected — they're folded at the `h()` call site
 via `FoldE`/`FoldR`, which operate on input child *shapes*
@@ -128,7 +131,7 @@ via `FoldE`/`FoldR`, which operate on input child *shapes*
 "JSX call site" in the emitted code — the compiler turns every
 `<div>...</div>` into a plain `h(...)` call before tsc sees it.
 See root [AGENTS.md](../../AGENTS.md) on JSX-as-syntax-only.) By
-the time `normalizeChild` returns a View, all channels have been
+the time `coerceAsync` returns a View, all channels have been
 hoisted into the surrounding Effect.
 
 Good candidates if a need arises: `Portal` (render children to a
@@ -149,10 +152,14 @@ with a Fragment.
 **Reactive nodes render a placeholder comment first**, then swap on
 the first emit (synchronous if the source is already populated).
 Source can be `Atom` or `AtomRef.ReadonlyRef`; dispatch on
-`Atom.isAtom` / `isAtomRef`. `valueToView` (synchronous) coerces the
-emitted value into a `View` — including `Effect`, which is run with
-the current scope so `Effect.acquireRelease` registers releases on
-*this* node's scope.
+`Atom.isAtom` / `isAtomRef`. `coerceSync` (from `coerce.ts`) coerces
+the emitted value into a `View` — including `Effect`, which is run
+with the current scope so `Effect.acquireRelease` registers releases
+on *this* node's scope. `coerceSync` is deliberately asymmetric vs.
+`coerceAsync`: at this point in the render path the Atom/AtomRef has
+already been peeled, so it does NOT recurse into
+Option/Result/Chunk/Atom/AtomRef. Don't "fix" that — the unwrap
+contract belongs upstream.
 
 **List reconciles by AtomRef identity.** Not by index, not by value
 equality. Each row's `AtomRef` is the key; on `subscribe`, only
@@ -184,12 +191,15 @@ the lifetime of the rendered UI.
 - Don't add View IR variants as convenience wrappers (`Card`,
   `Heading`, etc.) — those are components, not IR. New variants
   are for new DOM-materialization shapes (`Portal`, `Suspense`)
-  and require coordinated edits across `buildDom`, `valueToView`,
-  and `normalizeChild`. See "Closed-for-now, not closed-forever"
-  above.
-- Don't normalize Reactive sources eagerly. `valueToView` is
+  and require coordinated edits across `buildDom` and `coerce.ts`.
+  See "Closed-for-now, not closed-forever" above.
+- Don't normalize Reactive sources eagerly. `coerceSync` is
   synchronous on purpose; subscribing first then rendering would
   flash a comment in the DOM.
+- Don't make `coerceSync` peel Option/Result/Chunk/Atom/AtomRef.
+  Those containers are unwrapped upstream of the Reactive render
+  path; adding peeling here would either silently re-introduce
+  async dependencies into a sync hot path or grow dead code.
 - Don't return `DocumentFragment` from `buildDom`. Stable replacement
   needs a real parent node.
 - Don't extend `h.track`'s behavior to handle composite expressions

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -8,7 +8,8 @@
     ".": "./src/index.ts"
   },
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
     "effect": "4.0.0-beta.70"

--- a/packages/runtime/src/coerce.test.ts
+++ b/packages/runtime/src/coerce.test.ts
@@ -1,0 +1,225 @@
+import { Chunk, Effect, Option, Result, Scope } from "effect"
+import { Atom, AtomRef } from "effect/unstable/reactivity"
+import { describe, expect, it } from "vitest"
+import { coerceAsync, coerceSync, isAtomRef } from "./coerce.ts"
+import { View } from "./View.ts"
+
+// coerceAsync's signature is `(unknown) => Effect<View, any, any>` — the
+// `any` in R doesn't satisfy `runPromise`'s `R = never` under strict mode,
+// so we run via a typed helper.
+const run = (e: Effect.Effect<View, any, any>): Promise<View> =>
+  Effect.runPromise(e as Effect.Effect<View, never, never>)
+
+describe("coerceAsync — primitives", () => {
+  it("string → View.Text", async () => {
+    const view = await run(coerceAsync("hi"))
+    expect(view).toEqual(View.Text({ value: "hi" }))
+  })
+
+  it("number → View.Text via String()", async () => {
+    const view = await run(coerceAsync(42))
+    expect(view).toEqual(View.Text({ value: "42" }))
+  })
+
+  it("bigint → View.Text via String()", async () => {
+    const view = await run(coerceAsync(7n))
+    expect(view).toEqual(View.Text({ value: "7" }))
+  })
+
+  it.each([null, undefined, true, false])("%s → View.Empty", async (v) => {
+    const view = await run(coerceAsync(v))
+    expect(view).toEqual(View.Empty())
+  })
+})
+
+describe("coerceAsync — already-built View pass-through", () => {
+  it("returns the same View when given a View", async () => {
+    const input = View.Text({ value: "already a view" })
+    const view = await run(coerceAsync(input))
+    expect(view).toEqual(input)
+  })
+})
+
+describe("coerceAsync — container peeling", () => {
+  it("Effect<string> → coerce the inner value", async () => {
+    const view = await run(coerceAsync(Effect.succeed("from effect")))
+    expect(view).toEqual(View.Text({ value: "from effect" }))
+  })
+
+  it("Effect<Effect<string>> → recursively unwrap", async () => {
+    const view = await run(coerceAsync(Effect.succeed(Effect.succeed("nested"))))
+    expect(view).toEqual(View.Text({ value: "nested" }))
+  })
+
+  it("Option.none → Empty", async () => {
+    const view = await run(coerceAsync(Option.none()))
+    expect(view).toEqual(View.Empty())
+  })
+
+  it("Option.some(x) → coerce x", async () => {
+    const view = await run(coerceAsync(Option.some("inner")))
+    expect(view).toEqual(View.Text({ value: "inner" }))
+  })
+
+  it("Result failure → Empty", async () => {
+    const view = await run(coerceAsync(Result.fail("nope")))
+    expect(view).toEqual(View.Empty())
+  })
+
+  it("Result success → coerce inner", async () => {
+    const view = await run(coerceAsync(Result.succeed("ok")))
+    expect(view).toEqual(View.Text({ value: "ok" }))
+  })
+
+  it("Array → Fragment of coerced children", async () => {
+    const view = await run(coerceAsync(["a", 1, null]))
+    expect(view).toEqual(
+      View.Fragment({
+        children: [
+          View.Text({ value: "a" }),
+          View.Text({ value: "1" }),
+          View.Empty(),
+        ],
+      }),
+    )
+  })
+
+  it("Chunk → Fragment of coerced children", async () => {
+    const view = await run(coerceAsync(Chunk.fromIterable(["a", "b"])))
+    expect(view).toEqual(
+      View.Fragment({
+        children: [View.Text({ value: "a" }), View.Text({ value: "b" })],
+      }),
+    )
+  })
+})
+
+describe("coerceAsync — reactive sources", () => {
+  it("AtomRef → View.Reactive carrying the ref", async () => {
+    const ref = AtomRef.make("hello")
+    const view = await run(coerceAsync(ref))
+    expect(view).toEqual(View.Reactive({ source: ref }))
+  })
+
+  it("Atom → View.Reactive carrying the atom", async () => {
+    const atom = Atom.make("hello")
+    const view = await run(coerceAsync(atom))
+    expect(view).toEqual(View.Reactive({ source: atom }))
+  })
+})
+
+describe("coerceAsync — unknown fallback", () => {
+  it("plain object → View.Text via String()", async () => {
+    const view = await run(coerceAsync({ toString: () => "obj!" }))
+    expect(view).toEqual(View.Text({ value: "obj!" }))
+  })
+})
+
+describe("coerceSync — primitives + View pass-through", () => {
+  it("string → View.Text", () => {
+    expect(coerceSync("hi")).toEqual(View.Text({ value: "hi" }))
+  })
+
+  it("number → View.Text via String()", () => {
+    expect(coerceSync(42)).toEqual(View.Text({ value: "42" }))
+  })
+
+  it("bigint → View.Text via String()", () => {
+    expect(coerceSync(7n)).toEqual(View.Text({ value: "7" }))
+  })
+
+  it.each([null, undefined, true, false])("%s → View.Empty", (v) => {
+    expect(coerceSync(v)).toEqual(View.Empty())
+  })
+
+  it("View → pass through", () => {
+    const input = View.Text({ value: "v" })
+    expect(coerceSync(input)).toEqual(input)
+  })
+})
+
+describe("coerceSync — Effect handling", () => {
+  it("Effect.succeed(string) → coerce inner synchronously", () => {
+    expect(coerceSync(Effect.succeed("ok"))).toEqual(View.Text({ value: "ok" }))
+  })
+
+  it("Effect that requires Scope: runs with provided scope", () => {
+    const scope = Scope.makeUnsafe()
+    const eff = Effect.gen(function* () {
+      yield* Effect.addFinalizer(() => Effect.void)
+      return "scoped"
+    })
+    expect(coerceSync(eff, scope)).toEqual(View.Text({ value: "scoped" }))
+  })
+
+  it("Effect that fails synchronously → View.Text with `[effect failed:` prefix", () => {
+    const result = coerceSync(Effect.fail("boom"))
+    expect(result._tag).toBe("Text")
+    expect((result as { value: string }).value).toMatch(/^\[effect failed:/)
+  })
+})
+
+describe("coerceSync — Array → Fragment", () => {
+  it("array of primitives", () => {
+    expect(coerceSync(["a", 1, null])).toEqual(
+      View.Fragment({
+        children: [
+          View.Text({ value: "a" }),
+          View.Text({ value: "1" }),
+          View.Empty(),
+        ],
+      }),
+    )
+  })
+})
+
+describe("coerceSync — unknown fallback (String())", () => {
+  it("plain object → View.Text via String()", () => {
+    expect(coerceSync({ toString: () => "obj!" })).toEqual(
+      View.Text({ value: "obj!" }),
+    )
+  })
+})
+
+describe("coerceSync — asymmetry (does NOT peel async-only containers)", () => {
+  // These tests pin the design decision: sync mode handles only the shapes
+  // that can be emitted from a Reactive source at render-time. Containers
+  // like Option/Result/Atom/AtomRef would require subscribing or unwrapping
+  // an Effect, neither of which is appropriate inside the sync render path.
+
+  it("Option.some(x) → String() fallback, not unwrap", () => {
+    const result = coerceSync(Option.some("inner"))
+    expect(result._tag).toBe("Text")
+    expect((result as { value: string }).value).not.toBe("inner")
+  })
+
+  it("Result.succeed(x) → String() fallback, not unwrap", () => {
+    const result = coerceSync(Result.succeed("inner"))
+    expect(result._tag).toBe("Text")
+    expect((result as { value: string }).value).not.toBe("inner")
+  })
+
+  it("AtomRef → String() fallback, not View.Reactive", () => {
+    const ref = AtomRef.make("x")
+    const result = coerceSync(ref)
+    expect(result._tag).toBe("Text")
+  })
+
+  it("Chunk → String() fallback, not Fragment", () => {
+    const result = coerceSync(Chunk.fromIterable(["a", "b"]))
+    expect(result._tag).toBe("Text")
+  })
+})
+
+describe("isAtomRef predicate", () => {
+  it("returns true for AtomRef.make()", () => {
+    expect(isAtomRef(AtomRef.make(0))).toBe(true)
+  })
+
+  it("returns false for plain objects, null, primitives", () => {
+    expect(isAtomRef(null)).toBe(false)
+    expect(isAtomRef({})).toBe(false)
+    expect(isAtomRef("x")).toBe(false)
+    expect(isAtomRef(0)).toBe(false)
+  })
+})

--- a/packages/runtime/src/coerce.test.ts
+++ b/packages/runtime/src/coerce.test.ts
@@ -4,30 +4,24 @@ import { describe, expect, it } from "vitest"
 import { coerceAsync, coerceSync, isAtomRef } from "./coerce.ts"
 import { View } from "./View.ts"
 
-// coerceAsync's signature is `(unknown) => Effect<View, any, any>` — the
-// `any` in R doesn't satisfy `runPromise`'s `R = never` under strict mode,
-// so we run via a typed helper.
-const run = (e: Effect.Effect<View, any, any>): Promise<View> =>
-  Effect.runPromise(e as Effect.Effect<View, never, never>)
-
 describe("coerceAsync — primitives", () => {
   it("string → View.Text", async () => {
-    const view = await run(coerceAsync("hi"))
+    const view = await Effect.runPromise(coerceAsync("hi"))
     expect(view).toEqual(View.Text({ value: "hi" }))
   })
 
   it("number → View.Text via String()", async () => {
-    const view = await run(coerceAsync(42))
+    const view = await Effect.runPromise(coerceAsync(42))
     expect(view).toEqual(View.Text({ value: "42" }))
   })
 
   it("bigint → View.Text via String()", async () => {
-    const view = await run(coerceAsync(7n))
+    const view = await Effect.runPromise(coerceAsync(7n))
     expect(view).toEqual(View.Text({ value: "7" }))
   })
 
   it.each([null, undefined, true, false])("%s → View.Empty", async (v) => {
-    const view = await run(coerceAsync(v))
+    const view = await Effect.runPromise(coerceAsync(v))
     expect(view).toEqual(View.Empty())
   })
 })
@@ -35,44 +29,44 @@ describe("coerceAsync — primitives", () => {
 describe("coerceAsync — already-built View pass-through", () => {
   it("returns the same View when given a View", async () => {
     const input = View.Text({ value: "already a view" })
-    const view = await run(coerceAsync(input))
+    const view = await Effect.runPromise(coerceAsync(input))
     expect(view).toEqual(input)
   })
 })
 
 describe("coerceAsync — container peeling", () => {
   it("Effect<string> → coerce the inner value", async () => {
-    const view = await run(coerceAsync(Effect.succeed("from effect")))
+    const view = await Effect.runPromise(coerceAsync(Effect.succeed("from effect")))
     expect(view).toEqual(View.Text({ value: "from effect" }))
   })
 
   it("Effect<Effect<string>> → recursively unwrap", async () => {
-    const view = await run(coerceAsync(Effect.succeed(Effect.succeed("nested"))))
+    const view = await Effect.runPromise(coerceAsync(Effect.succeed(Effect.succeed("nested"))))
     expect(view).toEqual(View.Text({ value: "nested" }))
   })
 
   it("Option.none → Empty", async () => {
-    const view = await run(coerceAsync(Option.none()))
+    const view = await Effect.runPromise(coerceAsync(Option.none()))
     expect(view).toEqual(View.Empty())
   })
 
   it("Option.some(x) → coerce x", async () => {
-    const view = await run(coerceAsync(Option.some("inner")))
+    const view = await Effect.runPromise(coerceAsync(Option.some("inner")))
     expect(view).toEqual(View.Text({ value: "inner" }))
   })
 
   it("Result failure → Empty", async () => {
-    const view = await run(coerceAsync(Result.fail("nope")))
+    const view = await Effect.runPromise(coerceAsync(Result.fail("nope")))
     expect(view).toEqual(View.Empty())
   })
 
   it("Result success → coerce inner", async () => {
-    const view = await run(coerceAsync(Result.succeed("ok")))
+    const view = await Effect.runPromise(coerceAsync(Result.succeed("ok")))
     expect(view).toEqual(View.Text({ value: "ok" }))
   })
 
   it("Array → Fragment of coerced children", async () => {
-    const view = await run(coerceAsync(["a", 1, null]))
+    const view = await Effect.runPromise(coerceAsync(["a", 1, null]))
     expect(view).toEqual(
       View.Fragment({
         children: [
@@ -85,7 +79,7 @@ describe("coerceAsync — container peeling", () => {
   })
 
   it("Chunk → Fragment of coerced children", async () => {
-    const view = await run(coerceAsync(Chunk.fromIterable(["a", "b"])))
+    const view = await Effect.runPromise(coerceAsync(Chunk.fromIterable(["a", "b"])))
     expect(view).toEqual(
       View.Fragment({
         children: [View.Text({ value: "a" }), View.Text({ value: "b" })],
@@ -97,20 +91,20 @@ describe("coerceAsync — container peeling", () => {
 describe("coerceAsync — reactive sources", () => {
   it("AtomRef → View.Reactive carrying the ref", async () => {
     const ref = AtomRef.make("hello")
-    const view = await run(coerceAsync(ref))
+    const view = await Effect.runPromise(coerceAsync(ref))
     expect(view).toEqual(View.Reactive({ source: ref }))
   })
 
   it("Atom → View.Reactive carrying the atom", async () => {
     const atom = Atom.make("hello")
-    const view = await run(coerceAsync(atom))
+    const view = await Effect.runPromise(coerceAsync(atom))
     expect(view).toEqual(View.Reactive({ source: atom }))
   })
 })
 
 describe("coerceAsync — unknown fallback", () => {
   it("plain object → View.Text via String()", async () => {
-    const view = await run(coerceAsync({ toString: () => "obj!" }))
+    const view = await Effect.runPromise(coerceAsync({ toString: () => "obj!" }))
     expect(view).toEqual(View.Text({ value: "obj!" }))
   })
 })

--- a/packages/runtime/src/coerce.ts
+++ b/packages/runtime/src/coerce.ts
@@ -1,0 +1,87 @@
+import { Chunk, Effect, Exit, Option, Result, Scope } from "effect"
+import { Atom, AtomRef } from "effect/unstable/reactivity"
+import { isView, View } from "./View.ts"
+
+export const ATOM_REF_TYPE_ID = "~effect/reactivity/AtomRef"
+
+export const isAtomRef = (u: unknown): u is AtomRef.ReadonlyRef<unknown> =>
+  typeof u === "object" && u !== null && ATOM_REF_TYPE_ID in u
+
+const Empty = View.Empty()
+
+export const coerceAsync = (v: unknown): Effect.Effect<View, any, any> => {
+  if (v == null || v === false || v === true) return Effect.succeed(Empty)
+  if (typeof v === "string") return Effect.succeed(View.Text({ value: v }))
+  if (typeof v === "number" || typeof v === "bigint") {
+    return Effect.succeed(View.Text({ value: String(v) }))
+  }
+  if (isView(v)) return Effect.succeed(v)
+  if (Effect.isEffect(v)) {
+    return Effect.flatMap(v as Effect.Effect<unknown, any, any>, coerceAsync)
+  }
+  if (Option.isOption(v)) {
+    return Option.match(v, {
+      onNone: () => Effect.succeed(Empty),
+      onSome: coerceAsync,
+    })
+  }
+  if (Result.isResult(v)) {
+    return Result.match(v, {
+      onFailure: () => Effect.succeed(Empty),
+      onSuccess: coerceAsync,
+    })
+  }
+  if (Chunk.isChunk(v)) return coerceChildren(Chunk.toReadonlyArray(v))
+  if (Array.isArray(v)) return coerceChildren(v)
+  if (Atom.isAtom(v)) {
+    return Effect.succeed(View.Reactive({ source: v as Atom.Atom<View> }))
+  }
+  if (isAtomRef(v)) {
+    return Effect.succeed(View.Reactive({ source: v as AtomRef.ReadonlyRef<View> }))
+  }
+  return Effect.succeed(View.Text({ value: String(v) }))
+}
+
+const coerceChildren = (cs: ReadonlyArray<unknown>): Effect.Effect<View, any, any> =>
+  Effect.gen(function* () {
+    const out: View[] = []
+    for (const c of cs) {
+      out.push(yield* coerceAsync(c))
+    }
+    return View.Fragment({ children: out })
+  })
+
+/**
+ * Synchronously coerce an arbitrary value (typically read from a reactive
+ * source at render time) into a View. If `scope` is provided and the value
+ * is an Effect, the effect is run with that scope, so `Effect.acquireRelease`
+ * / `Effect.addFinalizer` inside the effect register releases against it.
+ *
+ * **Asymmetric vs. coerceAsync**: this path does NOT peel
+ * Option/Result/Chunk/Atom/AtomRef. At render-time those containers have
+ * already been unwrapped by the caller; if one shows up here it's coerced
+ * via `String()` rather than silently expanded.
+ */
+export const coerceSync = (v: unknown, scope?: Scope.Closeable): View => {
+  if (v == null || v === false || v === true) return Empty
+  if (typeof v === "string") return View.Text({ value: v })
+  if (typeof v === "number" || typeof v === "bigint") {
+    return View.Text({ value: String(v) })
+  }
+  if (isView(v)) return v
+  if (Effect.isEffect(v)) {
+    const provided = scope
+      ? Effect.provideService(v as Effect.Effect<unknown, unknown, Scope.Scope>, Scope.Scope, scope)
+      : (v as Effect.Effect<unknown, unknown, never>)
+    const exit = Effect.runSyncExit(provided)
+    return Exit.match(exit, {
+      onSuccess: (val) => coerceSync(val, scope),
+      onFailure: (cause) =>
+        View.Text({ value: `[effect failed: ${String(cause)}]` }),
+    })
+  }
+  if (Array.isArray(v)) {
+    return View.Fragment({ children: v.map((x) => coerceSync(x, scope)) })
+  }
+  return View.Text({ value: String(v) })
+}

--- a/packages/runtime/src/coerce.ts
+++ b/packages/runtime/src/coerce.ts
@@ -1,5 +1,6 @@
 import { Chunk, Effect, Exit, Option, Result, Scope } from "effect"
 import { Atom, AtomRef } from "effect/unstable/reactivity"
+import type { ChildE, ChildR } from "./types/Fold.ts"
 import { isView, View } from "./View.ts"
 
 export const ATOM_REF_TYPE_ID = "~effect/reactivity/AtomRef"
@@ -9,7 +10,8 @@ export const isAtomRef = (u: unknown): u is AtomRef.ReadonlyRef<unknown> =>
 
 const Empty = View.Empty()
 
-export const coerceAsync = (v: unknown): Effect.Effect<View, any, any> => {
+export function coerceAsync<C>(v: C): Effect.Effect<View, ChildE<C>, ChildR<C>>
+export function coerceAsync(v: unknown): Effect.Effect<View, any, any> {
   if (v == null || v === false || v === true) return Effect.succeed(Empty)
   if (typeof v === "string") return Effect.succeed(View.Text({ value: v }))
   if (typeof v === "number" || typeof v === "bigint") {
@@ -42,14 +44,16 @@ export const coerceAsync = (v: unknown): Effect.Effect<View, any, any> => {
   return Effect.succeed(View.Text({ value: String(v) }))
 }
 
-const coerceChildren = (cs: ReadonlyArray<unknown>): Effect.Effect<View, any, any> =>
-  Effect.gen(function* () {
+function coerceChildren<C>(cs: ReadonlyArray<C>): Effect.Effect<View, ChildE<C>, ChildR<C>>
+function coerceChildren(cs: ReadonlyArray<unknown>): Effect.Effect<View, any, any> {
+  return Effect.gen(function* () {
     const out: View[] = []
     for (const c of cs) {
       out.push(yield* coerceAsync(c))
     }
     return View.Fragment({ children: out })
   })
+}
 
 /**
  * Synchronously coerce an arbitrary value (typically read from a reactive

--- a/packages/runtime/src/h.ts
+++ b/packages/runtime/src/h.ts
@@ -1,12 +1,10 @@
-import { Chunk, Effect, Option, Result } from "effect"
-import { Atom, AtomRef } from "effect/unstable/reactivity"
+import { Effect } from "effect"
+import { AtomRef } from "effect/unstable/reactivity"
+import { coerceAsync, isAtomRef } from "./coerce.ts"
 import type { FoldE, FoldR, TagE, TagProps, TagR } from "./types/Fold.ts"
-import { isView, type Props, View } from "./View.ts"
+import { type Props, View } from "./View.ts"
 
-const ATOM_REF_TYPE_ID = "~effect/reactivity/AtomRef"
-
-export const isAtomRef = (u: unknown): u is AtomRef.ReadonlyRef<unknown> =>
-  typeof u === "object" && u !== null && ATOM_REF_TYPE_ID in u
+export { isAtomRef }
 
 // ─── Tracking scope for h.track / h.read ─────────────────────────────────
 //
@@ -90,84 +88,14 @@ function peekImpl(obj: unknown): unknown {
   return obj
 }
 
-const Empty = View.Empty()
-
-/**
- * Normalize an arbitrary child value into a `View` node.
- *
- * Recurses through container shapes (Effect, Option, Result, Array, Chunk,
- * AtomRef, Atom). Primitives become Text or Empty. The returned Effect
- * carries any channels the child contributed.
- */
-const normalizeChild = (c: unknown): Effect.Effect<View, any, any> => {
-  // Falsy → Empty (so `cond && <X/>` works when cond is false/null/undefined)
-  if (c === null || c === undefined || c === false || c === true) {
-    return Effect.succeed(Empty)
-  }
-  // Primitives → Text
-  if (typeof c === "string") {
-    return Effect.succeed(View.Text({ value: c }))
-  }
-  if (typeof c === "number" || typeof c === "bigint") {
-    return Effect.succeed(View.Text({ value: String(c) }))
-  }
-  // View IR (already-built node) — pass through
-  if (isView(c)) {
-    return Effect.succeed(c)
-  }
-  // Effect → run, then normalize the result
-  if (Effect.isEffect(c)) {
-    return Effect.flatMap(c as Effect.Effect<unknown, any, any>, normalizeChild)
-  }
-  // Option → onNone Empty, onSome normalize
-  if (Option.isOption(c)) {
-    return Option.match(c, {
-      onNone: () => Effect.succeed(Empty),
-      onSome: normalizeChild,
-    })
-  }
-  // Result → onFailure Empty (errors handled via E channel elsewhere), onSuccess normalize
-  if (Result.isResult(c)) {
-    return Result.match(c, {
-      onFailure: () => Effect.succeed(Empty),
-      onSuccess: normalizeChild,
-    })
-  }
-  // Chunk → like array
-  if (Chunk.isChunk(c)) {
-    return normalizeChildren(Chunk.toReadonlyArray(c))
-  }
-  // Plain readonly array → Fragment
-  if (Array.isArray(c)) {
-    return normalizeChildren(c)
-  }
-  // Atom — reactive binding via registry
-  if (Atom.isAtom(c)) {
-    return Effect.succeed(View.Reactive({ source: c as Atom.Atom<View> }))
-  }
-  // AtomRef — reactive binding via direct subscribe
-  if (isAtomRef(c)) {
-    return Effect.succeed(View.Reactive({ source: c as AtomRef.ReadonlyRef<View> }))
-  }
-  // Fallback: coerce to string
-  return Effect.succeed(View.Text({ value: String(c) }))
-}
-
-const normalizeChildren = (cs: ReadonlyArray<unknown>): Effect.Effect<View, any, any> =>
-  Effect.gen(function* () {
-    const out: View[] = []
-    for (const c of cs) {
-      out.push(yield* normalizeChild(c))
-    }
-    return View.Fragment({ children: out })
-  })
-
 /**
  * The view factory.
  *
  * Takes a tag (intrinsic element name or a component function) and any
  * number of children. The return type carries the union of every child's
- * `E` and `R` channels via `FoldE`/`FoldR`.
+ * `E` and `R` channels via `FoldE`/`FoldR`. Children of arbitrary shape
+ * (Effect, Option, Result, Atom, AtomRef, Array, Chunk, primitive) are
+ * normalized via `coerceAsync` in `./coerce.ts`.
  */
 const _h = (
   tag: string | ((props: Props) => Effect.Effect<View, any, any>),
@@ -177,7 +105,7 @@ const _h = (
   Effect.gen(function* () {
     const out: View[] = []
     for (const c of children) {
-      out.push(yield* normalizeChild(c))
+      out.push(yield* coerceAsync(c))
     }
     if (typeof tag === "function") {
       // Component: pass props (children threaded as a prop)

--- a/packages/runtime/src/mount.ts
+++ b/packages/runtime/src/mount.ts
@@ -1,10 +1,7 @@
 import { Effect, Exit, Scope } from "effect"
 import { Atom, AtomRef, AtomRegistry } from "effect/unstable/reactivity"
-import { isView, type Props, View } from "./View.ts"
-
-const ATOM_REF_TYPE_ID = "~effect/reactivity/AtomRef"
-const isAtomRef = (u: unknown): u is AtomRef.ReadonlyRef<unknown> =>
-  typeof u === "object" && u !== null && ATOM_REF_TYPE_ID in u
+import { coerceSync, isAtomRef } from "./coerce.ts"
+import { type Props, View } from "./View.ts"
 
 type Rendered = {
   readonly node: Node
@@ -12,36 +9,6 @@ type Rendered = {
 }
 
 const noop = () => {}
-
-/**
- * Synchronously coerce an arbitrary value (typically read from a reactive
- * source) into a View. If `scope` is provided and the value is an Effect,
- * the effect is run with that scope, so `Effect.acquireRelease` /
- * `Effect.addFinalizer` inside the effect register releases against it.
- */
-const valueToView = (v: unknown, scope?: Scope.Closeable): View => {
-  if (v == null || v === false || v === true) return View.Empty()
-  if (typeof v === "string") return View.Text({ value: v })
-  if (typeof v === "number" || typeof v === "bigint") {
-    return View.Text({ value: String(v) })
-  }
-  if (isView(v)) return v
-  if (Effect.isEffect(v)) {
-    const provided = scope
-      ? Effect.provideService(v as Effect.Effect<unknown, unknown, Scope.Scope>, Scope.Scope, scope)
-      : (v as Effect.Effect<unknown, unknown, never>)
-    const exit = Effect.runSyncExit(provided)
-    return Exit.match(exit, {
-      onSuccess: (val) => valueToView(val, scope),
-      onFailure: (cause) =>
-        View.Text({ value: `[effect failed: ${String(cause)}]` }),
-    })
-  }
-  if (Array.isArray(v)) {
-    return View.Fragment({ children: v.map((x) => valueToView(x, scope)) })
-  }
-  return View.Text({ value: String(v) })
-}
 
 const applyProp = (el: Element, key: string, value: unknown): (() => void) | undefined => {
   // Reactive prop: AtomRef → subscribe and re-apply on changes.
@@ -143,7 +110,7 @@ const buildDom = (view: View, registry: AtomRegistry.AtomRegistry): Rendered => 
       let currentCleanup: () => void = noop
 
       const render = (next: unknown): void => {
-        const r = buildDom(valueToView(next), registry)
+        const r = buildDom(coerceSync(next), registry)
         if (currentNode.parentNode) {
           currentNode.parentNode.replaceChild(r.node, currentNode)
         }
@@ -207,7 +174,7 @@ const buildDom = (view: View, registry: AtomRegistry.AtomRegistry): Rendered => 
           let r = rendered.get(ref)
           if (!r) {
             const rowScope = Scope.makeUnsafe()
-            const rowView = valueToView(view.render(ref, i), rowScope)
+            const rowView = coerceSync(view.render(ref, i), rowScope)
             const built = buildDom(rowView, registry)
             r = {
               node: built.node,

--- a/packages/runtime/vitest.config.ts
+++ b/packages/runtime/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+  },
+})


### PR DESCRIPTION
## Summary

- Collapse `normalizeChild` (h.ts) and `valueToView` (mount.ts) — two parallel implementations of "coerce arbitrary value to View" — into a single internal module `packages/runtime/src/coerce.ts` exporting `coerceAsync` and `coerceSync`. The variant matrix is now in one place.
- Dedupe the `ATOM_REF_TYPE_ID` constant and `isAtomRef` predicate that were copy-pasted across h.ts and mount.ts. `isAtomRef` lives in coerce.ts and is re-exported from h.ts for back-compat.
- **Sync/async asymmetry pinned, not "fixed":** `coerceSync` deliberately does NOT peel Option/Result/Chunk/Atom/AtomRef. Those containers are unwrapped upstream of the Reactive render path; supporting them in sync would either require running Effects inside the sync hot path or grow dead code. Asymmetry is covered by dedicated tests and documented as a new anti-pattern in `packages/runtime/AGENTS.md`.

## Test plan

- [x] Unit: 38 tests in `coerce.test.ts` (parity for both functions + asymmetry pins for Option/Result/Chunk/AtomRef under `coerceSync`)
- [x] Workspace tests: `pnpm -r test` exit 0 (compiler 35 + runtime 38 + ts-plugin integration)
- [x] Typecheck: `@efx/runtime` + `@efx/demo` clean. (ts-plugin typecheck errors are pre-existing on main — verified via `git stash`.)
- [x] Probe scripts against live demo: `probe.mjs`, `probe-liveuser.mjs`, `probe-todos.mjs`, `probe-lifecycle.mjs` all pass
- [x] Net LOC across coerced source: **-18** (h.ts -72, mount.ts -33, coerce.ts +87)
- [x] AGENTS.md updated: Files table, View IR section, "Closed-for-now, not closed-forever" (variant edit now spans 2 files instead of 3), and a new anti-pattern locking in the asymmetry

🤖 Generated with [Claude Code](https://claude.com/claude-code)