### PR TITLE
refactor(language): drop unused EfxVirtualCode offset methods

### DIFF
--- a/packages/language/AGENTS.md
+++ b/packages/language/AGENTS.md
@@ -19,7 +19,7 @@ certainly want to depend on this package rather than copy it.
 |---|---|
 | `src/language-plugin.ts` | `createEfxLanguagePlugin<T>(asFileName)` factory. Builds the Volar `LanguagePlugin` with `getLanguageId`, `createVirtualCode`, and `typescript: { extraFileExtensions, getServiceScript }`. Returns `LanguagePlugin<T, EfxVirtualCode>` so consumers can rely on the concrete class type at the boundary. |
 | `src/source-map.ts` | `convertSourceMap` — thin translator from `@efx/compiler`'s `CompilerMapping[]` to Volar's `Mapping<CodeInformation>[]`. Maps the compiler's `"user"` / `"h-call"` / `"punctuation"` kinds to Volar profiles. ~15 LOC of actual logic + the three profile objects. |
-| `src/virtual-code.ts` | `EfxVirtualCode` class — implements Volar's `VirtualCode` interface so Volar and downstream consumers share one object per `.efx` file. Holds `source` / `compiled` / `mappings` / `jsxRanges` alongside Volar's `id` / `languageId` / `snapshot` / `embeddedCodes`. Carries `compiledToSourceOffset` / `sourceToCompiledOffset` instance methods. Module-level cache `Map<string, EfxVirtualCode>` with `getEfxVirtualCode` / `setEfxVirtualCode` accessors. |
+| `src/virtual-code.ts` | `EfxVirtualCode` class — implements Volar's `VirtualCode` interface so Volar and downstream consumers share one object per `.efx` file. Holds `source` / `compiled` / `mappings` / `jsxRanges` alongside Volar's `id` / `languageId` / `snapshot` / `embeddedCodes`. Module-level cache `Map<string, EfxVirtualCode>` with `getEfxVirtualCode` / `setEfxVirtualCode` accessors. |
 | `src/index.ts` | Re-exports. |
 
 ## Why a factory over a fixed plugin
@@ -144,16 +144,14 @@ produces them.
 `virtual-code.ts` exports a module-level
 `Map<string, EfxVirtualCode>`. Both `@efx/ts-plugin` and
 `@efx/check` populate it from their `createVirtualCode` calls;
-ts-plugin's service-proxy reads from it to do offset conversion in
-definition/reference results.
+ts-plugin's `jsx-tags.ts` reads from it to fetch `jsxRanges` for
+tag-pair document highlights.
 
 The instance Volar holds (as the return value of `createVirtualCode`)
 is the same instance the cache holds — no duplication, no
-synchronization needed. Offset conversion is therefore a method on
-the instance (`vc.compiledToSourceOffset(n)`), not a free function
-that looks up the cache. Callers that already have the instance
-(e.g. ones that just called `getEfxVirtualCode` once) skip the
-extra lookup.
+synchronization needed. Volar consumes the `mappings` array
+directly via its own `SourceMap` indexing, so source ↔ generated
+offset translation never goes through this cache.
 
 In tsserver, the cache lives for the editor session. In
 `efx-check`'s CLI, the cache lives for the duration of the run.

--- a/packages/language/src/virtual-code.ts
+++ b/packages/language/src/virtual-code.ts
@@ -8,14 +8,15 @@ import type * as ts from "typescript"
  *
  * One instance per `.efx`: shared between Volar (which holds it as the
  * `VirtualCode` returned from `createVirtualCode`) and downstream
- * consumers (the ts-plugin's service-proxy and jsx-tags). No
- * duplication — the Volar contract fields (`id`, `languageId`,
- * `snapshot`, `mappings`, `embeddedCodes`) live alongside the
- * efx-specific data (`source`, `compiled`, `jsxRanges`) on the same
- * object. Matches Vue's `VueVirtualCode` pattern.
+ * consumers (`@efx/ts-plugin/jsx-tags`, which reads `jsxRanges` for
+ * tag-pair highlights). No duplication — the Volar contract fields
+ * (`id`, `languageId`, `snapshot`, `mappings`, `embeddedCodes`) live
+ * alongside the efx-specific data (`source`, `compiled`, `jsxRanges`)
+ * on the same object. Matches Vue's `VueVirtualCode` pattern.
  *
- * Offset conversion is a method, not a free function, so callers that
- * already have the instance avoid an extra cache lookup.
+ * Source ↔ generated offset translation is handled by Volar's own
+ * `SourceMap` (which indexes the `mappings` array) — we don't need to
+ * expose offset-conversion methods here.
  */
 export class EfxVirtualCode implements VirtualCode {
   readonly id = "efx-ts"
@@ -47,48 +48,6 @@ export class EfxVirtualCode implements VirtualCode {
       getLength: () => compiled.length,
       getChangeRange: () => undefined,
     }
-  }
-
-  /**
-   * Find the source offset corresponding to a compiled-side offset.
-   * Mappings are point-to-point — we pick the closest mapping at or
-   * before the query and apply the delta.
-   */
-  compiledToSourceOffset(compiledOffset: number): number | null {
-    let bestMapping: { generatedOffset: number; sourceOffset: number } | null = null
-    for (const mapping of this.mappings) {
-      const genOff = mapping.generatedOffsets[0]
-      if (genOff === undefined) continue
-      if (genOff <= compiledOffset) {
-        if (!bestMapping || genOff > bestMapping.generatedOffset) {
-          const srcOff = mapping.sourceOffsets[0]
-          if (srcOff === undefined) continue
-          bestMapping = { generatedOffset: genOff, sourceOffset: srcOff }
-        }
-      }
-    }
-    if (!bestMapping) return null
-    const delta = compiledOffset - bestMapping.generatedOffset
-    return bestMapping.sourceOffset + delta
-  }
-
-  /** The inverse of `compiledToSourceOffset`. */
-  sourceToCompiledOffset(sourceOffset: number): number | null {
-    let bestMapping: { generatedOffset: number; sourceOffset: number } | null = null
-    for (const mapping of this.mappings) {
-      const srcOff = mapping.sourceOffsets[0]
-      if (srcOff === undefined) continue
-      if (srcOff <= sourceOffset) {
-        if (!bestMapping || srcOff > bestMapping.sourceOffset) {
-          const genOff = mapping.generatedOffsets[0]
-          if (genOff === undefined) continue
-          bestMapping = { generatedOffset: genOff, sourceOffset: srcOff }
-        }
-      }
-    }
-    if (!bestMapping) return null
-    const delta = sourceOffset - bestMapping.sourceOffset
-    return bestMapping.generatedOffset + delta
   }
 }
 

