### PR TITLE
refactor(ts-plugin): classify references once, sort on the result

### DIFF
--- a/packages/ts-plugin/AGENTS.md
+++ b/packages/ts-plugin/AGENTS.md
@@ -21,7 +21,10 @@ for tsserver to `require()`.
 |---|---|
 | `src/index.ts` | Entry. Re-exports `pluginFactory` via `export =`. |
 | `src/jsx-tags.ts` | `findJsxTagPair` — uses cached `jsxRanges` from the shared `EfxVirtualCode` (read via `getEfxVirtualCode` from `@efx/language`) to find tag-pair partners for document highlights. |
+| `src/classify-references.ts` | `classifyRefs` — decorates each ref with `{ isDef, isImport }` in one pass, with a per-call file-content cache so each source file is read at most once. `findReferences` then sorts on the precomputed booleans instead of doing disk I/O inside the comparator. |
 | `src/service-proxy.ts` | `pluginFactory` — instantiates the shared LanguagePlugin via `createEfxLanguagePlugin<string>(identity)`, builds Volar's `createLanguageServicePlugin`, then wraps the resulting `LanguageService` in a Proxy with a few method overrides (filter `@efx/runtime`'s `h.ts` from definition results, JSX tag-pair document highlights, `_tag`/`_props`/`_children` inlay-hint filter, reference dedup + sort). |
+| `src/classify-references.test.ts` | Unit tests for `classifyRefs` — injects a fake `readFile` to assert classification rules and per-call caching without touching disk. |
+| `vitest.config.ts` | Picks up `src/**/*.test.ts`. The package's `test` script runs vitest first, then builds and runs the integration harness. |
 | `test/integration.mjs` | tsserver-subprocess harness. The acceptance-level check that the plugin really works end-to-end. |
 | `build.mjs` | esbuild bundle producing `dist/index.cjs` (tsserver `require()`s the plugin as CJS). |
 
@@ -124,7 +127,12 @@ Volar produces a working LanguageService. We then wrap it in a
     returns the same logical reference under both the renamed
     component name and the `h(...)` call symbol.
   - Sort: definition first, then non-imports (usages), then
