### PR TITLE
refactor(compiler): emit typed CompilerMapping[]; @efx/language becomes a translator

### DIFF
--- a/packages/compiler/AGENTS.md
+++ b/packages/compiler/AGENTS.md
@@ -8,11 +8,22 @@ TypeScript with every `<...>` expression rewritten as an
 brackets — they are gone before tsc, Vite, or any other downstream
 tool sees the file.
 
-Entry point: `transformEfx(source, filename) → { code, map, jsxRanges }`.
-Used by `@efx/vite-plugin` (for runtime serving) and
-`@efx/language` (for the Volar virtual code). `@efx/vite-plugin`
-ignores `jsxRanges`; `@efx/language` consumes it for
-`CodeInformation` region tagging.
+Entry point: `transformEfx(source, filename) → { code, map, jsxRanges, mappings }`.
+
+- `code` — compiled TypeScript output.
+- `map` — Babel V3 source map. Used by `@efx/vite-plugin` for HMR /
+  dev-server source maps.
+- `jsxRanges` — source-side metadata about each `JSXElement` /
+  `JSXFragment` (opening/closing tag positions). Used by
+  `@efx/ts-plugin/src/jsx-tags.ts` for `<Foo>` ↔ `</Foo>` document
+  highlights.
+- `mappings` — `CompilerMapping[]`: typed source↔generated spans
+  with explicit lengths on both sides and a `kind` tag (`"user"` /
+  `"h-call"` / `"punctuation"`). Built by `computeMappings` in
+  `src/source-map.ts`. This is the single source of truth for
+  position translation; `@efx/language` translates it directly into
+  Volar's `Mapping<CodeInformation>[]` without touching `map` or
+  `jsxRanges`. See "Source-map mappings" below.
 
 ## Why Babel, not tsc/swc
 
@@ -117,11 +128,11 @@ If you add a new node kind to the emit (e.g., a future
 `h.something(...)` call from a new compiler rewrite), wrap its
 constructors in `copyLoc` against the source node they replace.
 
-## `jsxRanges` — source-side metadata for downstream tools
+## `jsxRanges` — source-side metadata for tag-pair matching
 
-Alongside `code` and `map`, the transform emits one `JsxRange` per
-`JSXElement` / `JSXFragment` the parser saw, in source order
-(pre-order: outer before nested). Each range carries:
+Alongside `code`, `map`, and `mappings`, the transform emits one
+`JsxRange` per `JSXElement` / `JSXFragment` the parser saw, in
+source order (pre-order: outer before nested). Each range carries:
 
 - `start` / `end` — the full node span (`<div>...</div>`)
 - `openingTag.start` / `.end` — the `<...>` part
@@ -131,16 +142,56 @@ Alongside `code` and `map`, the transform emits one `JsxRange` per
 - Fragments (`kind: "fragment"`) have no name positions; their
   `openingTag` is `<>`, `closingTag` is `</>`
 
-This exists so consumers (today: `@efx/ts-plugin`) don't have to
-re-discover JSX structure by regex-scanning the source or the
-compiled output. The Babel AST already knows these positions; we
-report them. Anti-pattern: anywhere in the workspace running a
-JSX-shaped regex against `.efx` content — they should consume
-`jsxRanges` instead.
+This exists so consumers (today: `@efx/ts-plugin/src/jsx-tags.ts`)
+don't have to re-discover JSX structure by regex-scanning the
+source. The Babel AST already knows these positions; we report
+them. Anti-pattern: anywhere in the workspace running a JSX-shaped
+regex against `.efx` content — consume `jsxRanges` instead.
 
