### PR TITLE
refactor(language): inject VirtualCodeRegistry instead of global cache

### DIFF
--- a/packages/check/AGENTS.md
+++ b/packages/check/AGENTS.md
@@ -70,12 +70,19 @@ LSP protocol.
 - **Exit code**: 0 if `result.errors === 0`, else 1. Warnings do
   not fail. (`tsc` matches: warnings only fail with `noEmitOnError`
   or `strict` flags that promote them.)
+- **In-process isolation**: each `runCheck` call constructs its own
+  `VirtualCodeRegistry`. Two calls in the same Node process — e.g.
+  a test that exercises the fixture, mutates it, then re-runs —
+  see independent virtual-code state, not leftovers from the
+  previous invocation.
 
 ## Coupling
 
-- **`@efx/language`** — provides `createEfxLanguagePlugin`. The
-  CLI instantiates it with `<URI>(uri => uri.fsPath)` because kit
-  uses `URI` as its script-id type.
+- **`@efx/language`** — provides `createEfxLanguagePlugin` and
+  `VirtualCodeRegistry`. The CLI instantiates the plugin with
+  `<URI>(uri => uri.fsPath, registry)` because kit uses `URI` as
+  its script-id type, and constructs a fresh `VirtualCodeRegistry`
+  per `runCheck` call.
 - **`@volar/kit`** — `createTypeScriptChecker`,
   `createTypeScriptInferredChecker` (not currently used; would be
   needed for "no tsconfig" mode).

--- a/packages/check/src/index.ts
+++ b/packages/check/src/index.ts
@@ -3,7 +3,7 @@ import * as ts from "typescript"
 import * as kit from "@volar/kit"
 import { create as createTypeScriptServices } from "volar-service-typescript"
 import { URI } from "vscode-uri"
-import { createEfxLanguagePlugin } from "@efx/language"
+import { createEfxLanguagePlugin, VirtualCodeRegistry } from "@efx/language"
 
 // LSP DiagnosticSeverity constants (stable wire protocol). `@volar/language-service`
 // re-exports the type but not the values, so we inline these to avoid pulling in
@@ -50,7 +50,10 @@ export async function runCheck(options: CheckOptions = {}): Promise<CheckResult>
 
   // `@volar/kit` uses `URI` as the script-id type, so the plugin gets URIs
   // and reduces them to filesystem paths for the compiler + cache.
-  const languagePlugin = createEfxLanguagePlugin<URI>((uri) => uri.fsPath)
+  // Fresh registry per call — repeated runCheck invocations in one process
+  // must not share virtual-code state.
+  const registry = new VirtualCodeRegistry()
+  const languagePlugin = createEfxLanguagePlugin<URI>((uri) => uri.fsPath, registry)
   const tsServices = createTypeScriptServices(ts)
   const linter = kit.createTypeScriptChecker([languagePlugin], tsServices, tsconfigPath)
 

--- a/packages/language/AGENTS.md
+++ b/packages/language/AGENTS.md
@@ -17,9 +17,9 @@ certainly want to depend on this package rather than copy it.
 
 | File | Purpose |
 |---|---|
-| `src/language-plugin.ts` | `createEfxLanguagePlugin<T>(asFileName)` factory. Builds the Volar `LanguagePlugin` with `getLanguageId`, `createVirtualCode`, and `typescript: { extraFileExtensions, getServiceScript }`. Returns `LanguagePlugin<T, EfxVirtualCode>` so consumers can rely on the concrete class type at the boundary. |
+| `src/language-plugin.ts` | `createEfxLanguagePlugin<T>(asFileName, registry)` factory. Builds the Volar `LanguagePlugin` with `getLanguageId`, `createVirtualCode`, and `typescript: { extraFileExtensions, getServiceScript }`. Writes per-`.efx` `EfxVirtualCode` into the supplied `VirtualCodeRegistry`. Returns `LanguagePlugin<T, EfxVirtualCode>` so consumers can rely on the concrete class type at the boundary. |
 | `src/source-map.ts` | `convertSourceMap` — thin translator from `@efx/compiler`'s `CompilerMapping[]` to Volar's `Mapping<CodeInformation>[]`. Maps the compiler's `"user"` / `"h-call"` / `"punctuation"` kinds to Volar profiles. ~15 LOC of actual logic + the three profile objects. |
