### PR TITLE
fix(runtime): diff h.track deps to survive notify-during-iteration

### DIFF
--- a/packages/runtime/AGENTS.md
+++ b/packages/runtime/AGENTS.md
@@ -74,11 +74,22 @@ The compiler wraps `{expr}` JSX expressions in `h.track(() => expr)`
    its initial value to the thunk's result, subscribes to every
    tracked ref, re-runs the thunk on change.
 5. Deps are re-collected on every rerun (a ternary may read
-   different refs on its other branch). Old subs are dropped first.
+   different refs on its other branch) and **diffed** against the
+   prior set — only deps that disappeared are unsubscribed, only
+   newly-read deps are subscribed. Stable deps don't churn.
 
 **Invariant: the empty-deps early return is load-bearing.** Without
 it, every `<Row item={item} />` would erase `item`'s generic type to
 `unknown`.
+
+**Why diff, not unsub-all-then-resub.** `AtomRef.notify` iterates
+`listeners` while `subscribe`/unsub mutates that same array via
+swap-pop. When two JSX expressions in one component read the same
+ref (e.g. `<li class={done ? "done" : ""}><span>{done ? "✓" : "·"}</span></li>`),
+they both subscribe on the row ref's listener array. A blanket
+"drop all subs, re-add them" inside one listener's rerun reshuffles
+the array under `notify`'s loop and the sibling listener is
+skipped. Diffing means stable-deps reruns leave the array alone.
 
 ## View IR
 

--- a/packages/runtime/src/h.ts
+++ b/packages/runtime/src/h.ts
@@ -32,18 +32,34 @@ const trackImpl = (thunk: () => unknown): unknown => {
 
   // At least one ref was read — wrap in a derived AtomRef that re-runs
   // the thunk whenever any tracked ref changes. Deps may change between
-  // runs (a ternary's "other branch" reads different refs), so we
-  // re-subscribe fresh on each run.
+  // runs (a ternary's "other branch" reads different refs), so we diff
+  // them: unsubscribe only deps no longer read, subscribe only newly-read
+  // ones. Stable deps (the common case) cause no listener-array churn.
+  //
+  // Why diff instead of unsub-all-then-resub: AtomRef's `notify` iterates
+  // `listeners` while `subscribe`/unsub mutates that same array via
+  // swap-pop. When several JSX expressions in one component all read the
+  // same ref (e.g. `{done ? ...}` in two places), a blanket resubscribe
+  // inside one listener's rerun would shuffle the array under the
+  // iteration and skip sibling listeners.
   const derived = AtomRef.make<unknown>(result)
-  let unsubs: Array<() => void> = []
+  const currentSubs = new Map<AtomRef.ReadonlyRef<unknown>, () => void>()
 
-  const subscribeAll = (set: Set<AtomRef.ReadonlyRef<unknown>>) => {
-    for (const dep of set) unsubs.push(dep.subscribe(rerun))
+  const syncSubs = (next: Set<AtomRef.ReadonlyRef<unknown>>) => {
+    for (const [dep, unsub] of currentSubs) {
+      if (!next.has(dep)) {
+        unsub()
+        currentSubs.delete(dep)
+      }
+    }
+    for (const dep of next) {
+      if (!currentSubs.has(dep)) {
+        currentSubs.set(dep, dep.subscribe(rerun))
+      }
+    }
   }
 
   const rerun = () => {
-    for (const u of unsubs) u()
-    unsubs = []
     const nextDeps = new Set<AtomRef.ReadonlyRef<unknown>>()
     const prevTracker = currentTracker
     currentTracker = nextDeps
@@ -52,10 +68,10 @@ const trackImpl = (thunk: () => unknown): unknown => {
     } finally {
       currentTracker = prevTracker
     }
-    subscribeAll(nextDeps)
+    syncSubs(nextDeps)
   }
 
-  subscribeAll(deps)
+  syncSubs(deps)
   return derived
 }
 


### PR DESCRIPTION
## Summary

- Three reactive bindings on the same row ref (Todos.efx: `class`, glyph, text) used to desync as you clicked — only one of the three updated per click, in a `T1, T1, T2, T2, T1, T1…` pattern.
- Root cause: `AtomRef.notify` (effect-smol) iterates `listeners` while `subscribe`/unsub mutate the same array via swap-pop. `h.track`'s rerun did blanket unsub-all-then-resubscribe on every notification, reshuffling the array under `notify`'s loop and skipping sibling listeners on the same ref.
- Fix in `packages/runtime/src/h.ts`: track subs in a `Map<dep, unsub>` and diff on rerun. Stable deps (the common case) don't touch the listener array; only deps that disappeared get unsubscribed, only newly-read deps get subscribed.

The underlying notify-during-iteration fragility still lives in effect-smol's `ReadonlyRefImpl` — out of scope here, but worth a separate upstream fix.

## Reproduction (before fix)

In `apps/demo`, clicking a todo row 10× cycles through: `✓+strike → unstrike, ✓ stays → nothing → ✓ gone → no ✓, striked → nothing → ✓+strike → ✓+unstrike → nothing → uncheck+unstrike`. Matches a worked-out trace of swap-pop interactions across the three trackers on the row ref.

## Test plan

- [x] `pnpm --filter @efx/runtime typecheck`
- [x] `pnpm --filter @efx/demo typecheck` (includes `efx:compile`)
- [x] `pnpm --filter @efx/compiler test` (35/35)
- [x] End-to-end h.track simulation: 10 toggles each consistently update all three derived refs (`class="done"/""`, `child="✓"/"·"`, `text="test"`)
- [x] Manual: load `pnpm --filter @efx/demo dev`, click todo rows, verify checkmark and strike stay in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)