--- a/packages/ts-plugin/AGENTS.md
+++ b/packages/ts-plugin/AGENTS.md
@@ -79,9 +79,11 @@ package's actual responsibility.
 
 `getEfxVirtualCode(efxPath)` returns the same `EfxVirtualCode`
 instance Volar received from `createVirtualCode` — no duplication
-(matches Vue's `VueVirtualCode` pattern). Offset conversion is a
-method on that instance (`vc.compiledToSourceOffset(n)` /
-`vc.sourceToCompiledOffset(n)`), not a free function.
+(matches Vue's `VueVirtualCode` pattern). The proxy wrapper below
+doesn't translate offsets itself: Volar's own `SourceMap` indexes
+`mappings` and maps virtual-code coordinates back to `.efx` source
+before results reach us. We read the cache only for `jsxRanges`
+(consumed by `jsx-tags.ts`).
 
 ## The proxy wrapper
 
@@ -89,16 +91,13 @@ Volar produces a working LanguageService. We then wrap it in a
 `Proxy` (in the outer `pluginFactory`) and override five methods:
 
 - **`getDefinitionAtPosition` / `getDefinitionAndBoundSpan` /
-  `getTypeDefinitionAtPosition`** — call Volar, then map each
-  result through `rewriteDefinitionInfo`. This:
-  - filters out hits in `packages/runtime/src/h.ts` (the JSX
-    factory itself — go-to-def on `<div>` should NOT land you in
-    `h.ts`)
-  - rewrites `.ts` paths to `.efx` when a sibling source exists
-  - subtracts the `// @generated` header offset (see "Dual-file
-    setup" below) from `textSpan.start`
-  - re-maps the (now header-adjusted) compiled offset back to a
-    source offset via `compiledToSourceOffset`
+  `getTypeDefinitionAtPosition`** — call Volar, then drop any hit
+  in `packages/runtime/src/h.ts` (the JSX factory itself — go-to-def
+  on `<div>` should NOT land you in `h.ts`). Volar has already
+  mapped results back to `.efx` source coordinates via its own
+  `SourceMap`, and TS's resolver finds `.efx` files directly via
+  `extraFileExtensions` — no path rewriting, no offset re-mapping,
+  no header-offset subtraction needed.
 
 - **`getDocumentHighlights`** — `.efx`-only custom path. If the
   cursor is on a JSX tag (anywhere on the brackets or name, but


### PR DESCRIPTION
## Summary

- `EfxVirtualCode.compiledToSourceOffset` and `sourceToCompiledOffset` had **zero callers** in the repo — Volar's own `SourceMap` (which indexes `mappings`) handles source ↔ generated translation now, and the ts-plugin proxy stopped post-processing offsets when path-resolution moved to `extraFileExtensions`. Removing both methods (-50 LOC).
- Refresh stale `AGENTS.md` sections in `@efx/language` and `@efx/ts-plugin` that still described those methods (plus the adjacent `rewriteDefinitionInfo` / `.ts`→`.efx` rewrite / `@generated` header-offset subtraction pipeline) as if in use — they all died together with the same refactor.

## How I confirmed they're dead

```
$ grep -rn 'compiledToSourceOffset\|sourceToCompiledOffset' --include='*.ts' --include='*.mjs'
packages/language/src/virtual-code.ts:  <only the definitions themselves>
```

Plus the comment in `service-proxy.ts:38` makes it explicit: *"Cross-file path/offset rewriting isn't needed anymore: Volar maps virtual-code results back to source `.efx` coordinates natively."*

## Test plan

- [x] `pnpm -r typecheck` — all 7 packages clean
- [x] `pnpm --filter @efx/language test` — 14/14
- [x] `pnpm -r test` — compiler 45/45, runtime 38/38, language 14/14, ts-plugin integration harness PASS on hover, inlay hints (including the PR #12 column-45 regression case), go-to-def, JSX go-to-def, find-references, `@efx/check` PASS