-| `src/virtual-code.ts` | `EfxVirtualCode` class — implements Volar's `VirtualCode` interface so Volar and downstream consumers share one object per `.efx` file. Holds `source` / `compiled` / `mappings` / `jsxRanges` alongside Volar's `id` / `languageId` / `snapshot` / `embeddedCodes`. Module-level cache `Map<string, EfxVirtualCode>` with `getEfxVirtualCode` / `setEfxVirtualCode` accessors. |
+| `src/virtual-code.ts` | `EfxVirtualCode` class — implements Volar's `VirtualCode` interface so Volar and downstream consumers share one object per `.efx` file. Holds `source` / `compiled` / `mappings` / `jsxRanges` alongside Volar's `id` / `languageId` / `snapshot` / `embeddedCodes`. Plus `VirtualCodeRegistry` — the per-consumer `Map<string, EfxVirtualCode>` cache (one per tsserver session, one per `runCheck`). |
 | `src/index.ts` | Re-exports. |
 
 ## Why a factory over a fixed plugin
@@ -29,11 +29,11 @@ Different Volar hosts identify scripts differently:
 - tsserver passes string filenames (`"/path/to/Counter.efx"`).
 - `@volar/kit` passes `URI` objects (`URI.file("/path/to/Counter.efx")`).
 
-`createEfxLanguagePlugin<T>(asFileName: (id: T) => string)` lets
-each consumer collapse its native id type to a file-path string at
+`createEfxLanguagePlugin<T>(asFileName: (id: T) => string, registry: VirtualCodeRegistry)`
+lets each consumer collapse its native id type to a file-path string at
 the boundary. Internally the plugin always works in path strings:
 
-- The cache `Map<string, EfxVirtualCode>` is keyed by file path.
+- The `VirtualCodeRegistry` keyed by file path is the cache.
 - `transformEfx` is called with file path (it's used as the source
   map filename).
 - `getLanguageId` decides language by `.efx` suffix on the path.
@@ -41,11 +41,13 @@ the boundary. Internally the plugin always works in path strings:
 This means consumers can write:
 
 ```ts
-// tsserver (@efx/ts-plugin)
-createEfxLanguagePlugin<string>((s) => s)
+// tsserver (@efx/ts-plugin) — one registry per session
+const registry = new VirtualCodeRegistry()
+createEfxLanguagePlugin<string>((s) => s, registry)
 
-// kit (@efx/check)
-createEfxLanguagePlugin<URI>((uri) => uri.fsPath)
+// kit (@efx/check) — one registry per runCheck call
+const registry = new VirtualCodeRegistry()
+createEfxLanguagePlugin<URI>((uri) => uri.fsPath, registry)
 ```
 
 ## The `extraFileExtensions` shape is load-bearing
@@ -139,28 +141,44 @@ tests pinning this exact case.
 `convertSourceMap` just copies the lengths through — the compiler
 produces them.
 
-## The cache is process-local module state
+## The registry is per-consumer state
 
-`virtual-code.ts` exports a module-level
-`Map<string, EfxVirtualCode>`. Both `@efx/ts-plugin` and
-`@efx/check` populate it from their `createVirtualCode` calls;
+`virtual-code.ts` exports `VirtualCodeRegistry` — a class holding a
+`Map<string, EfxVirtualCode>`. The host that constructs the plugin
+also constructs the registry and passes it to `createEfxLanguagePlugin`:
+`@efx/ts-plugin` creates one at module scope (tsserver loads the
+plugin once per session), `@efx/check` creates one inside each
+`runCheck` call.
+
+The plugin writes into the registry from `createVirtualCode`;
 ts-plugin's `jsx-tags.ts` reads from it to fetch `jsxRanges` for
-tag-pair document highlights.
+tag-pair document highlights. The instance Volar holds (as the
+return value of `createVirtualCode`) is the same instance the
+registry holds — no duplication, no synchronization needed. Volar
+consumes the `mappings` array directly via its own `SourceMap`
+indexing, so source ↔ generated offset translation never goes
+through this cache.
 
