### PR TITLE
fix(language): emit generatedLengths so inlay-hint positions land correctly

### DIFF
--- a/packages/language/AGENTS.md
+++ b/packages/language/AGENTS.md
@@ -117,6 +117,23 @@ parallel array of node spans, not a regex scan of the output text).
 That coupling is intentional: the compiler is the only thing that
 authoritatively knows what's "h() machinery" vs. user code.
 
+### Source and generated lengths are tracked separately
+
+Each mapping carries both `lengths` (source span) and
+`generatedLengths` (generated span). They can differ — Babel's
+output often shrinks regions: `(n) =>` compiles to `n =>` (parens
+dropped for single-param arrows), so a source mapping covering
+`((` (2 chars) lines up with generated `(` (1 char).
+
+If we only tracked source lengths, Volar would assume the
+generated span has the same length and over-claim generated
+territory for that mapping — swallowing positions that belong to
+the next mapping. Inlay-hint positions get this wrong most
+visibly: a `: number` parameter-type hint that should render
+after `n` lands at the `n`'s position instead, displaying as
+`( : numbern)`. The integration test in `@efx/ts-plugin` asserts
+this exact case.
+
 ## The cache is process-local module state
 
 `virtual-code.ts` exports a module-level

--- a/packages/language/src/source-map.ts
+++ b/packages/language/src/source-map.ts
@@ -101,16 +101,34 @@ export function convertSourceMap(
     }
   }
 
-  // Sort by source offset for proper length calculation
+  // Compute generated-side lengths by sorting independently. We track source AND
+  // generated lengths because Babel's transforms can shrink spans — `(n) =>`
+  // becomes `n =>` with the parens dropped, so a source mapping covering `((` (2
+  // chars) lines up with generated `(` (1 char). With only source lengths, Volar
+  // would think the source `((` mapping covers 2 generated chars and swallow the
+  // position of `n` that follows. Inlay-hint positions, in particular, land in
+  // the wrong source mapping and render at the wrong screen column.
+  const sortedByGen = [...segmentsBySource.values()].sort((a, b) => a.genOffset - b.genOffset)
+  const nextGenOffset = new Map<number, number>()
+  for (let i = 0; i < sortedByGen.length; i++) {
+    const cur = sortedByGen[i]!
+    const next = sortedByGen[i + 1]
+    nextGenOffset.set(cur.genOffset, next ? next.genOffset : cur.genOffset + 1)
+  }
+
+  // Sort by source offset for source-side length calculation
   const sortedSegments = [...segmentsBySource.values()].sort((a, b) => a.srcOffset - b.srcOffset)
 
-  // Create mappings with lengths extending to next segment
+  // Create mappings with both source and generated lengths
   for (let i = 0; i < sortedSegments.length; i++) {
     const seg = sortedSegments[i]!
     const nextSeg = sortedSegments[i + 1]
 
     // Length in source space: from this offset to the next (or 1 if last)
     const srcLength = nextSeg ? nextSeg.srcOffset - seg.srcOffset : 1
+    // Length in generated space: from this offset to the next generated offset
+    // (which may be a different sorted neighbor than the source one)
+    const genLength = (nextGenOffset.get(seg.genOffset) ?? seg.genOffset + 1) - seg.genOffset
 
     // Position is JSX-derived if its source offset falls inside any JSX node range.
     const isInHCall = insideJsxNode(seg.srcOffset)
@@ -136,6 +154,7 @@ export function convertSourceMap(
       sourceOffsets: [seg.srcOffset],
       generatedOffsets: [seg.genOffset],
       lengths: [srcLength],
+      generatedLengths: [genLength],
       data,
     })
   }

--- a/packages/ts-plugin/test/integration.mjs
+++ b/packages/ts-plugin/test/integration.mjs
@@ -101,6 +101,7 @@ async function main() {
     preferences: {
       includeInlayParameterNameHints: "all",
       includeInlayVariableTypeHints: true,
+      includeInlayFunctionParameterTypeHints: true,
     },
   })
 
@@ -200,6 +201,27 @@ async function main() {
     console.log(`   WARNING: ${hParamHints.length} h() parameter hints still present`)
   } else {
     console.log("   PASS: No h() parameter hints")
+  }
+
+  // Counter.efx line 19 has: `<button onclick={() => count.update((n) => n + 1)}>+</button>`
+  // With `includeInlayFunctionParameterTypeHints` on, tsserver emits a Type hint
+  // `: number` for the `n` parameter. It must render IMMEDIATELY AFTER the `n`
+  // (column 45 = the `)` position), not at column 44 = the `n` position itself —
+  // that would render as `( : numbern)` instead of `(n: number)`. Stale source-map
+  // mappings without `generatedLengths` produce the wrong column. See
+  // `@efx/language/src/source-map.ts`.
+  const paramTypeHint = hints.find(h => {
+    const text = typeof h.text === 'string' ? h.text : JSON.stringify(h.text)
+    return h.kind === 'Type' && /^:\s*number/.test(text) && h.position?.line === 19
+  })
+  if (!paramTypeHint) {
+    console.log("   FAIL: missing ': number' Type hint on line 19's `n` parameter")
+    process.exitCode = 1
+  } else if (paramTypeHint.position.offset === 45) {
+    console.log("   PASS: ': number' hint at line 19 column 45 (after the `n`)")
+  } else {
+    console.log(`   FAIL: ': number' hint at line 19 column ${paramTypeHint.position.offset} — expected 45 (after the n)`)
+    process.exitCode = 1
   }
 
   console.log("\n7. Test go-to-definition on Counter import in main.efx...")


### PR DESCRIPTION
## Summary

A `: number` parameter-type inlay hint for `n` in `(n) => n + 1` was rendering BEFORE the `n` (showing as `( : numbern)`) instead of after it (showing as `(n: number)`).

Root cause: `convertSourceMap` was setting `lengths` (source-side spans) on each Volar `Mapping` but leaving `generatedLengths` unset, so Volar assumed the generated span matched the source span. That's wrong whenever Babel's output shrinks — `(n) =>` compiles to `n =>` (parens dropped for single-param arrows), so a source mapping covering `((` (2 chars) lines up with generated `(` (1 char). Volar over-claimed generated territory for that mapping and swallowed the `n` position that follows. Inlay-hint positions, returned by tsserver in generated coordinates, get mapped to the wrong source mapping and land one column to the left.

Fix: compute generated lengths by sorting segments by generated offset (independently from the source-order sort used for source lengths). Each mapping now carries both `lengths` and `generatedLengths`. Concrete impact: the `: number` hint moves from line 19 col 44 (at `n`) to line 19 col 45 (right after `n`).

## Test plan

- [x] New assertion in `packages/ts-plugin/test/integration.mjs` locks in the corrected column. The test now enables `includeInlayFunctionParameterTypeHints` so the regression is reproducible from `pnpm test`.
- [x] `pnpm -r test` → all three suites pass
- [x] `pnpm -r typecheck` → all 7 packages clean
- [x] `pnpm --filter @efx/ts-plugin test` → new `PASS: ': number' hint at line 19 column 45 (after the n)` plus the existing go-to-def / find-references / etc. all still pass

## Notes

- The user spotted this in the editor (an actual rendered inlay hint between the `((` and `n`). The integration test didn't catch it because it wasn't enabling `includeInlayFunctionParameterTypeHints` and was only checking that the parameter-name hints (e.g. `f:`) weren't bleeding through from h() internals.
- `@efx/language/AGENTS.md` gains a short subsection explaining why both length fields matter — the constraint isn't obvious from reading the Volar `Mapping` type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)