-If you add a new compiler output shape (e.g. richer mappings,
-embedded codes), keep `jsxRanges` as a plain serializable array —
-the contract is structural, not class-based.
+`jsxRanges` is ALSO used internally by `computeMappings` to
+classify each source position as `"user"` / `"h-call"` /
+`"punctuation"` — but external consumers should reach for
+`mappings` (which has the classification baked in) over rebuilding
+that classifier from `jsxRanges`.
+
+## Source-map mappings — typed source↔generated spans
+
+`computeMappings(map, source, generated, jsxRanges)` in
+`src/source-map.ts` produces the `mappings` array. The algorithm
+in five steps:
+
+1. Decode Babel's V3 mappings into `(genOffset, srcOffset, srcChar)`
+   segments via `@jridgewell/sourcemap-codec`.
+2. Dedupe by source offset (first segment wins) — Babel sometimes
+   emits multiple generated points for the same source point.
+3. Compute source-side spans by sorting segments by source offset
+   and taking consecutive differences.
+4. Compute generated-side spans by sorting INDEPENDENTLY by
+   generated offset and taking differences. Source and generated
+   spans **can differ** because Babel transforms shift byte counts:
+   - `(n) =>` → `n =>` (single-arg arrow paren strip): source `((`
+     of 2 chars maps to generated `(` of 1 char.
+   - `x.value` → `h.read(x)`: source 7 chars → generated 9 chars.
+   - `<div>...</div>` → `h("div", ..., ...)`: source 5 chars
+     (opening tag) → generated 8+ chars.
+5. Classify each mapping's `kind` via `jsxRanges` intersection:
+   - JSX angle bracket `<` / `>` / `/` inside an opening or closing
+     tag span → `"punctuation"` (no semantic, no navigation —
+     cursor on `<` shouldn't jump into `h.ts`).
+   - Inside any JSX node range → `"h-call"` (semantic features kept
+     but highlight suppressed — cursor on a tag name shouldn't
+     highlight every `h` identifier).
+   - Otherwise → `"user"` (full features).
+
+The lengths-on-both-sides design is **load-bearing**: a regression
+where only source lengths were tracked caused inlay-hint positions
+to drift one column to the left (`( : numbern)` instead of
+`(n: number)`). See `src/source-map.test.ts` — that test asserts
+the exact `(source: 2, generated: 1)` shape for the PR #12 case.
+
+`@efx/language` uses `mappings` directly and never re-decodes the
+Babel source map. The bidirectional length asymmetry is captured
+once, here, in the compiler.
 
 ## Tests
 
@@ -154,10 +205,10 @@ attributes, source maps. Run with `pnpm --filter @efx/compiler test`.
 - No type checking. That's tsc's job (post-transform).
 - No reactivity wiring. `h.track`/`read`/`peek` live in
   `@efx/runtime`; the compiler only emits *calls* to them.
-- No source-map remapping for diagnostics. That's the
-  `@efx/ts-plugin` consumer's job. We DO emit the source-side
-  `jsxRanges` it needs to classify positions; the actual mapping
-  decode (Babel VLQ → Volar `Mapping<CodeInformation>`) lives there.
+- No `CodeInformation` profile assignment. The compiler classifies
+  each span as `"user"` / `"h-call"` / `"punctuation"` (a
+  Volar-free taxonomy); `@efx/language` translates kind → Volar
+  `CodeInformation`. Keeps the compiler Volar-agnostic.
 - No file watching, no caching. Pure function of `(source, filename)`.
   Callers cache.
 

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -15,7 +15,8 @@
     "@babel/parser": "^7.26.0",
     "@babel/traverse": "^7.26.0",
     "@babel/generator": "^7.26.0",
-    "@babel/types": "^7.26.0"
+    "@babel/types": "^7.26.0",
+    "@jridgewell/sourcemap-codec": "^1.5.5"
   },
   "devDependencies": {
     "@effect/vitest": "4.0.0-beta.70",

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -7,3 +7,9 @@ export {
   type NamedTagPosition,
   type TagPosition,
 } from "./transform.ts"
+
+export {
+  computeMappings,
+  type CompilerMapping,
+  type CompilerMappingKind,
+} from "./source-map.ts"

--- a/packages/compiler/src/source-map.test.ts
+++ b/packages/compiler/src/source-map.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest"
+import { transformEfx } from "./transform.ts"
+import type { CompilerMapping } from "./source-map.ts"
+
+/**
+ * Tests for the compiler's `mappings` output (typed source↔generated spans).
+ *
+ * `@efx/language`'s `src/source-map.test.ts` covers the same ground but goes
+ * through the Volar-shaped `Mapping<CodeInformation>[]` translation. These
+ * tests assert on the compiler's typed shape directly — they protect the
+ * contract any Volar-agnostic consumer would depend on.
+ */
+
+const compile = (src: string) => transformEfx(src, "test.efx")
+
+const findBySourceOffset = (
+  mappings: ReadonlyArray<CompilerMapping>,
+  offset: number,
+) => mappings.find((m) => m.source.offset === offset)
+
+describe("transformEfx — mappings shape", () => {
+  it("every mapping carries source and generated lengths plus a kind", () => {
+    const result = compile(`const x = <div class="page">hi</div>`)
+    expect(result.mappings.length).toBeGreaterThan(0)
+    for (const m of result.mappings) {
+      expect(typeof m.source.offset).toBe("number")
+      expect(typeof m.source.length).toBe("number")
+      expect(typeof m.generated.offset).toBe("number")
+      expect(typeof m.generated.length).toBe("number")
+      expect(["user", "h-call", "punctuation"]).toContain(m.kind)
+    }
+  })
+
+  it("single-arg arrow paren strip: source `((` (2 chars) → generated `(` (1 char)", () => {
+    // PR #12 regression: Babel strips parens on single-arg arrows so
+    // `(n) =>` compiles to `n =>`. The source mapping covering `((` (the
+    // function-call paren + arrow paren) has source length 2 but generated
+    // length 1. Without this, downstream consumers over-claim generated
+    // territory and inlay-hint positions drift.
+    const src = `const f = () => count.update((n) => n + 1)`
+    const result = compile(src)
+    expect(result.code).toContain("count.update(n => n + 1)")
+
+    const outerParenSrc = src.indexOf("update(") + "update".length
+    const m = findBySourceOffset(result.mappings, outerParenSrc)
+    expect(m).toBeDefined()
+    expect(m!.source.length, "covers source `((`").toBe(2)
+    expect(m!.generated.length, "covers generated `(`").toBe(1)
+  })
+
+  it("source positions are not duplicated (dedup by source offset)", () => {
+    const src = `const view = <div><span>x</span></div>`
+    const result = compile(src)
+    const seen = new Set<number>()
+    for (const m of result.mappings) {
+      expect(seen.has(m.source.offset), `duplicate at offset ${m.source.offset}`).toBe(false)
+      seen.add(m.source.offset)
+    }
+  })
+
+  it("user source positions are covered by at most one mapping (no overlap)", () => {
+    const src = `const view = <div>hi</div>`
+    const result = compile(src)
+    for (let i = 0; i < src.length; i++) {
+      const containing = result.mappings.filter(
+        (m) => i >= m.source.offset && i < m.source.offset + m.source.length,
+      )
+      expect(containing.length, `offset ${i} claimed by ${containing.length}`).toBeLessThanOrEqual(1)
+    }
+  })
+
+  it("mappings are sorted by source offset", () => {
+    const src = `const view = <div><span>x</span></div>`
+    const result = compile(src)
+    for (let i = 1; i < result.mappings.length; i++) {
+      expect(result.mappings[i]!.source.offset).toBeGreaterThan(result.mappings[i - 1]!.source.offset)
+    }
+  })
+})
+
+describe("transformEfx — mapping kinds", () => {
+  it("JSX angle brackets `<` `>` `/` are classified as punctuation", () => {
+    const src = `const x = <div>hi</div>`
+    const result = compile(src)
+    const ltSrc = src.indexOf("<div")
+    const ltMapping = findBySourceOffset(result.mappings, ltSrc)
+    expect(ltMapping?.kind).toBe("punctuation")
+  })
+
+  it("positions inside an h() call (JSX-derived) are classified as h-call", () => {
+    const src = `const x = <div class="page">hi</div>`
+    const result = compile(src)
+    // Find a mapping whose source span sits inside the JSX opening tag.
+    // Babel's source map doesn't emit a mapping at every character, so we
+    // look up by containment rather than exact match.
+    const classSrc = src.indexOf("class")
+    const containing = result.mappings.find(
+      (m) => m.source.offset <= classSrc && m.source.offset + m.source.length > classSrc,
+    )
+    expect(containing, "expected a mapping covering the `class` attribute").toBeDefined()
+    expect(containing!.kind).toBe("h-call")
+  })
+
+  it("normal user code outside JSX is classified as user", () => {
+    const src = `const x = 1
+const view = <div>hi</div>`
+    const result = compile(src)
+    const constSrc = src.indexOf("const x")
+    const m = findBySourceOffset(result.mappings, constSrc)
+    expect(m?.kind).toBe("user")
+  })
+
+  it("operator `>` inside a JSX expression is NOT punctuation", () => {
+    // `{a > b}` inside JSX: the `>` is a JS operator, not JSX angle bracket.
+    // The classifier checks for the tag-span containment to disambiguate.
+    const src = `const a = 1, b = 2
+const view = <div>{a > b ? "yes" : "no"}</div>`
+    const result = compile(src)
+    const gtSrc = src.indexOf("a > b") + 2
+    const m = findBySourceOffset(result.mappings, gtSrc)
+    // Whether a mapping exists at that exact position depends on Babel's
+    // emission, but if one does, it must NOT be classified as punctuation.
+    if (m) {
+      expect(m.kind).not.toBe("punctuation")
+    }
+  })
+})
+
+describe("transformEfx — no-source-map cases", () => {
+  it("file without JSX produces a single passthrough-ish mapping", () => {
+    const src = `export const x = 42`
+    const result = compile(src)
+    expect(result.mappings.length).toBeGreaterThan(0)
+    // All mappings should be classified as user code (no JSX in source).
+    for (const m of result.mappings) {
+      expect(m.kind).toBe("user")
+    }
+  })
+})

--- a/packages/compiler/src/source-map.ts
+++ b/packages/compiler/src/source-map.ts
@@ -1,0 +1,161 @@
+import { decode } from "@jridgewell/sourcemap-codec"
+import type { JsxRange } from "./transform.ts"
+
+/**
+ * Source-to-generated mapping with explicit lengths on both sides.
+ *
+ * Babel's source map records POINT mappings — each segment is a single
+ * (generatedLine, generatedColumn, sourceLine, sourceColumn) tuple. Volar's
+ * `Mapping` records SPAN mappings with separate source/generated lengths,
+ * because the two can differ: `(n) =>` compiles to `n =>` (paren strip), so
+ * a 2-char source span pairs with a 1-char generated span. We compute those
+ * lengths here, in the compiler, and ship them out as a typed array.
+ *
+ * `kind` is the semantic role of the mapped source span:
+ *   - `"user"`        — normal user code, full editor features
+ *   - `"h-call"`      — JSX-derived position inside an `h(...)` call's
+ *                       internals, semantic highlighting suppressed so cursor
+ *                       on a tag name doesn't highlight every `h` in the file
+ *   - `"punctuation"` — JSX angle brackets `<` `>` `/` inside a tag span,
+ *                       no semantic / completion / navigation
+ *
+ * Downstream consumers (`@efx/language/convertSourceMap`) translate `kind`
+ * to a Volar `CodeInformation` profile.
+ */
+export interface CompilerMapping {
+  readonly source: { readonly offset: number; readonly length: number }
+  readonly generated: { readonly offset: number; readonly length: number }
+  readonly kind: CompilerMappingKind
+}
+
+export type CompilerMappingKind = "user" | "h-call" | "punctuation"
+
+/**
+ * Build `CompilerMapping[]` from Babel's source map + the compiler's
+ * `jsxRanges`. This is the single source of truth for source↔generated
+ * position translation. Consumers should NOT re-process Babel's source map.
+ *
+ * Algorithm:
+ *   1. Decode Babel's V3 mappings into (genOffset, srcOffset, srcChar) segments.
+ *   2. Dedupe by source offset (first wins) — Babel sometimes emits multiple
+ *      generated points for the same source point.
+ *   3. Compute source spans by sorting segments by source offset and taking
+ *      consecutive differences.
+ *   4. Compute generated spans by sorting INDEPENDENTLY by generated offset
+ *      and taking consecutive differences. Source and generated spans can
+ *      differ because Babel transforms (paren strip, `.value` → `h.read(x)`,
+ *      JSX → `h(...)`) shift byte counts.
+ *   5. Classify each mapping's `kind` by intersecting its source offset
+ *      against `jsxRanges` (punctuation inside tag spans, h-call inside any
+ *      JSX range, otherwise user code).
+ */
+export function computeMappings(
+  map: { mappings?: string } | null | undefined,
+  source: string,
+  generated: string,
+  jsxRanges: ReadonlyArray<JsxRange>,
+): CompilerMapping[] {
+  if (!map?.mappings) {
+    // No source map (e.g., JSX-free input where Babel emits trivial output) —
+    // produce a single passthrough mapping covering both sides.
+    const length = Math.min(source.length, generated.length)
+    return [
+      { source: { offset: 0, length }, generated: { offset: 0, length }, kind: "user" },
+    ]
+  }
+
+  const decoded = decode(map.mappings)
+  const sourceLineStarts = computeLineStarts(source)
+  const generatedLineStarts = computeLineStarts(generated)
+
+  // Collect segments, deduplicating by source offset (first occurrence wins).
+  const segmentsBySource = new Map<
+    number,
+    { genOffset: number; srcOffset: number; srcChar: string }
+  >()
+  for (let genLine = 0; genLine < decoded.length; genLine++) {
+    const segments = decoded[genLine]
+    if (!segments) continue
+
+    for (const segment of segments) {
+      if (segment.length < 4) continue
+      const [genCol, , srcLine, srcCol] = segment
+      if (srcLine === undefined || srcCol === undefined) continue
+      const genOffset = lineColToOffset(generatedLineStarts, genLine, genCol)
+      const srcOffset = lineColToOffset(sourceLineStarts, srcLine, srcCol)
+      const srcChar = source[srcOffset] || ""
+
+      if (!segmentsBySource.has(srcOffset)) {
+        segmentsBySource.set(srcOffset, { genOffset, srcOffset, srcChar })
+      }
+    }
+  }
+
+  // Sort by generated offset to compute generated spans independently —
+  // Babel transforms can pair a multi-char source span with a single-char
+  // generated span (paren strip), so source-order length ≠ generated-order
+  // length.
+  const sortedByGen = [...segmentsBySource.values()].sort((a, b) => a.genOffset - b.genOffset)
+  const nextGenOffset = new Map<number, number>()
+  for (let i = 0; i < sortedByGen.length; i++) {
+    const cur = sortedByGen[i]!
+    const next = sortedByGen[i + 1]
+    nextGenOffset.set(cur.genOffset, next ? next.genOffset : cur.genOffset + 1)
+  }
+
+  // JSX punctuation is `<`/`>`/`/` AND falls inside an opening/closing tag
+  // span — that condition keeps `{a > b}` inside a JSX expression from
+  // false-positively matching the angle-bracket profile.
+  const jsxPunctuation = new Set(["<", ">", "/"])
+  const insideJsxNode = (srcOffset: number): boolean =>
+    jsxRanges.some((r) => srcOffset >= r.start && srcOffset < r.end)
+  const insideTagPunctuationSpan = (srcOffset: number): boolean =>
+    jsxRanges.some((r) => {
+      if (srcOffset >= r.openingTag.start && srcOffset < r.openingTag.end) return true
+      if (r.closingTag && srcOffset >= r.closingTag.start && srcOffset < r.closingTag.end) return true
+      return false
+    })
+
+  // Sort by source offset and build the final spans + kind classification.
+  const sortedBySource = [...segmentsBySource.values()].sort((a, b) => a.srcOffset - b.srcOffset)
+  const mappings: CompilerMapping[] = []
+  for (let i = 0; i < sortedBySource.length; i++) {
+    const seg = sortedBySource[i]!
+    const nextSeg = sortedBySource[i + 1]
+
+    const srcLength = nextSeg ? nextSeg.srcOffset - seg.srcOffset : 1
+    const genLength = (nextGenOffset.get(seg.genOffset) ?? seg.genOffset + 1) - seg.genOffset
+
+    let kind: CompilerMappingKind
+    if (jsxPunctuation.has(seg.srcChar) && insideTagPunctuationSpan(seg.srcOffset)) {
+      kind = "punctuation"
+    } else if (insideJsxNode(seg.srcOffset)) {
+      kind = "h-call"
+    } else {
+      kind = "user"
+    }
+
+    mappings.push({
+      source: { offset: seg.srcOffset, length: srcLength },
+      generated: { offset: seg.genOffset, length: genLength },
+      kind,
+    })
+  }
+
+  return mappings
+}
+
+function computeLineStarts(text: string): number[] {
+  const starts: number[] = [0]
+  for (let i = 0; i < text.length; i++) {
+    if (text.charCodeAt(i) === 10 /* \n */) {
+      starts.push(i + 1)
+    }
+  }
+  return starts
+}
+
+function lineColToOffset(lineStarts: number[], line: number, col: number): number {
+  const start = lineStarts[line] ?? lineStarts[lineStarts.length - 1] ?? 0
+  return start + col
+}

--- a/packages/compiler/src/transform.ts
+++ b/packages/compiler/src/transform.ts
@@ -2,6 +2,7 @@ import { parse, type ParserOptions } from "@babel/parser"
 import _traverse, { type NodePath } from "@babel/traverse"
 import * as t from "@babel/types"
 import _generate from "@babel/generator"
+import { computeMappings, type CompilerMapping } from "./source-map.ts"
 
 // Babel's traverse/generate ship as CJS-default-export; in ESM contexts that
 // surfaces as the actual function on `.default`.
@@ -14,6 +15,15 @@ export interface TransformResult {
   readonly code: string
   readonly map: object | null
   readonly jsxRanges: ReadonlyArray<JsxRange>
+  /**
+   * Typed source↔generated mappings with explicit lengths on both sides and a
+   * kind classification for each span. Computed from `map` + `jsxRanges`;
+   * consumers should prefer this over re-processing the Babel source map.
+   *
+   * See `CompilerMapping` for the shape and `computeMappings` for the
+   * algorithm.
+   */
+  readonly mappings: ReadonlyArray<CompilerMapping>
 }
 
 /** Source-side span. All offsets are 0-based byte indices into the original `.efx` source. */
@@ -419,9 +429,13 @@ export const transformEfx = (source: string, filename: string): TransformResult 
     source,
   )
 