-The instance Volar holds (as the return value of `createVirtualCode`)
-is the same instance the cache holds — no duplication, no
-synchronization needed. Volar consumes the `mappings` array
-directly via its own `SourceMap` indexing, so source ↔ generated
-offset translation never goes through this cache.
-
-In tsserver, the cache lives for the editor session. In
-`efx-check`'s CLI, the cache lives for the duration of the run.
+In tsserver, the registry lives for the editor session. In
+`efx-check`'s CLI, each `runCheck` call owns its own — repeated
+in-process invocations don't see each other's virtual codes.
 There's no cross-process sharing — Map state is per-Node-process.
 
 If `createVirtualCode` is called twice for the same `.efx` (rapid
-edits), the cache entry is overwritten with a fresh
-`EfxVirtualCode`. Stale entries for files that have been deleted
-persist until process exit; that's fine in practice.
+edits), the entry is overwritten with a fresh `EfxVirtualCode`.
+Stale entries for files that have been deleted persist until the
+registry is dropped; that's fine in practice.
+
+### Why a per-consumer registry, not a module-level singleton
+
+Earlier versions kept the cache as a module-level `Map`. That tied
+the cache lifetime to module-load (i.e. process lifetime), so two
+`runCheck` calls in one Node process would share entries — including
+stale ones from a previous run. Threading a `VirtualCodeRegistry`
+through the factory makes the lifetime explicit and matches what each
+consumer actually wants. The registry deliberately exposes only
+`get` and `set` — `clear` was considered and dropped because no
+caller needs it (consumers throw the whole registry away).
 
 ### Parameter properties are deliberately avoided
 
@@ -198,13 +216,14 @@ without arranging for a build step.
   `structure` / `format`. Subtle combinations matter — for
   instance, removing `navigation: true` on the h-call profile
   would break go-to-definition through JSX expressions.
-- Don't move the module-level cache `Map` to a class with
-  per-instance state. Both consumers expect the module-level
-  singleton; instance state would mean Volar-host-specific caches
-  that don't share between the plugin and the checker even when
-  they happen to run together. (`EfxVirtualCode` itself IS a class,
-  but the cache holding instances of it is intentionally a
-  module-level singleton.)
+- Don't reintroduce a module-level singleton cache. The registry
+  is per-consumer on purpose: in one Node process, multiple
+  `runCheck` calls (and theoretically multiple tsserver-plugin
+  setups) must not share virtual-code state. If you add a new
+  consumer, give it its own `VirtualCodeRegistry`.
+- Don't add a `clear` (or `delete`) method to `VirtualCodeRegistry`
+  without a real caller. Consumers throw the whole registry away;
+  growing the surface invites resurrection of stale-state bugs.
 - Don't switch `EfxVirtualCode`'s constructor to parameter
   properties (`constructor(readonly source: string, ...)`). They
   desugar into field assignments and break Node's
@@ -216,17 +235,23 @@ without arranging for a build step.
 
 ## Tests
 
-This package has no tests of its own. Its behavior is covered by:
+In-package vitests:
+
+- `src/source-map.test.ts` — pins the bidirectional source/generated
+  position-mapping contract through `convertSourceMap`.
+- `src/virtual-code-registry.test.ts` — pins the per-consumer
+  isolation of `VirtualCodeRegistry` (two plugins, two registries,
+  no cross-pollination).
+
+Broader behavior is covered by:
 
 - `@efx/ts-plugin/test/integration.mjs` — exercises the LanguagePlugin
   through a real tsserver subprocess.
 - `@efx/check/test/integration.mjs` — exercises it through
   `@volar/kit`.
 
-If you find yourself needing finer-grained tests (e.g., for
-`convertSourceMap` edge cases), add a `src/source-map.test.ts`
-using vitest — both `compiler` and `runtime` are configured that
-way and you can copy their scripts.
+If you need more fine-grained tests, follow the existing pattern
+(`src/*.test.ts` + the shared `vitest.config.ts`).
 
 ## Related context
 

--- a/packages/language/src/index.ts
+++ b/packages/language/src/index.ts
@@ -1,3 +1,3 @@
 export { createEfxLanguagePlugin, type TypeScriptConfig } from "./language-plugin.ts"
 export { convertSourceMap } from "./source-map.ts"
-export { EfxVirtualCode, getEfxVirtualCode, setEfxVirtualCode } from "./virtual-code.ts"
+export { EfxVirtualCode, VirtualCodeRegistry } from "./virtual-code.ts"