-    imports.
+    imports. The "is this an import line?" decision needs to read
+    the source file — `classifyRefs` does that **once** per
+    distinct file before the sort runs, so the comparator only
+    looks at precomputed booleans. Previously the comparator
+    called `ts.sys.readFile` inline, paying O(N log N) reads of
+    the same handful of files.
 
   Cross-file references work natively because user code writes
   `import { Counter } from "./Counter.efx"` (the Vue/Astro

--- a/packages/ts-plugin/package.json
+++ b/packages/ts-plugin/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "node build.mjs",
     "typecheck": "tsc --noEmit",
-    "test": "pnpm run build && node test/integration.mjs"
+    "test": "vitest run && pnpm run build && node test/integration.mjs"
   },
   "dependencies": {
     "@efx/language": "workspace:*",

--- a/packages/ts-plugin/src/classify-references.test.ts
+++ b/packages/ts-plugin/src/classify-references.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest"
+import type * as ts from "typescript"
+import { classifyRefs } from "./classify-references.ts"
+
+const span = (start: number, length = 1): ts.TextSpan => ({ start, length })
+
+describe("classifyRefs", () => {
+  it("flags the definition ref", () => {
+    const def = { fileName: "a.ts", textSpan: span(10) }
+    const refs = [
+      { fileName: "a.ts", textSpan: span(10) },
+      { fileName: "a.ts", textSpan: span(50) },
+    ]
+    const out = classifyRefs(refs, def, () => "")
+    expect(out[0]?.isDef).toBe(true)
+    expect(out[1]?.isDef).toBe(false)
+  })
+
+  it("flags refs whose line starts with `import`", () => {
+    const def = { fileName: "a.ts", textSpan: span(0) }
+    const content = `import { X } from './x'\nconst y = X()\n`
+    const importPos = content.indexOf("X")
+    const usagePos = content.indexOf("X", importPos + 1)
+    const refs = [
+      { fileName: "b.ts", textSpan: span(importPos) },
+      { fileName: "b.ts", textSpan: span(usagePos) },
+    ]
+    const out = classifyRefs(refs, def, () => content)
+    expect(out[0]?.isImport).toBe(true)
+    expect(out[1]?.isImport).toBe(false)
+  })
+
+  it("flags refs whose line starts with `export * from`", () => {
+    const def = { fileName: "a.ts", textSpan: span(0) }
+    const content = `export * from './foo'\n`
+    const pos = content.indexOf("foo")
+    const out = classifyRefs(
+      [{ fileName: "b.ts", textSpan: span(pos) }],
+      def,
+      () => content,
+    )
+    expect(out[0]?.isImport).toBe(true)
+  })
+
+  it("reads each file at most once across many refs in the same call", () => {
+    const def = { fileName: "a.ts", textSpan: span(0) }
+    const fileA = `import { X } from './x'\nconst a = X()\nconst b = X()\n`
+    const fileB = `import { Y } from './y'\nconst c = Y()\n`
+    const calls: string[] = []
+    const readFile = (path: string): string | undefined => {
+      calls.push(path)
+      if (path === "a.ts") return fileA
+      if (path === "b.ts") return fileB
+      return undefined
+    }
+    const refs = [
+      { fileName: "a.ts", textSpan: span(fileA.indexOf("X")) },
+      { fileName: "a.ts", textSpan: span(fileA.indexOf("X", 30)) },
+      { fileName: "a.ts", textSpan: span(fileA.lastIndexOf("X")) },
+      { fileName: "b.ts", textSpan: span(fileB.indexOf("Y")) },
+      { fileName: "b.ts", textSpan: span(fileB.lastIndexOf("Y")) },
+    ]
+    classifyRefs(refs, def, readFile)
+    expect(calls.sort()).toEqual(["a.ts", "b.ts"])
+  })
+
+  it("caches a missing-file lookup too (undefined is a valid cache value)", () => {
+    const def = { fileName: "a.ts", textSpan: span(0) }
+    const calls: string[] = []
+    const readFile = (path: string): string | undefined => {
+      calls.push(path)
+      return undefined
+    }
+    const refs = [
+      { fileName: "ghost.ts", textSpan: span(0) },
+      { fileName: "ghost.ts", textSpan: span(10) },
+    ]
+    classifyRefs(refs, def, readFile)
+    expect(calls).toEqual(["ghost.ts"])
+  })
+
+  it("treats refs in unreadable files as non-imports", () => {
+    const def = { fileName: "a.ts", textSpan: span(0) }
+    const out = classifyRefs(
+      [{ fileName: "missing.ts", textSpan: span(0) }],
+      def,
+      () => undefined,
+    )
+    expect(out[0]?.isImport).toBe(false)
+  })
+
+  it("preserves the original ref identity", () => {
+    const def = { fileName: "a.ts", textSpan: span(0) }
+    const ref = { fileName: "a.ts", textSpan: span(5) }
+    const out = classifyRefs([ref], def, () => "")
+    expect(out[0]?.ref).toBe(ref)
+  })
+
+  it("handles a ref on the first line (no leading newline before lineStart)", () => {
+    const def = { fileName: "a.ts", textSpan: span(0) }
+    const content = `import { X } from './x'`
+    const refs = [{ fileName: "b.ts", textSpan: span(content.indexOf("X")) }]
+    const out = classifyRefs(refs, def, () => content)
+    expect(out[0]?.isImport).toBe(true)
+  })
+})

--- a/packages/ts-plugin/src/classify-references.ts
+++ b/packages/ts-plugin/src/classify-references.ts
@@ -1,0 +1,52 @@
+import type * as ts from "typescript"
+
+/**
+ * One pass over the refs to decide "where does each one sit?" — definition,
+ * usage, or import line. `findReferences` then sorts on the precomputed
+ * booleans instead of re-reading source files inside the sort comparator
+ * (which was O(N log N) reads of M files for N refs across M files).
+ *
+ * `readFile` is injected so tests can run without disk I/O. The local
+ * `fileCache` collapses repeat reads of the same file *within a single
+ * call* to one; cross-call caching is intentionally out of scope because
+ * files change between language-service requests.
+ */
+export type ClassifiedRef<R> = {
+  readonly ref: R
+  readonly isDef: boolean
+  readonly isImport: boolean
+}
+
+export function classifyRefs<R extends { fileName: string; textSpan: ts.TextSpan }>(
+  refs: ReadonlyArray<R>,
+  def: { fileName: string; textSpan: ts.TextSpan },
+  readFile: (path: string) => string | undefined,
+): ClassifiedRef<R>[] {
+  const fileCache = new Map<string, string | undefined>()
+  const readCached = (path: string): string | undefined => {
+    if (fileCache.has(path)) return fileCache.get(path)
+    const content = readFile(path)
+    fileCache.set(path, content)
+    return content
+  }
+  return refs.map((ref) => ({
+    ref,
+    isDef: ref.fileName === def.fileName && ref.textSpan.start === def.textSpan.start,
+    isImport: isImportLine(ref, readCached),
+  }))
+}
+
+const IMPORT_LINE = /^\s*(import|export\s+\*?\s*from)/
+
+function isImportLine(
+  ref: { fileName: string; textSpan: ts.TextSpan },
+  readFile: (path: string) => string | undefined,
+): boolean {
+  const content = readFile(ref.fileName)
+  if (!content) return false
+  let lineStart = ref.textSpan.start
+  while (lineStart > 0 && content[lineStart - 1] !== "\n") lineStart--
+  const lineEnd = content.indexOf("\n", ref.textSpan.start)
+  const line = content.slice(lineStart, lineEnd === -1 ? undefined : lineEnd)
+  return IMPORT_LINE.test(line)
+}

--- a/packages/ts-plugin/src/service-proxy.ts
+++ b/packages/ts-plugin/src/service-proxy.ts
@@ -2,6 +2,7 @@ import { createLanguageServicePlugin } from "@volar/typescript/lib/quickstart/cr
 import type * as ts from "typescript"
 import { createEfxLanguagePlugin, getEfxVirtualCode } from "@efx/language"
 import { findJsxTagPair } from "./jsx-tags.ts"
+import { classifyRefs } from "./classify-references.ts"
 
 // tsserver identifies scripts by file path strings — asFileName is identity.
 const efxLanguagePlugin = createEfxLanguagePlugin<string>((scriptId) => scriptId)
@@ -161,40 +162,21 @@ export const pluginFactory: ts.server.PluginModuleFactory = (modules) => {
                   allRefs.push(filtered)
                 }
               }