+  const map = (result.map as object | null) ?? null
+  const mappings = computeMappings(map, source, result.code, jsxRanges)
+
   return {
     code: result.code,
-    map: (result.map as object | null) ?? null,
+    map,
     jsxRanges,
+    mappings,
   }
 }

--- a/packages/language/AGENTS.md
+++ b/packages/language/AGENTS.md
@@ -18,7 +18,7 @@ certainly want to depend on this package rather than copy it.
 | File | Purpose |
 |---|---|
 | `src/language-plugin.ts` | `createEfxLanguagePlugin<T>(asFileName)` factory. Builds the Volar `LanguagePlugin` with `getLanguageId`, `createVirtualCode`, and `typescript: { extraFileExtensions, getServiceScript }`. Returns `LanguagePlugin<T, EfxVirtualCode>` so consumers can rely on the concrete class type at the boundary. |
-| `src/source-map.ts` | `convertSourceMap` (Babel map → Volar `Mapping<CodeInformation>[]`, three-profile region tagging via compiler-emitted JSX ranges). |
+| `src/source-map.ts` | `convertSourceMap` — thin translator from `@efx/compiler`'s `CompilerMapping[]` to Volar's `Mapping<CodeInformation>[]`. Maps the compiler's `"user"` / `"h-call"` / `"punctuation"` kinds to Volar profiles. ~15 LOC of actual logic + the three profile objects. |
 | `src/virtual-code.ts` | `EfxVirtualCode` class — implements Volar's `VirtualCode` interface so Volar and downstream consumers share one object per `.efx` file. Holds `source` / `compiled` / `mappings` / `jsxRanges` alongside Volar's `id` / `languageId` / `snapshot` / `embeddedCodes`. Carries `compiledToSourceOffset` / `sourceToCompiledOffset` instance methods. Module-level cache `Map<string, EfxVirtualCode>` with `getEfxVirtualCode` / `setEfxVirtualCode` accessors. |
 | `src/index.ts` | Re-exports. |
 
