### PR TITLE
ci: hardened workflow with GH Pages deploy and pnpm 11

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  # Keep pinned action SHAs current — security advisories land here.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,82 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# Least-privilege default — jobs opt in to extra permissions.
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        with:
+          version: 11.3.0
+          run_install: false
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '24'
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm typecheck
+      - run: pnpm test
+      - run: pnpm build
+
+  deploy:
+    needs: ci
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        with:
+          version: 11.3.0
+          run_install: false
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '24'
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+      - run: pnpm --filter @efx/demo exec vite build --base=/efx/
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: apps/demo/dist
+      - id: deploy
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/package.json
+++ b/package.json
@@ -17,5 +17,5 @@
     "typescript": "^5.7.2",
     "vitest": "^4.1.7"
   },
-  "packageManager": "pnpm@10.28.0"
+  "packageManager": "pnpm@11.3.0"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,13 @@
 packages:
   - "packages/*"
   - "apps/*"
+
+# pnpm 11 errors on dependencies with postinstall scripts unless they
+# appear in allowBuilds. These two have scripts we deliberately skip:
+# esbuild ships its platform binary via optionalDependencies (the
+# postinstall is a no-op for pnpm users), and msgpackr-extract falls
+# back to its pure-JS path when the prebuild isn't compiled. Both
+# behaved fine under pnpm 10 with the scripts ignored.
+allowBuilds:
+  esbuild: false
+  msgpackr-extract: false


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow: typecheck/test/build on PRs; on push to main, build the demo with `--base=/efx/` and deploy to GitHub Pages via OIDC.
- Pin every action to a commit SHA; add Dependabot for `github-actions` + `npm`.
- Supply-chain hardening: top-level `permissions: contents: read`, StepSecurity harden-runner in audit mode, `actions/checkout` with `persist-credentials: false`.
- Upgrade pnpm 10.28.0 -> 11.3.0 to inherit stricter defaults (`minimumReleaseAge: 1440`, `blockExoticSubdeps: true`, `strictDepBuilds: true`); `pnpm-workspace.yaml` explicitly denies `esbuild` and `msgpackr-extract` postinstall scripts (already silently ignored under pnpm 10).

## Test plan
- [ ] `ci` job passes on this PR (typecheck, test, build under Node 24 + pnpm 11.3.0)
- [ ] After merge to main, `deploy` job runs, uploads `apps/demo/dist`, and publishes to GH Pages
- [ ] Demo loads at https://m9tdev.github.io/efx/ and the Counter / Todos / LiveUser examples work
- [ ] Dependabot opens its first update PR within a week (sanity check the config)

## Repo-setting prerequisites (not in this diff)
- **Settings -> Pages -> Source: "GitHub Actions"** — required before the deploy job can succeed.
- Optional: enable secret scanning, push protection, Dependabot alerts; set Workflow permissions default to read-only at the repo level; add branch protection on `main` requiring the `ci` check.