-              // Sort: definition first, then usages, then imports
               const firstSymbol = result[0]
               if (!firstSymbol) return result
               const def = firstSymbol.definition
-              // Check if ref is in an import statement by reading the line
-              const isImportRef = (ref: { fileName: string; textSpan: ts.TextSpan }): boolean => {
-                try {
-                  const content = ts.sys.readFile(ref.fileName)
-                  if (!content) return false
-                  // Find line start
-                  let lineStart = ref.textSpan.start
-                  while (lineStart > 0 && content[lineStart - 1] !== "\n") lineStart--
-                  const lineEnd = content.indexOf("\n", ref.textSpan.start)
-                  const line = content.slice(lineStart, lineEnd === -1 ? undefined : lineEnd)
-                  return /^\s*(import|export\s+\*?\s*from)/.test(line)
-                } catch {
-                  return false
-                }
-              }
-              // Definition first, then non-imports (usages), then imports
-              allRefs.sort((a, b) => {
-                const aIsDef = a.fileName === def.fileName && a.textSpan.start === def.textSpan.start
-                const bIsDef = b.fileName === def.fileName && b.textSpan.start === def.textSpan.start
-                if (aIsDef && !bIsDef) return -1
-                if (bIsDef && !aIsDef) return 1
-                const aIsImport = isImportRef(a)
-                const bIsImport = isImportRef(b)
-                if (!aIsImport && bIsImport) return -1
-                if (aIsImport && !bIsImport) return 1
+              // Classify once (one read per distinct file), then sort on the
+              // booleans. Otherwise the comparator would re-read source for
+              // each pair it compared.
+              const classified = classifyRefs(allRefs, def, ts.sys.readFile)
+              classified.sort((a, b) => {
+                if (a.isDef !== b.isDef) return a.isDef ? -1 : 1
+                if (a.isImport !== b.isImport) return a.isImport ? 1 : -1
                 return 0
               })
               return [{
                 definition: def,
-                references: allRefs,
+                references: classified.map((c) => c.ref),
               }]
             }
           }

--- a/packages/ts-plugin/vitest.config.ts
+++ b/packages/ts-plugin/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+  },
+})


### PR DESCRIPTION
## Summary
- `findReferences`' sort comparator used to call `ts.sys.readFile` inline to decide "is this ref on an import line?", paying O(N log N) reads of the same handful of files for N refs across M files.
- New `classify-references.ts` module: one pass over the refs, one read per distinct file (cached locally for the call). Comparator now sorts on precomputed booleans.
- `readFile` is injected so the unit test runs without touching disk.
- Wires vitest into `@efx/ts-plugin` (matching sibling packages); `pnpm --filter @efx/ts-plugin test` now runs vitest before the integration harness.

## Test plan
- [x] `pnpm --filter @efx/ts-plugin test` — 8/8 unit tests + integration PASS, find-references ordering verified (def → usages → imports)
- [x] `pnpm -r test` — all workspace tests green
- [x] `pnpm -r typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)