@@ -103,21 +103,23 @@ find one `.efx` file from another.
 
 ## The three `CodeInformation` profiles
 
-`convertSourceMap` tags each source↔generated mapping with one of
-three profiles, decided by the source character + position:
+`convertSourceMap` is a one-pass translator over the compiler's
+`CompilerMapping[]`. Each mapping carries a `kind` tag classified
+by the compiler; we map it to a Volar `CodeInformation` profile:
 
-| Region | Profile | What's disabled | Why |
+| Kind (from compiler) | Profile | What's disabled | Why |
 |---|---|---|---|
-| Normal source code | `fullData` | nothing | Default. |
-| Inside an `h(...)` call (JSX-compiled internals) | `noHighlightData` | `semantic.shouldHighlight: () => false` | Without this, cursor on a JSX tag name highlights every `h` identifier in the file. Hover/completions still work. |
-| JSX punctuation `<` `>` `/` inside a tag span | `structuralOnlyData` | `semantic: false`, `completion: false`, `navigation: false` | Cursor on `<` shouldn't navigate to `h`'s definition or highlight every `<`. The `> b}` inside a JSX expression must NOT match — that's why this profile only applies when the punctuation falls inside an opening/closing tag span. |
+| `"user"` | `fullData` | nothing | Default. Normal user code. |
+| `"h-call"` | `noHighlightData` | `semantic.shouldHighlight: () => false` | Without this, cursor on a JSX tag name highlights every `h` identifier in the file. Hover/completions still work. |
+| `"punctuation"` | `structuralOnlyData` | `semantic: false`, `completion: false`, `navigation: false` | Cursor on `<` shouldn't navigate to `h`'s definition or highlight every `<`. |
 