--- a/packages/language/src/language-plugin.ts
+++ b/packages/language/src/language-plugin.ts
@@ -2,7 +2,7 @@ import type { LanguagePlugin, VirtualCode } from "@volar/language-core"
 import type * as ts from "typescript"
 import { transformEfx } from "@efx/compiler"
 import { convertSourceMap } from "./source-map.ts"
-import { EfxVirtualCode, setEfxVirtualCode } from "./virtual-code.ts"
+import { EfxVirtualCode, VirtualCodeRegistry } from "./virtual-code.ts"
 
 // Volar's typescript property type isn't in the public LanguagePlugin interface
 // but is expected by createLanguageServicePlugin
@@ -28,12 +28,18 @@ export interface TypeScriptConfig {
  * passes `URI` instances. Internally we always cache and pass to the compiler
  * by file-path string, so the host-specific identity collapses here.
  *
- * The `EfxVirtualCode` instance returned here is the same instance the cache
- * holds — Volar and downstream consumers share one object per `.efx` file
- * (matches Vue's `VueVirtualCode` pattern).
+ * `registry` is the per-consumer cache the plugin writes into and downstream
+ * readers consult — one instance per tsserver session, one per `runCheck`
+ * call. Without an explicit registry, multiple consumers in one Node process
+ * would cross-pollinate (the previous module-level Map cache).
+ *
+ * The `EfxVirtualCode` instance returned here is the same instance the
+ * registry holds — Volar and downstream consumers share one object per
+ * `.efx` file (matches Vue's `VueVirtualCode` pattern).
  */
 export function createEfxLanguagePlugin<T>(
   asFileName: (scriptId: T) => string,
+  registry: VirtualCodeRegistry,
 ): LanguagePlugin<T, EfxVirtualCode> & { typescript: TypeScriptConfig } {
   return {
     getLanguageId(scriptId) {
@@ -53,7 +59,7 @@ export function createEfxLanguagePlugin<T>(
       const result = transformEfx(source, fileName)
       const mappings = convertSourceMap(result.mappings)
       const vc = new EfxVirtualCode(source, result.code, mappings, result.jsxRanges)
-      setEfxVirtualCode(fileName, vc)
+      registry.set(fileName, vc)
       return vc
     },
 

--- a/packages/language/src/virtual-code-registry.test.ts
+++ b/packages/language/src/virtual-code-registry.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest"
+import type { CodegenContext } from "@volar/language-core"
+import type * as ts from "typescript"
+import { createEfxLanguagePlugin } from "./language-plugin.ts"
+import { VirtualCodeRegistry } from "./virtual-code.ts"
+
+/**
+ * Concurrency regression: two independent consumers of the LanguagePlugin
+ * (e.g. two `runCheck` calls in one Node process) must see only their own
+ * virtual codes. With the previous module-level Map cache, the second
+ * consumer would observe entries created by the first.
+ */
+
+const snapshotOf = (text: string): ts.IScriptSnapshot => ({
+  getText: (start, end) => text.slice(start, end),
+  getLength: () => text.length,
+  getChangeRange: () => undefined,
+})
+
+// The plugin's createVirtualCode doesn't consult the ctx — we never call
+// getAssociatedScript — so a stub is fine here. Tests don't run inside Volar.
+const stubCtx: CodegenContext<string> = {
+  getAssociatedScript: () => undefined,
+}
+
+const buildVC = (
+  plugin: ReturnType<typeof createEfxLanguagePlugin<string>>,
+  fileName: string,
+  source: string,
+) => {
+  const create = plugin.createVirtualCode
+  if (!create) throw new Error("plugin.createVirtualCode missing")
+  return create(fileName, "efx", snapshotOf(source), stubCtx)
+}
+
+describe("VirtualCodeRegistry isolation", () => {
+  it("two plugins with separate registries do not see each other's virtual codes", () => {
+    const registryA = new VirtualCodeRegistry()
+    const registryB = new VirtualCodeRegistry()
+    const pluginA = createEfxLanguagePlugin<string>((s) => s, registryA)
+    const pluginB = createEfxLanguagePlugin<string>((s) => s, registryB)
+
+    const aPath = "/proj-a/Counter.efx"
+    const bPath = "/proj-b/Other.efx"
+
+    const vcA = buildVC(pluginA, aPath, "const x = <div/>")
+    const vcB = buildVC(pluginB, bPath, "const y = <span/>")
+
+    expect(vcA).toBeDefined()
+    expect(vcB).toBeDefined()
+
+    expect(registryA.get(aPath)).toBe(vcA)
+    expect(registryB.get(bPath)).toBe(vcB)
+    expect(registryA.get(bPath)).toBeUndefined()
+    expect(registryB.get(aPath)).toBeUndefined()
+  })
+
+  it("a registry returns the same instance Volar received from createVirtualCode", () => {
+    const registry = new VirtualCodeRegistry()
+    const plugin = createEfxLanguagePlugin<string>((s) => s, registry)
+    const fileName = "/proj/Counter.efx"
+
+    const vc = buildVC(plugin, fileName, "const x = <div/>")
+    expect(vc).toBeDefined()
+    expect(registry.get(fileName)).toBe(vc)
+  })
+})

--- a/packages/language/src/virtual-code.ts
+++ b/packages/language/src/virtual-code.ts
@@ -51,13 +51,21 @@ export class EfxVirtualCode implements VirtualCode {
   }
 }
 
-// Module-level cache keyed by `.efx` script path. Sole writer is
-// `language-plugin.ts`; readers go through `getEfxVirtualCode`.
-const cache = new Map<string, EfxVirtualCode>()
+/**
+ * Per-consumer cache of compiled `.efx` files keyed by script path. The
+ * LanguagePlugin's `createVirtualCode` writes through it; downstream
+ * consumers (ts-plugin's service-proxy + jsx-tags) read from it. One
+ * registry per consumer (one per tsserver session, one per `runCheck`
+ * call) — invocations don't share state through a module-level singleton.
+ */
+export class VirtualCodeRegistry {
+  private readonly cache = new Map<string, EfxVirtualCode>()
 
-export const setEfxVirtualCode = (efxPath: string, vc: EfxVirtualCode): void => {
-  cache.set(efxPath, vc)
+  set(efxPath: string, vc: EfxVirtualCode): void {
+    this.cache.set(efxPath, vc)
+  }
+
+  get(efxPath: string): EfxVirtualCode | undefined {
+    return this.cache.get(efxPath)
+  }
 }
-
-export const getEfxVirtualCode = (efxPath: string): EfxVirtualCode | undefined =>
-  cache.get(efxPath)

--- a/packages/ts-plugin/AGENTS.md
+++ b/packages/ts-plugin/AGENTS.md
@@ -20,16 +20,16 @@ for tsserver to `require()`.
 | File | Purpose |
 |---|---|
 | `src/index.ts` | Entry. Re-exports `pluginFactory` via `export =`. |
-| `src/jsx-tags.ts` | `findJsxTagPair` — uses cached `jsxRanges` from the shared `EfxVirtualCode` (read via `getEfxVirtualCode` from `@efx/language`) to find tag-pair partners for document highlights. |
+| `src/jsx-tags.ts` | `findJsxTagPair` — uses cached `jsxRanges` from the shared `EfxVirtualCode` (looked up via the `VirtualCodeRegistry` passed in by the service-proxy) to find tag-pair partners for document highlights. |
 | `src/classify-references.ts` | `classifyRefs` — decorates each ref with `{ isDef, isImport }` in one pass, with a per-call file-content cache so each source file is read at most once. `findReferences` then sorts on the precomputed booleans instead of doing disk I/O inside the comparator. |
-| `src/service-proxy.ts` | `pluginFactory` — instantiates the shared LanguagePlugin via `createEfxLanguagePlugin<string>(identity)`, builds Volar's `createLanguageServicePlugin`, then wraps the resulting `LanguageService` in a Proxy with a few method overrides (filter `@efx/runtime`'s `h.ts` from definition results, JSX tag-pair document highlights, `_tag`/`_props`/`_children` inlay-hint filter, reference dedup + sort). |
+| `src/service-proxy.ts` | `pluginFactory` — owns one `VirtualCodeRegistry` at module scope, instantiates the shared LanguagePlugin via `createEfxLanguagePlugin<string>(identity, registry)`, builds Volar's `createLanguageServicePlugin`, then wraps the resulting `LanguageService` in a Proxy with a few method overrides (filter `@efx/runtime`'s `h.ts` from definition results, JSX tag-pair document highlights, `_tag`/`_props`/`_children` inlay-hint filter, reference dedup + sort). |
 | `src/classify-references.test.ts` | Unit tests for `classifyRefs` — injects a fake `readFile` to assert classification rules and per-call caching without touching disk. |
 | `vitest.config.ts` | Picks up `src/**/*.test.ts`. The package's `test` script runs vitest first, then builds and runs the integration harness. |
 | `test/integration.mjs` | tsserver-subprocess harness. The acceptance-level check that the plugin really works end-to-end. |
 | `build.mjs` | esbuild bundle producing `dist/index.cjs` (tsserver `require()`s the plugin as CJS). |
 
 The LanguagePlugin itself (the Volar contract), `convertSourceMap`,
-the `EfxVirtualCode` class + module-level cache, and the three
+the `EfxVirtualCode` class + `VirtualCodeRegistry`, and the three
 `CodeInformation` profiles live in
 [`@efx/language`](../language/AGENTS.md) — shared with `@efx/check`.
 
@@ -61,13 +61,15 @@ the `EfxVirtualCode` class + module-level cache, and the three
 
 The plugin itself — `getLanguageId`, `createVirtualCode`,
 `typescript.extraFileExtensions`, `typescript.getServiceScript`,
-source-map conversion, the per-`.efx` cache, the three
+source-map conversion, the `VirtualCodeRegistry`, the three
 `CodeInformation` profiles for h-call vs. punctuation vs. normal
 source — lives in [`@efx/language`](../language/AGENTS.md). Read
 that node for the full picture; the short version is:
 
-- `service-proxy.ts` calls `createEfxLanguagePlugin<string>((s) => s)`
-  because tsserver identifies scripts by string filenames.
+- `service-proxy.ts` constructs a single `VirtualCodeRegistry` at
+  module scope and calls
+  `createEfxLanguagePlugin<string>((s) => s, registry)` —
+  tsserver identifies scripts by string filenames.
 - The resulting LanguagePlugin gets handed to Volar's
   `createLanguageServicePlugin` quickstart helper, which is what
   hooks Volar into tsserver's plugin protocol.
@@ -80,7 +82,7 @@ If a bug points at file enumeration, virtual-code content, the
 `@efx/language`, not here. The proxy wrapper below is this
 package's actual responsibility.
 
-`getEfxVirtualCode(efxPath)` returns the same `EfxVirtualCode`
+`registry.get(efxPath)` returns the same `EfxVirtualCode`
 instance Volar received from `createVirtualCode` — no duplication
 (matches Vue's `VueVirtualCode` pattern). The proxy wrapper below
 doesn't translate offsets itself: Volar's own `SourceMap` indexes
@@ -104,7 +106,8 @@ Volar produces a working LanguageService. We then wrap it in a
 
 - **`getDocumentHighlights`** — `.efx`-only custom path. If the
   cursor is on a JSX tag (anywhere on the brackets or name, but
-  not on attributes), `findJsxTagPair` walks `cache.jsxRanges` and
+  not on attributes), `findJsxTagPair` walks the
+  `EfxVirtualCode.jsxRanges` looked up from the registry and
   returns the matching opening↔closing name spans. Highlights just
   the names. Babel paired the tags during parse; we don't depth-
   count or regex-scan. Self-closing (`<Foo />`) and fragments
@@ -180,10 +183,11 @@ Vue and Astro use the same convention for the same reason.
   array is stored on `EfxVirtualCode` next to `mappings` so neither
   consumer re-runs the compiler.
 
-- **`@efx/language` cache key shape** — `getEfxVirtualCode` is keyed
-  by file-path string. `jsx-tags.ts` reads from the cache using
-  the `.efx` path tsserver hands it. If `@efx/language` ever
-  changes the key type, both packages break together.
+- **`@efx/language` registry key shape** — `VirtualCodeRegistry`
+  is keyed by file-path string. `jsx-tags.ts` reads from the
+  registry using the `.efx` path tsserver hands it. If
+  `@efx/language` ever changes the key type, both packages break
+  together.
 
 ## Anti-patterns
 

--- a/packages/ts-plugin/src/jsx-tags.ts
+++ b/packages/ts-plugin/src/jsx-tags.ts
@@ -1,4 +1,4 @@
-import { getEfxVirtualCode } from "@efx/language"
+import type { VirtualCodeRegistry } from "@efx/language"
 
 export interface NameSpan {
   readonly start: number
@@ -21,10 +21,11 @@ export interface NameSpan {
  * Fragments (`<>...</>`) have no names — skipped.
  */
 export function findJsxTagPair(
+  registry: VirtualCodeRegistry,
   efxPath: string,
   position: number,
 ): { current: NameSpan; partner: NameSpan } | null {
-  const vc = getEfxVirtualCode(efxPath)
+  const vc = registry.get(efxPath)
   if (!vc) return null
 
   for (const r of vc.jsxRanges) {

--- a/packages/ts-plugin/src/service-proxy.ts
+++ b/packages/ts-plugin/src/service-proxy.ts
@@ -1,11 +1,16 @@
 import { createLanguageServicePlugin } from "@volar/typescript/lib/quickstart/createLanguageServicePlugin"
 import type * as ts from "typescript"
-import { createEfxLanguagePlugin, getEfxVirtualCode } from "@efx/language"
+import { createEfxLanguagePlugin, VirtualCodeRegistry } from "@efx/language"
 import { findJsxTagPair } from "./jsx-tags.ts"
 import { classifyRefs } from "./classify-references.ts"
 
+// One registry per tsserver session. tsserver loads this plugin module once,
+// so this single instance is the cache for the editor's lifetime — and is
+// passed to both the LanguagePlugin (writer) and findJsxTagPair (reader).
+const registry = new VirtualCodeRegistry()
+
 // tsserver identifies scripts by file path strings — asFileName is identity.
-const efxLanguagePlugin = createEfxLanguagePlugin<string>((scriptId) => scriptId)
+const efxLanguagePlugin = createEfxLanguagePlugin<string>((scriptId) => scriptId, registry)
 
 // Create the base Volar plugin
 const volarPluginFactory = createLanguageServicePlugin((_ts, _info) => ({
@@ -83,14 +88,14 @@ export const pluginFactory: ts.server.PluginModuleFactory = (modules) => {
               }
 
               // Whitespace at cursor → suppress; tsserver otherwise returns spurious empty hits
-              const vc = getEfxVirtualCode(fileName)
+              const vc = registry.get(fileName)
               const charAtPos = vc?.source[position]
               if (charAtPos && /\s/.test(charAtPos)) {
                 return undefined
               }
 
               // JSX tag-pair highlight, backed by compiler jsxRanges
-              const pair = findJsxTagPair(fileName, position)
+              const pair = findJsxTagPair(registry, fileName, position)
               if (pair) {
                 return [{
                   fileName,


### PR DESCRIPTION
## Summary
- Replaces the module-level `Map<string, EfxVirtualCode>` cache in `@efx/language` with an explicit `VirtualCodeRegistry` threaded through `createEfxLanguagePlugin`.
- Fixes a real concurrency hazard: `@efx/check`'s `runCheck` can be invoked multiple times in one Node process; with the singleton cache, every invocation shared one Map. Each call now owns a fresh registry.
- Drops the `getEfxVirtualCode` / `setEfxVirtualCode` free functions (no compat shim — workspace package, no external consumers). `findJsxTagPair` now takes the registry as a parameter.

## Why this shape
- `VirtualCodeRegistry` exposes only `get` + `set`. `clear` was considered and dropped — consumers throw the whole registry away.
- `@efx/ts-plugin` constructs one registry at module scope (tsserver loads the plugin once per session); `@efx/check` constructs one inside each `runCheck`.
- The previous AGENTS.md anti-pattern that explicitly forbade this refactor has been flipped, with the new rationale documented.

## Test plan
- [x] `pnpm -r typecheck` — clean across all 7 packages including `apps/demo` (efx-check → tsc --noEmit).
- [x] `pnpm -r test` — compiler 45/45, runtime 38/38, language 16/16 (incl. 2 new isolation tests), `@efx/check` integration PASS, `@efx/ts-plugin` integration PASS (real tsserver subprocess, 6 demo `.efx` files, cross-file go-to-def + find-references).
- [x] New `packages/language/src/virtual-code-registry.test.ts` proves two plugins with separate registries don't see each other's virtual codes.
- [x] Independent code-review pass found no correctness bugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)