-The region classification uses `jsxRanges` from `@efx/compiler` (a
-parallel array of node spans, not a regex scan of the output text).
-That coupling is intentional: the compiler is the only thing that
-authoritatively knows what's "h() machinery" vs. user code.
+The compiler decides `kind` while building the mappings — it
+already knows what each emitted byte represents. This package's
+job is the Volar-shape translation only. See
+[`@efx/compiler` AGENTS.md → "Source-map mappings"](../compiler/AGENTS.md#source-map-mappings--typed-sourcegenerated-spans)
+for the algorithm.
 
-### Source and generated lengths are tracked separately
+### Source and generated lengths come from the compiler
 
 Each mapping carries both `lengths` (source span) and
 `generatedLengths` (generated span). They can differ — Babel's
@@ -125,14 +127,17 @@ output often shrinks regions: `(n) =>` compiles to `n =>` (parens
 dropped for single-param arrows), so a source mapping covering
 `((` (2 chars) lines up with generated `(` (1 char).
 
-If we only tracked source lengths, Volar would assume the
+If only source lengths were tracked, Volar would assume the
 generated span has the same length and over-claim generated
 territory for that mapping — swallowing positions that belong to
 the next mapping. Inlay-hint positions get this wrong most
 visibly: a `: number` parameter-type hint that should render
 after `n` lands at the `n`'s position instead, displaying as
-`( : numbern)`. The integration test in `@efx/ts-plugin` asserts
-this exact case.
+`( : numbern)`. Both `@efx/compiler` and `@efx/ts-plugin` have
+tests pinning this exact case.
+
+`convertSourceMap` just copies the lengths through — the compiler
+produces them.
 
 ## The cache is process-local module state
 
@@ -175,7 +180,12 @@ without arranging for a build step.
 
 - **`@efx/compiler`** — required at runtime. `createVirtualCode`
   calls `transformEfx`; `convertSourceMap` consumes the
-  `JsxRange[]` the compiler emits alongside its source map.
+  `CompilerMapping[]` the compiler produces (it has both source
+  and generated lengths plus a kind tag, ready for translation to
+  Volar shape). `jsxRanges` is also consumed but only for
+  `EfxVirtualCode.jsxRanges` (used by `@efx/ts-plugin/jsx-tags.ts`
+  for opening↔closing tag-pair document highlights), not for
+  position translation.
 - **`@volar/language-core`** and **`@volar/source-map`** — types only.
   The `Mapping<CodeInformation>` shape is Volar's public contract.
 

--- a/packages/language/package.json
+++ b/packages/language/package.json
@@ -13,7 +13,6 @@
   },
   "dependencies": {
     "@efx/compiler": "workspace:*",
-    "@jridgewell/sourcemap-codec": "^1.5.5",
     "@volar/language-core": "^2.4.28",
     "@volar/source-map": "^2.4.28"
   },

--- a/packages/language/src/language-plugin.ts
+++ b/packages/language/src/language-plugin.ts
@@ -51,7 +51,7 @@ export function createEfxLanguagePlugin<T>(
       const fileName = asFileName(scriptId)
       const source = snapshot.getText(0, snapshot.getLength())
       const result = transformEfx(source, fileName)
-      const mappings = convertSourceMap(result.map, source, result.code, result.jsxRanges)
+      const mappings = convertSourceMap(result.mappings)
       const vc = new EfxVirtualCode(source, result.code, mappings, result.jsxRanges)
       setEfxVirtualCode(fileName, vc)
       return vc

--- a/packages/language/src/source-map.test.ts
+++ b/packages/language/src/source-map.test.ts
@@ -16,7 +16,7 @@ import { convertSourceMap } from "./source-map.ts"
 
 const buildMappings = (src: string) => {
   const result = transformEfx(src, "test.efx")
-  const mappings = convertSourceMap(result.map, src, result.code, result.jsxRanges)
+  const mappings = convertSourceMap(result.mappings)
   return { code: result.code, mappings }
 }
 

--- a/packages/language/src/source-map.ts
+++ b/packages/language/src/source-map.ts
@@ -1,178 +1,63 @@
 import type { CodeInformation } from "@volar/language-core"
 import type { Mapping } from "@volar/source-map"
-import type { JsxRange } from "@efx/compiler"
-import { decode } from "@jridgewell/sourcemap-codec"
+import type { CompilerMapping, CompilerMappingKind } from "@efx/compiler"
 
 /**
- * Convert Babel's source map format to Volar's Mapping format.
- * Uses compiler-provided jsxRanges to mark JSX-derived positions as non-semantic
- * (suppress inlay hints on h() internals, disable semantic on `<` `>` `/`).
+ * Translate the compiler's typed `CompilerMapping[]` into Volar's
+ * `Mapping<CodeInformation>[]`.
+ *
+ * All the heavy lifting (decoding Babel's V3 source map, deduplicating
+ * segments, computing source AND generated span lengths, intersecting with
+ * `jsxRanges` to classify each region) lives in `@efx/compiler/src/source-map`.
+ * This function is intentionally trivial: kind → `CodeInformation` profile,
+ * and copy the offset/length pairs across.
  */
 export function convertSourceMap(
-  map: { mappings?: string } | null | undefined,
-  source: string,
-  generated: string,
-  jsxRanges: ReadonlyArray<JsxRange>,
+  mappings: ReadonlyArray<CompilerMapping>,
 ): Mapping<CodeInformation>[] {
-  if (!map?.mappings) {
-    // No source map - create a simple 1:1 mapping
-    const length = Math.min(source.length, generated.length)
-    return [
-      {
-        sourceOffsets: [0],
-        generatedOffsets: [0],
-        lengths: [length],
-        data: {
-          verification: true,
-          completion: true,
-          semantic: true,
-          navigation: true,
-          structure: true,
-          format: true,
-        },
-      },
-    ]
-  }
-
-  const decoded = decode(map.mappings)
-  const sourceLineStarts = computeLineStarts(source)
-  const generatedLineStarts = computeLineStarts(generated)
-
-  const mappings: Mapping<CodeInformation>[] = []
-  const fullData: CodeInformation = {
-    verification: true,
-    completion: true,
-    semantic: true,
-    navigation: true,
-    structure: true,
-    format: true,
-  }
-  // For h() internals: keep semantic but disable highlights (like Vue does)
-  const noHighlightData: CodeInformation = {
-    verification: true,
-    completion: true,
-    semantic: { shouldHighlight: () => false },
-    navigation: true,
-    structure: true,
-    format: true,
-  }
-  // For JSX punctuation (< > /): these map to h() structure, disable all semantic
-  const structuralOnlyData: CodeInformation = {
-    verification: true,
-    completion: false,
-    semantic: false,
-    navigation: false, // Don't navigate to h() from <
-    structure: true,
-    format: true,
-  }
-
-  // JSX punctuation characters (`<`, `>`, `/`) only get the structural-only profile
-  // when they sit inside an opening/closing tag span — otherwise `{a > b}` inside
-  // a JSX expression would false-positive on `>`.
-  const jsxPunctuation = new Set(["<", ">", "/"])
-  const insideJsxNode = (srcOffset: number): boolean =>
-    jsxRanges.some((r) => srcOffset >= r.start && srcOffset < r.end)
-  const insideTagPunctuationSpan = (srcOffset: number): boolean =>
-    jsxRanges.some((r) => {
-      if (srcOffset >= r.openingTag.start && srcOffset < r.openingTag.end) return true
-      if (r.closingTag && srcOffset >= r.closingTag.start && srcOffset < r.closingTag.end) return true
-      return false
-    })
-
-  // Collect all segments, deduplicating by source offset (keep first/best match)
-  const segmentsBySource = new Map<number, { genOffset: number; srcOffset: number; srcChar: string }>()
-  for (let genLine = 0; genLine < decoded.length; genLine++) {
-    const segments = decoded[genLine]
-    if (!segments) continue
-
-    for (const segment of segments) {
-      if (segment.length < 4) continue
-
-      const [genCol, , srcLine, srcCol] = segment
-      if (srcLine === undefined || srcCol === undefined) continue
-      const genOffset = lineColToOffset(generatedLineStarts, genLine, genCol)
-      const srcOffset = lineColToOffset(sourceLineStarts, srcLine, srcCol)
-      const srcChar = source[srcOffset] || ""
-
-      // Only keep the first mapping for each source offset
-      if (!segmentsBySource.has(srcOffset)) {
-        segmentsBySource.set(srcOffset, { genOffset, srcOffset, srcChar })
-      }
-    }
-  }
-
-  // Compute generated-side lengths by sorting independently. We track source AND
-  // generated lengths because Babel's transforms can shrink spans — `(n) =>`
-  // becomes `n =>` with the parens dropped, so a source mapping covering `((` (2
-  // chars) lines up with generated `(` (1 char). With only source lengths, Volar
-  // would think the source `((` mapping covers 2 generated chars and swallow the
-  // position of `n` that follows. Inlay-hint positions, in particular, land in
-  // the wrong source mapping and render at the wrong screen column.
-  const sortedByGen = [...segmentsBySource.values()].sort((a, b) => a.genOffset - b.genOffset)
-  const nextGenOffset = new Map<number, number>()
-  for (let i = 0; i < sortedByGen.length; i++) {
-    const cur = sortedByGen[i]!
-    const next = sortedByGen[i + 1]
-    nextGenOffset.set(cur.genOffset, next ? next.genOffset : cur.genOffset + 1)
-  }
-
-  // Sort by source offset for source-side length calculation
-  const sortedSegments = [...segmentsBySource.values()].sort((a, b) => a.srcOffset - b.srcOffset)
-
-  // Create mappings with both source and generated lengths
-  for (let i = 0; i < sortedSegments.length; i++) {
-    const seg = sortedSegments[i]!
-    const nextSeg = sortedSegments[i + 1]
-
-    // Length in source space: from this offset to the next (or 1 if last)
-    const srcLength = nextSeg ? nextSeg.srcOffset - seg.srcOffset : 1
-    // Length in generated space: from this offset to the next generated offset
-    // (which may be a different sorted neighbor than the source one)
-    const genLength = (nextGenOffset.get(seg.genOffset) ?? seg.genOffset + 1) - seg.genOffset
-
-    // Position is JSX-derived if its source offset falls inside any JSX node range.
-    const isInHCall = insideJsxNode(seg.srcOffset)
-
-    // JSX punctuation (< > /) — only when actually inside a tag span, not e.g. {a > b}.
-    const isJsxPunctuation =
-      jsxPunctuation.has(seg.srcChar) && insideTagPunctuationSpan(seg.srcOffset)
-
-    // Choose appropriate CodeInformation:
-    // - JSX punctuation: structural only (no semantic, no navigation)
-    // - Inside h() call: no highlights but keep other semantic features
-    // - Normal code: full features
-    let data: CodeInformation
-    if (isJsxPunctuation) {
-      data = structuralOnlyData
-    } else if (isInHCall) {
-      data = noHighlightData
-    } else {
-      data = fullData
-    }
-
-    mappings.push({
-      sourceOffsets: [seg.srcOffset],
-      generatedOffsets: [seg.genOffset],
-      lengths: [srcLength],
-      generatedLengths: [genLength],
-      data,
-    })
-  }
-
-  return mappings
+  return mappings.map((m) => ({
+    sourceOffsets: [m.source.offset],
+    generatedOffsets: [m.generated.offset],
+    lengths: [m.source.length],
+    generatedLengths: [m.generated.length],
+    data: PROFILE_BY_KIND[m.kind],
+  }))
 }
 
-function computeLineStarts(text: string): number[] {
-  const starts: number[] = [0]
-  for (let i = 0; i < text.length; i++) {
-    if (text.charCodeAt(i) === 10 /* \n */) {
-      starts.push(i + 1)
-    }
-  }
-  return starts
+const fullData: CodeInformation = {
+  verification: true,
+  completion: true,
+  semantic: true,
+  navigation: true,
+  structure: true,
+  format: true,
 }
 
-function lineColToOffset(lineStarts: number[], line: number, col: number): number {
-  const start = lineStarts[line] ?? lineStarts[lineStarts.length - 1] ?? 0
-  return start + col
+// h() internals: keep semantic features but suppress highlight (cursor on a
+// tag name shouldn't highlight every `h` identifier in the file). Matches the
+// Vue tactic for `<template>` content.
+const noHighlightData: CodeInformation = {
+  verification: true,
+  completion: true,
+  semantic: { shouldHighlight: () => false },
+  navigation: true,
+  structure: true,
+  format: true,
+}
+
+// JSX punctuation (`<`/`>`/`/`): no semantic, no completion, no navigation —
+// cursor on `<` shouldn't navigate to `h`'s definition.
+const structuralOnlyData: CodeInformation = {
+  verification: true,
+  completion: false,
+  semantic: false,
+  navigation: false,
+  structure: true,
+  format: true,
+}
+
+const PROFILE_BY_KIND: Record<CompilerMappingKind, CodeInformation> = {
+  user: fullData,
+  "h-call": noHighlightData,
+  punctuation: structuralOnlyData,
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,6 +79,9 @@ importers:
       '@babel/types':
         specifier: ^7.26.0
         version: 7.29.0
+      '@jridgewell/sourcemap-codec':
+        specifier: ^1.5.5
+        version: 1.5.5
     devDependencies:
       '@effect/vitest':
         specifier: 4.0.0-beta.70
@@ -95,9 +98,6 @@ importers:
       '@efx/compiler':
         specifier: workspace:*
         version: link:../compiler
-      '@jridgewell/sourcemap-codec':
-        specifier: ^1.5.5
-        version: 1.5.5
       '@volar/language-core':
         specifier: ^2.4.28
         version: 2.4.28


### PR DESCRIPTION
## Summary

Move source-map processing into the compiler. `@efx/compiler` now emits `mappings: CompilerMapping[]` alongside `code`, `map`, and `jsxRanges`. Each `CompilerMapping` carries source AND generated offset+length pairs plus a `kind` tag (`"user"` / `"h-call"` / `"punctuation"`) — Volar-free taxonomy.

`@efx/language/convertSourceMap` shrinks from ~150 LOC (sort-by-source + sort-by-generated + dedup + length-extension + jsxRanges-intersection + profile-assignment) to a ~15-LOC translator: `kind` → `CodeInformation` profile, copy offsets and lengths through. The `@jridgewell/sourcemap-codec` dependency moves with the logic and drops out of `@efx/language`.

## Why

- **Single source of truth.** The bidirectional length asymmetry that PR #12 fixed (e.g. `((` source / `(` generated for single-arg arrow paren strip) is now captured once, in the compiler, where the AST traversal can reason about it directly. Downstream tools can't accidentally re-introduce the bug by deriving lengths differently.
- **Compiler stays Volar-agnostic.** `kind` is a plain string, not a Volar `CodeInformation` profile. `@efx/language` is the only package that imports Volar types.
- **Reusable.** Any future non-Volar consumer of `@efx/compiler` (a formatter, a custom CLI checker, etc.) gets the typed mappings for free without depending on Volar.

## Test plan

- [x] `pnpm --filter @efx/compiler test` → 45/45 (10 new tests for the typed mappings)
- [x] `pnpm --filter @efx/language test` → 14/14 (existing tests updated to call `convertSourceMap(result.mappings)`)
- [x] `pnpm --filter @efx/ts-plugin test` → integration all PASS including the PR #12 inlay-hint position assertion
- [x] `pnpm --filter @efx/check test` → All assertions passed
- [x] `pnpm -r test` → all suites pass
- [x] `pnpm -r typecheck` → all 7 packages clean
- [x] `pnpm --filter @efx/demo typecheck` → 8 files, 0 errors

## Notes

- `vite-plugin` continues to consume `result.map` (Babel V3 source map) for HMR — unchanged.
- This is Phase 1-3 of the plan laid out earlier (Phase 0 shipped as #13 — test coverage that locked in the contract). With the tests already in place from #13, this restructure was risk-bounded — the tests verified equivalence at each step.
- Diff: **+477/-211** across 12 files. Most of the LOC moved between packages; the new compiler tests account for ~140 of the additions.
- AGENTS.md updates in `@efx/compiler` and `@efx/language` reflect the new architecture, including a "Source-map mappings" section in the compiler docs that documents the 5-step algorithm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)