### PR TITLE
refactor(runtime): thread Scope through mount, drop cleanup tuples

### DIFF
--- a/apps/demo/src/main.efx
+++ b/apps/demo/src/main.efx
@@ -1,4 +1,4 @@
-import { Cause, Effect, Layer } from "effect"
+import { Cause, Effect, Fiber, Layer } from "effect"
 import { EfxLive, mount } from "@efx/runtime"
 import { Counter } from "./Counter.efx"
 import { Lifecycle } from "./Lifecycle.efx"
@@ -50,4 +50,11 @@ const program = Effect.gen(function* () {
   Effect.provide(Layer.mergeAll(EfxLive, HttpLive, ThemeLive)),
 )
 
-Effect.runFork(program)
+const fiber = Effect.runFork(program)
+
+// Test affordance: scripts/probe-lifecycle.mjs calls this to trigger a full
+// unmount via fiber interruption. Closing the program scope cascades through
+// every per-row / per-Reactive sub-scope and fires their finalizers.
+;(globalThis as { __teardown?: () => void }).__teardown = () => {
+  Effect.runFork(Fiber.interrupt(fiber))
+}

--- a/packages/runtime/AGENTS.md
+++ b/packages/runtime/AGENTS.md
@@ -33,7 +33,7 @@ the editor margin. If you rename them, update the regex.
 | `src/h.ts` | `h()` factory + `track`/`read`/`peek` reactivity-tracking machinery. Re-exports `isAtomRef` from `coerce.ts` for back-compat |
 | `src/coerce.ts` | `coerceAsync` (any child shape → `Effect<View>`) and `coerceSync` (render-time emission → `View`). Internal; not re-exported from `index.ts`. Also owns `isAtomRef` / `ATOM_REF_TYPE_ID` |
 | `src/View.ts` | `View` IR (intermediate representation) — hand-written union of 6 named interfaces (`ViewText`, `ViewElement`, `ViewFragment`, `ViewReactive`, `ViewList`, `ViewEmpty`); constructors via `Data.taggedEnum<View>()`. The normalized DOM-materialization shape `mount` switches on. Plus `isView`, `VIEW_TAGS` |
-| `src/mount.ts` | DOM renderer. `buildDom(View, registry) → { node, cleanup }`, `mount(app, el)` |
+| `src/mount.ts` | DOM renderer. `buildDom(view, registry, scope) → Node`, `mount(app, el)`. Cleanup is delegated to `Scope` — every subscription/listener/release registers a finalizer on the scope it was created in, and parent-fork cascade tears them down on close |
 | `src/index.ts` | Public exports + `list`, `Fragment`, `EfxLive` |
 | `src/coerce.test.ts` | Vitest suite for `coerceAsync` / `coerceSync` (parity + the sync/async asymmetry pin) |
 | `src/types/Fold.ts` | `ChildE`/`ChildR`/`FoldE`/`FoldR`/`TagE`/`TagR`/`TagProps` — the channel-fold conditional types |
@@ -152,6 +152,21 @@ are components, not IR.
 
 ## mount internals — invariants
 
+**Scope is threaded through `buildDom`.** Signature:
+`buildDom(view, registry, scope: Scope.Scope) → Node`. Every
+subscription, event listener, and per-row `Effect.acquireRelease`
+release registers a finalizer on this scope (directly via
+`Scope.addFinalizer`, or via a forked child for sub-trees that need
+their own lifetime). On scope close, parent-fork cascade tears
+everything down. There is no `{ node, cleanup }` wrapper return type
+— closing the surrounding scope IS the cleanup.
+
+**`subscribeRefScoped` / `subscribeAtomScoped`** are the only two
+ways to subscribe to a reactive source from inside `mount.ts`.
+They register the `dispose` callback as a `Scope.addFinalizer`
+finalizer. Don't subscribe outside these helpers — the dispose
+function would have no scope to bind to and would leak on teardown.
+
 **Fragments wrap in `<span style="display: contents">`.** Not a
 `DocumentFragment`, because `DocumentFragment` is consumed on insert
 — a later `replaceChild(fragment, ...)` would fail. The wrapper
@@ -165,12 +180,21 @@ the first emit (synchronous if the source is already populated).
 Source can be `Atom` or `AtomRef.ReadonlyRef`; dispatch on
 `Atom.isAtom` / `isAtomRef`. `coerceSync` (from `coerce.ts`) coerces
 the emitted value into a `View` — including `Effect`, which is run
-with the current scope so `Effect.acquireRelease` registers releases
-on *this* node's scope. `coerceSync` is deliberately asymmetric vs.
-`coerceAsync`: at this point in the render path the Atom/AtomRef has
-already been peeled, so it does NOT recurse into
-Option/Result/Chunk/Atom/AtomRef. Don't "fix" that — the unwrap
-contract belongs upstream.
+with the per-render child scope so `Effect.acquireRelease`
+registers releases on *that* render's scope. `coerceSync` is
+deliberately asymmetric vs. `coerceAsync`: at this point in the
+render path the Atom/AtomRef has already been peeled, so it does
+NOT recurse into Option/Result/Chunk/Atom/AtomRef. Don't "fix" that
+— the unwrap contract belongs upstream.
+
+**Reactive ordering: build NEW → swap DOM → close OLD.** Per emit,
+fork a fresh child scope from the Reactive's scope, build the new
+subtree into it (subscribing whatever refs the new subtree needs),
+swap into the DOM via `replaceChild`, THEN close the previous
+emit's child scope. The reverse order (close OLD first, then build
+NEW) would unsubscribe many refs and resubscribe many during a
+single `notify` loop on the source — the same "diff, not
+unsub-all-then-resub" hazard documented for `h.track`.
 
 **List reconciles by AtomRef identity.** Not by index, not by value
 equality. Each row's `AtomRef` is the key; on `subscribe`, only
@@ -185,17 +209,24 @@ tear down DOM unnecessarily.
 references would always say "no change." `snapshot = Array.from(next)`
 is critical.
 
-**List per-row Scope**: each new row gets its own
-`Scope.makeUnsafe()`. The row's render Effect runs in that scope so
-`Effect.acquireRelease(acquire, release)` inside the row component
-registers `release` on the row scope. On row removal,
-`Scope.closeUnsafe(rowScope, Exit.void)` fires the release. This is
-the mechanism Lifecycle.efx exercises.
+**List per-row Scope is a `Scope.forkUnsafe` child of the List's
+scope** — not an orphan `Scope.makeUnsafe`. The row's render Effect
+runs in that scope so `Effect.acquireRelease(acquire, release)`
+inside the row component registers `release` on the row scope. On
+row removal, `Scope.closeUnsafe(rowScope, Exit.void)` fires the
+releases; on full teardown, the parent-fork cascade closes any
+remaining rows automatically — leak-safe by construction. The
+`Effect.runFork(closeExit)` shape is intentional: row releases can
+be async, and fire-and-forget matches the surrounding DOM
+synchronicity. Lifecycle.efx exercises this mechanism, and
+`scripts/probe-lifecycle.mjs` exercises both row-removal and the
+full-teardown cascade.
 
-**`mount` adds a finalizer** that removes the rendered DOM and
-calls `rendered.cleanup()` when its scope closes. The caller must
-provide a scope (`Effect.scoped` typically) and keep it alive for
-the lifetime of the rendered UI.
+**`mount`** captures the ambient `Scope` via `yield* Effect.scope`,
+threads it into `buildDom`, and adds one finalizer of its own
+(removes the rendered root from the DOM). All other cleanup is
+inside the scope. Callers must provide a scope (`Effect.scoped`
+typically) and keep it alive for the lifetime of the rendered UI.
 
 ## Anti-patterns
 
@@ -213,6 +244,17 @@ the lifetime of the rendered UI.
   async dependencies into a sync hot path or grow dead code.
 - Don't return `DocumentFragment` from `buildDom`. Stable replacement
   needs a real parent node.
+- Don't return `{ node, cleanup }` (or any wrapper around `Node`)
+  from `buildDom`. Cleanup is the scope's job — adding a tuple back
+  reintroduces parallel cleanup conventions that the scope-threading
+  refactor consolidated. If you need teardown for something, register
+  it via `Scope.addFinalizer` (or one of the `subscribe*Scoped`
+  helpers).
+- Don't call `Scope.makeUnsafe()` from inside `buildDom` to make an
+  orphan scope for a sub-tree. Use `Scope.forkUnsafe(parent, ...)`
+  so the sub-scope is parent-linked — closing the surrounding scope
+  cascades into the sub-scope. Orphan scopes leak finalizers on
+  unexpected teardown paths.
 - Don't extend `h.track`'s behavior to handle composite expressions
   — the compiler decides what's rewritten; the runtime just executes.
 - Don't subscribe to `AtomRef.Collection` per-item-value events

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -13,5 +13,8 @@
   },
   "dependencies": {
     "effect": "4.0.0-beta.70"
+  },
+  "devDependencies": {
+    "@effect/vitest": "4.0.0-beta.70"
   }
 }

--- a/packages/runtime/src/coerce.test.ts
+++ b/packages/runtime/src/coerce.test.ts
@@ -1,190 +1,217 @@
-import { Chunk, Effect, Exit, Option, Result, Scope } from "effect"
+import { describe, expect, it } from "@effect/vitest"
+import { Chunk, Effect, Option, Result } from "effect"
 import { Atom, AtomRef } from "effect/unstable/reactivity"
-import { describe, expect, it } from "vitest"
 import { coerceAsync, coerceSync, isAtomRef } from "./coerce.ts"
 import { View } from "./View.ts"
 
+// `it.effect` wraps each test body in an `Effect.scoped`, so an ambient
+// `Scope.Scope` is available via `yield* Effect.scope`. That's exactly what
+// `coerceSync` requires — no manual `Scope.makeUnsafe` / `closeUnsafe` dance
+// in the test source.
+
 describe("coerceAsync — primitives", () => {
-  it("string → View.Text", async () => {
-    const view = await Effect.runPromise(coerceAsync("hi"))
-    expect(view).toEqual(View.Text({ value: "hi" }))
-  })
+  it.effect("string → View.Text", () =>
+    Effect.gen(function* () {
+      const view = yield* coerceAsync("hi")
+      expect(view).toEqual(View.Text({ value: "hi" }))
+    }))
 
-  it("number → View.Text via String()", async () => {
-    const view = await Effect.runPromise(coerceAsync(42))
-    expect(view).toEqual(View.Text({ value: "42" }))
-  })
+  it.effect("number → View.Text via String()", () =>
+    Effect.gen(function* () {
+      const view = yield* coerceAsync(42)
+      expect(view).toEqual(View.Text({ value: "42" }))
+    }))
 
-  it("bigint → View.Text via String()", async () => {
-    const view = await Effect.runPromise(coerceAsync(7n))
-    expect(view).toEqual(View.Text({ value: "7" }))
-  })
+  it.effect("bigint → View.Text via String()", () =>
+    Effect.gen(function* () {
+      const view = yield* coerceAsync(7n)
+      expect(view).toEqual(View.Text({ value: "7" }))
+    }))
 
-  it.each([null, undefined, true, false])("%s → View.Empty", async (v) => {
-    const view = await Effect.runPromise(coerceAsync(v))
-    expect(view).toEqual(View.Empty())
-  })
+  it.effect.each([null, undefined, true, false])("%s → View.Empty", (v) =>
+    Effect.gen(function* () {
+      const view = yield* coerceAsync(v)
+      expect(view).toEqual(View.Empty())
+    }))
 })
 
 describe("coerceAsync — already-built View pass-through", () => {
-  it("returns the same View when given a View", async () => {
-    const input = View.Text({ value: "already a view" })
-    const view = await Effect.runPromise(coerceAsync(input))
-    expect(view).toEqual(input)
-  })
+  it.effect("returns the same View when given a View", () =>
+    Effect.gen(function* () {
+      const input = View.Text({ value: "already a view" })
+      const view = yield* coerceAsync(input)
+      expect(view).toEqual(input)
+    }))
 })
 
 describe("coerceAsync — container peeling", () => {
-  it("Effect<string> → coerce the inner value", async () => {
-    const view = await Effect.runPromise(coerceAsync(Effect.succeed("from effect")))
-    expect(view).toEqual(View.Text({ value: "from effect" }))
-  })
+  it.effect("Effect<string> → coerce the inner value", () =>
+    Effect.gen(function* () {
+      const view = yield* coerceAsync(Effect.succeed("from effect"))
+      expect(view).toEqual(View.Text({ value: "from effect" }))
+    }))
 
-  it("Effect<Effect<string>> → recursively unwrap", async () => {
-    const view = await Effect.runPromise(coerceAsync(Effect.succeed(Effect.succeed("nested"))))
-    expect(view).toEqual(View.Text({ value: "nested" }))
-  })
+  it.effect("Effect<Effect<string>> → recursively unwrap", () =>
+    Effect.gen(function* () {
+      const view = yield* coerceAsync(Effect.succeed(Effect.succeed("nested")))
+      expect(view).toEqual(View.Text({ value: "nested" }))
+    }))
 
-  it("Option.none → Empty", async () => {
-    const view = await Effect.runPromise(coerceAsync(Option.none()))
-    expect(view).toEqual(View.Empty())
-  })
+  it.effect("Option.none → Empty", () =>
+    Effect.gen(function* () {
+      const view = yield* coerceAsync(Option.none())
+      expect(view).toEqual(View.Empty())
+    }))
 
-  it("Option.some(x) → coerce x", async () => {
-    const view = await Effect.runPromise(coerceAsync(Option.some("inner")))
-    expect(view).toEqual(View.Text({ value: "inner" }))
-  })
+  it.effect("Option.some(x) → coerce x", () =>
+    Effect.gen(function* () {
+      const view = yield* coerceAsync(Option.some("inner"))
+      expect(view).toEqual(View.Text({ value: "inner" }))
+    }))
 
-  it("Result failure → Empty", async () => {
-    const view = await Effect.runPromise(coerceAsync(Result.fail("nope")))
-    expect(view).toEqual(View.Empty())
-  })
+  it.effect("Result failure → Empty", () =>
+    Effect.gen(function* () {
+      const view = yield* coerceAsync(Result.fail("nope"))
+      expect(view).toEqual(View.Empty())
+    }))
 
-  it("Result success → coerce inner", async () => {
-    const view = await Effect.runPromise(coerceAsync(Result.succeed("ok")))
-    expect(view).toEqual(View.Text({ value: "ok" }))
-  })
+  it.effect("Result success → coerce inner", () =>
+    Effect.gen(function* () {
+      const view = yield* coerceAsync(Result.succeed("ok"))
+      expect(view).toEqual(View.Text({ value: "ok" }))
+    }))
 
-  it("Array → Fragment of coerced children", async () => {
-    const view = await Effect.runPromise(coerceAsync(["a", 1, null]))
-    expect(view).toEqual(
-      View.Fragment({
-        children: [
-          View.Text({ value: "a" }),
-          View.Text({ value: "1" }),
-          View.Empty(),
-        ],
-      }),
-    )
-  })
+  it.effect("Array → Fragment of coerced children", () =>
+    Effect.gen(function* () {
+      const view = yield* coerceAsync(["a", 1, null])
+      expect(view).toEqual(
+        View.Fragment({
+          children: [
+            View.Text({ value: "a" }),
+            View.Text({ value: "1" }),
+            View.Empty(),
+          ],
+        }),
+      )
+    }))
 
-  it("Chunk → Fragment of coerced children", async () => {
-    const view = await Effect.runPromise(coerceAsync(Chunk.fromIterable(["a", "b"])))
-    expect(view).toEqual(
-      View.Fragment({
-        children: [View.Text({ value: "a" }), View.Text({ value: "b" })],
-      }),
-    )
-  })
+  it.effect("Chunk → Fragment of coerced children", () =>
+    Effect.gen(function* () {
+      const view = yield* coerceAsync(Chunk.fromIterable(["a", "b"]))
+      expect(view).toEqual(
+        View.Fragment({
+          children: [View.Text({ value: "a" }), View.Text({ value: "b" })],
+        }),
+      )
+    }))
 })
 
 describe("coerceAsync — reactive sources", () => {
-  it("AtomRef → View.Reactive carrying the ref", async () => {
-    const ref = AtomRef.make("hello")
-    const view = await Effect.runPromise(coerceAsync(ref))
-    expect(view).toEqual(View.Reactive({ source: ref }))
-  })
+  it.effect("AtomRef → View.Reactive carrying the ref", () =>
+    Effect.gen(function* () {
+      const ref = AtomRef.make("hello")
+      const view = yield* coerceAsync(ref)
+      expect(view).toEqual(View.Reactive({ source: ref }))
+    }))
 
-  it("Atom → View.Reactive carrying the atom", async () => {
-    const atom = Atom.make("hello")
-    const view = await Effect.runPromise(coerceAsync(atom))
-    expect(view).toEqual(View.Reactive({ source: atom }))
-  })
+  it.effect("Atom → View.Reactive carrying the atom", () =>
+    Effect.gen(function* () {
+      const atom = Atom.make("hello")
+      const view = yield* coerceAsync(atom)
+      expect(view).toEqual(View.Reactive({ source: atom }))
+    }))
 })
 
 describe("coerceAsync — unknown fallback", () => {
-  it("plain object → View.Text via String()", async () => {
-    const view = await Effect.runPromise(coerceAsync({ toString: () => "obj!" }))
-    expect(view).toEqual(View.Text({ value: "obj!" }))
-  })
+  it.effect("plain object → View.Text via String()", () =>
+    Effect.gen(function* () {
+      const view = yield* coerceAsync({ toString: () => "obj!" })
+      expect(view).toEqual(View.Text({ value: "obj!" }))
+    }))
 })
 
-// Fresh scope per coerceSync call — `coerceSync` requires one to provide to
-// any Effect-shaped value it has to run.
-const withFreshScope = <A>(fn: (scope: Scope.Closeable) => A): A => {
-  const scope = Scope.makeUnsafe()
-  try {
-    return fn(scope)
-  } finally {
-    const closeExit = Scope.closeUnsafe(scope, Exit.void)
-    if (closeExit) Effect.runFork(closeExit)
-  }
-}
-
 describe("coerceSync — primitives + View pass-through", () => {
-  it("string → View.Text", () => {
-    expect(withFreshScope((s) => coerceSync("hi", s))).toEqual(View.Text({ value: "hi" }))
-  })
+  it.effect("string → View.Text", () =>
+    Effect.gen(function* () {
+      const scope = yield* Effect.scope
+      expect(coerceSync("hi", scope)).toEqual(View.Text({ value: "hi" }))
+    }))
 
-  it("number → View.Text via String()", () => {
-    expect(withFreshScope((s) => coerceSync(42, s))).toEqual(View.Text({ value: "42" }))
-  })
+  it.effect("number → View.Text via String()", () =>
+    Effect.gen(function* () {
+      const scope = yield* Effect.scope
+      expect(coerceSync(42, scope)).toEqual(View.Text({ value: "42" }))
+    }))
 
-  it("bigint → View.Text via String()", () => {
-    expect(withFreshScope((s) => coerceSync(7n, s))).toEqual(View.Text({ value: "7" }))
-  })
+  it.effect("bigint → View.Text via String()", () =>
+    Effect.gen(function* () {
+      const scope = yield* Effect.scope
+      expect(coerceSync(7n, scope)).toEqual(View.Text({ value: "7" }))
+    }))
 
-  it.each([null, undefined, true, false])("%s → View.Empty", (v) => {
-    expect(withFreshScope((s) => coerceSync(v, s))).toEqual(View.Empty())
-  })
+  it.effect.each([null, undefined, true, false])("%s → View.Empty", (v) =>
+    Effect.gen(function* () {
+      const scope = yield* Effect.scope
+      expect(coerceSync(v, scope)).toEqual(View.Empty())
+    }))
 
-  it("View → pass through", () => {
-    const input = View.Text({ value: "v" })
-    expect(withFreshScope((s) => coerceSync(input, s))).toEqual(input)
-  })
+  it.effect("View → pass through", () =>
+    Effect.gen(function* () {
+      const scope = yield* Effect.scope
+      const input = View.Text({ value: "v" })
+      expect(coerceSync(input, scope)).toEqual(input)
+    }))
 })
 
 describe("coerceSync — Effect handling", () => {
-  it("Effect.succeed(string) → coerce inner synchronously", () => {
-    expect(withFreshScope((s) => coerceSync(Effect.succeed("ok"), s)))
-      .toEqual(View.Text({ value: "ok" }))
-  })
+  it.effect("Effect.succeed(string) → coerce inner synchronously", () =>
+    Effect.gen(function* () {
+      const scope = yield* Effect.scope
+      expect(coerceSync(Effect.succeed("ok"), scope)).toEqual(View.Text({ value: "ok" }))
+    }))
 
-  it("Effect that requires Scope: runs with provided scope", () => {
-    const scope = Scope.makeUnsafe()
-    const eff = Effect.gen(function* () {
-      yield* Effect.addFinalizer(() => Effect.void)
-      return "scoped"
-    })
-    expect(coerceSync(eff, scope)).toEqual(View.Text({ value: "scoped" }))
-  })
+  it.effect("Effect that requires Scope: runs with provided scope", () =>
+    Effect.gen(function* () {
+      const scope = yield* Effect.scope
+      const eff = Effect.gen(function* () {
+        yield* Effect.addFinalizer(() => Effect.void)
+        return "scoped"
+      })
+      expect(coerceSync(eff, scope)).toEqual(View.Text({ value: "scoped" }))
+    }))
 
-  it("Effect that fails synchronously → View.Text with `[effect failed:` prefix", () => {
-    const result = withFreshScope((s) => coerceSync(Effect.fail("boom"), s))
-    expect(result._tag).toBe("Text")
-    expect((result as { value: string }).value).toMatch(/^\[effect failed:/)
-  })
+  it.effect("Effect that fails synchronously → View.Text with `[effect failed:` prefix", () =>
+    Effect.gen(function* () {
+      const scope = yield* Effect.scope
+      const result = coerceSync(Effect.fail("boom"), scope)
+      expect(result._tag).toBe("Text")
+      expect((result as { value: string }).value).toMatch(/^\[effect failed:/)
+    }))
 })
 
 describe("coerceSync — Array → Fragment", () => {
-  it("array of primitives", () => {
-    expect(withFreshScope((s) => coerceSync(["a", 1, null], s))).toEqual(
-      View.Fragment({
-        children: [
-          View.Text({ value: "a" }),
-          View.Text({ value: "1" }),
-          View.Empty(),
-        ],
-      }),
-    )
-  })
+  it.effect("array of primitives", () =>
+    Effect.gen(function* () {
+      const scope = yield* Effect.scope
+      expect(coerceSync(["a", 1, null], scope)).toEqual(
+        View.Fragment({
+          children: [
+            View.Text({ value: "a" }),
+            View.Text({ value: "1" }),
+            View.Empty(),
+          ],
+        }),
+      )
+    }))
 })
 
 describe("coerceSync — unknown fallback (String())", () => {
-  it("plain object → View.Text via String()", () => {
-    expect(withFreshScope((s) => coerceSync({ toString: () => "obj!" }, s)))
-      .toEqual(View.Text({ value: "obj!" }))
-  })
+  it.effect("plain object → View.Text via String()", () =>
+    Effect.gen(function* () {
+      const scope = yield* Effect.scope
+      expect(coerceSync({ toString: () => "obj!" }, scope))
+        .toEqual(View.Text({ value: "obj!" }))
+    }))
 })
 
 describe("coerceSync — asymmetry (does NOT peel async-only containers)", () => {
@@ -193,28 +220,36 @@ describe("coerceSync — asymmetry (does NOT peel async-only containers)", () =>
   // like Option/Result/Atom/AtomRef would require subscribing or unwrapping
   // an Effect, neither of which is appropriate inside the sync render path.
 
-  it("Option.some(x) → String() fallback, not unwrap", () => {
-    const result = withFreshScope((s) => coerceSync(Option.some("inner"), s))
-    expect(result._tag).toBe("Text")
-    expect((result as { value: string }).value).not.toBe("inner")
-  })
+  it.effect("Option.some(x) → String() fallback, not unwrap", () =>
+    Effect.gen(function* () {
+      const scope = yield* Effect.scope
+      const result = coerceSync(Option.some("inner"), scope)
+      expect(result._tag).toBe("Text")
+      expect((result as { value: string }).value).not.toBe("inner")
+    }))
 
-  it("Result.succeed(x) → String() fallback, not unwrap", () => {
-    const result = withFreshScope((s) => coerceSync(Result.succeed("inner"), s))
-    expect(result._tag).toBe("Text")
-    expect((result as { value: string }).value).not.toBe("inner")
-  })
+  it.effect("Result.succeed(x) → String() fallback, not unwrap", () =>
+    Effect.gen(function* () {
+      const scope = yield* Effect.scope
+      const result = coerceSync(Result.succeed("inner"), scope)
+      expect(result._tag).toBe("Text")
+      expect((result as { value: string }).value).not.toBe("inner")
+    }))
 
-  it("AtomRef → String() fallback, not View.Reactive", () => {
-    const ref = AtomRef.make("x")
-    const result = withFreshScope((s) => coerceSync(ref, s))
-    expect(result._tag).toBe("Text")
-  })
+  it.effect("AtomRef → String() fallback, not View.Reactive", () =>
+    Effect.gen(function* () {
+      const scope = yield* Effect.scope
+      const ref = AtomRef.make("x")
+      const result = coerceSync(ref, scope)
+      expect(result._tag).toBe("Text")
+    }))
 
-  it("Chunk → String() fallback, not Fragment", () => {
-    const result = withFreshScope((s) => coerceSync(Chunk.fromIterable(["a", "b"]), s))
-    expect(result._tag).toBe("Text")
-  })
+  it.effect("Chunk → String() fallback, not Fragment", () =>
+    Effect.gen(function* () {
+      const scope = yield* Effect.scope
+      const result = coerceSync(Chunk.fromIterable(["a", "b"]), scope)
+      expect(result._tag).toBe("Text")
+    }))
 })
 
 describe("isAtomRef predicate", () => {

--- a/packages/runtime/src/coerce.test.ts
+++ b/packages/runtime/src/coerce.test.ts
@@ -1,4 +1,4 @@
-import { Chunk, Effect, Option, Result, Scope } from "effect"
+import { Chunk, Effect, Exit, Option, Result, Scope } from "effect"
 import { Atom, AtomRef } from "effect/unstable/reactivity"
 import { describe, expect, it } from "vitest"
 import { coerceAsync, coerceSync, isAtomRef } from "./coerce.ts"
@@ -109,32 +109,45 @@ describe("coerceAsync — unknown fallback", () => {
   })
 })
 
+// Fresh scope per coerceSync call — `coerceSync` requires one to provide to
+// any Effect-shaped value it has to run.
+const withFreshScope = <A>(fn: (scope: Scope.Closeable) => A): A => {
+  const scope = Scope.makeUnsafe()
+  try {
+    return fn(scope)
+  } finally {
+    const closeExit = Scope.closeUnsafe(scope, Exit.void)
+    if (closeExit) Effect.runFork(closeExit)
+  }
+}
+
 describe("coerceSync — primitives + View pass-through", () => {
   it("string → View.Text", () => {
-    expect(coerceSync("hi")).toEqual(View.Text({ value: "hi" }))
+    expect(withFreshScope((s) => coerceSync("hi", s))).toEqual(View.Text({ value: "hi" }))
   })
 
   it("number → View.Text via String()", () => {
-    expect(coerceSync(42)).toEqual(View.Text({ value: "42" }))
+    expect(withFreshScope((s) => coerceSync(42, s))).toEqual(View.Text({ value: "42" }))
   })
 
   it("bigint → View.Text via String()", () => {
-    expect(coerceSync(7n)).toEqual(View.Text({ value: "7" }))
+    expect(withFreshScope((s) => coerceSync(7n, s))).toEqual(View.Text({ value: "7" }))
   })
 
   it.each([null, undefined, true, false])("%s → View.Empty", (v) => {
-    expect(coerceSync(v)).toEqual(View.Empty())
+    expect(withFreshScope((s) => coerceSync(v, s))).toEqual(View.Empty())
   })
 
   it("View → pass through", () => {
     const input = View.Text({ value: "v" })
-    expect(coerceSync(input)).toEqual(input)
+    expect(withFreshScope((s) => coerceSync(input, s))).toEqual(input)
   })
 })
 
 describe("coerceSync — Effect handling", () => {
   it("Effect.succeed(string) → coerce inner synchronously", () => {
-    expect(coerceSync(Effect.succeed("ok"))).toEqual(View.Text({ value: "ok" }))
+    expect(withFreshScope((s) => coerceSync(Effect.succeed("ok"), s)))
+      .toEqual(View.Text({ value: "ok" }))
   })
 
   it("Effect that requires Scope: runs with provided scope", () => {
@@ -147,7 +160,7 @@ describe("coerceSync — Effect handling", () => {
   })
 
   it("Effect that fails synchronously → View.Text with `[effect failed:` prefix", () => {
-    const result = coerceSync(Effect.fail("boom"))
+    const result = withFreshScope((s) => coerceSync(Effect.fail("boom"), s))
     expect(result._tag).toBe("Text")
     expect((result as { value: string }).value).toMatch(/^\[effect failed:/)
   })
@@ -155,7 +168,7 @@ describe("coerceSync — Effect handling", () => {
 
 describe("coerceSync — Array → Fragment", () => {
   it("array of primitives", () => {
-    expect(coerceSync(["a", 1, null])).toEqual(
+    expect(withFreshScope((s) => coerceSync(["a", 1, null], s))).toEqual(
       View.Fragment({
         children: [
           View.Text({ value: "a" }),
@@ -169,9 +182,8 @@ describe("coerceSync — Array → Fragment", () => {
 
 describe("coerceSync — unknown fallback (String())", () => {
   it("plain object → View.Text via String()", () => {
-    expect(coerceSync({ toString: () => "obj!" })).toEqual(
-      View.Text({ value: "obj!" }),
-    )
+    expect(withFreshScope((s) => coerceSync({ toString: () => "obj!" }, s)))
+      .toEqual(View.Text({ value: "obj!" }))
   })
 })
 
@@ -182,25 +194,25 @@ describe("coerceSync — asymmetry (does NOT peel async-only containers)", () =>
   // an Effect, neither of which is appropriate inside the sync render path.
 
   it("Option.some(x) → String() fallback, not unwrap", () => {
-    const result = coerceSync(Option.some("inner"))
+    const result = withFreshScope((s) => coerceSync(Option.some("inner"), s))
     expect(result._tag).toBe("Text")
     expect((result as { value: string }).value).not.toBe("inner")
   })
 
   it("Result.succeed(x) → String() fallback, not unwrap", () => {
-    const result = coerceSync(Result.succeed("inner"))
+    const result = withFreshScope((s) => coerceSync(Result.succeed("inner"), s))
     expect(result._tag).toBe("Text")
     expect((result as { value: string }).value).not.toBe("inner")
   })
 
   it("AtomRef → String() fallback, not View.Reactive", () => {
     const ref = AtomRef.make("x")
-    const result = coerceSync(ref)
+    const result = withFreshScope((s) => coerceSync(ref, s))
     expect(result._tag).toBe("Text")
   })
 
   it("Chunk → String() fallback, not Fragment", () => {
-    const result = coerceSync(Chunk.fromIterable(["a", "b"]))
+    const result = withFreshScope((s) => coerceSync(Chunk.fromIterable(["a", "b"]), s))
     expect(result._tag).toBe("Text")
   })
 })

--- a/packages/runtime/src/coerce.ts
+++ b/packages/runtime/src/coerce.ts
@@ -66,7 +66,7 @@ function coerceChildren(cs: ReadonlyArray<unknown>): Effect.Effect<View, any, an
  * already been unwrapped by the caller; if one shows up here it's coerced
  * via `String()` rather than silently expanded.
  */
-export const coerceSync = (v: unknown, scope: Scope.Closeable): View => {
+export const coerceSync = (v: unknown, scope: Scope.Scope): View => {
   if (v == null || v === false || v === true) return Empty
   if (typeof v === "string") return View.Text({ value: v })
   if (typeof v === "number" || typeof v === "bigint") {

--- a/packages/runtime/src/coerce.ts
+++ b/packages/runtime/src/coerce.ts
@@ -57,16 +57,16 @@ function coerceChildren(cs: ReadonlyArray<unknown>): Effect.Effect<View, any, an
 
 /**
  * Synchronously coerce an arbitrary value (typically read from a reactive
- * source at render time) into a View. If `scope` is provided and the value
- * is an Effect, the effect is run with that scope, so `Effect.acquireRelease`
- * / `Effect.addFinalizer` inside the effect register releases against it.
+ * source at render time) into a View. `scope` is provided to any Effect-shaped
+ * value via `Effect.provideService`, so `Effect.acquireRelease` /
+ * `Effect.addFinalizer` inside the effect register releases against it.
  *
  * **Asymmetric vs. coerceAsync**: this path does NOT peel
  * Option/Result/Chunk/Atom/AtomRef. At render-time those containers have
  * already been unwrapped by the caller; if one shows up here it's coerced
  * via `String()` rather than silently expanded.
  */
-export const coerceSync = (v: unknown, scope?: Scope.Closeable): View => {
+export const coerceSync = (v: unknown, scope: Scope.Closeable): View => {
   if (v == null || v === false || v === true) return Empty
   if (typeof v === "string") return View.Text({ value: v })
   if (typeof v === "number" || typeof v === "bigint") {
@@ -74,9 +74,11 @@ export const coerceSync = (v: unknown, scope?: Scope.Closeable): View => {
   }
   if (isView(v)) return v
   if (Effect.isEffect(v)) {
-    const provided = scope
-      ? Effect.provideService(v as Effect.Effect<unknown, unknown, Scope.Scope>, Scope.Scope, scope)
-      : (v as Effect.Effect<unknown, unknown, never>)
+    const provided = Effect.provideService(
+      v as Effect.Effect<unknown, unknown, Scope.Scope>,
+      Scope.Scope,
+      scope,
+    )
     const exit = Effect.runSyncExit(provided)
     return Exit.match(exit, {
       onSuccess: (val) => coerceSync(val, scope),

--- a/packages/runtime/src/mount.ts
+++ b/packages/runtime/src/mount.ts
@@ -3,39 +3,69 @@ import { Atom, AtomRef, AtomRegistry } from "effect/unstable/reactivity"
 import { coerceSync, isAtomRef } from "./coerce.ts"
 import { type Props, View } from "./View.ts"
 
-type Rendered = {
-  readonly node: Node
-  readonly cleanup: () => void
+// Subscribe to a ref and register the unsubscribe as a finalizer on the
+// given scope. The teardown happens via scope close (full or cascade), so
+// individual call sites never have to thread cleanup callbacks back up.
+const subscribeRefScoped = <A>(
+  ref: AtomRef.ReadonlyRef<A>,
+  fn: (v: A) => void,
+  scope: Scope.Scope,
+): void => {
+  const dispose = ref.subscribe(fn)
+  Effect.runSync(Scope.addFinalizer(scope, Effect.sync(dispose)))
 }
 
-const noop = () => {}
+// AtomRegistry uses a different subscribe shape (registry.subscribe(atom, fn))
+// than AtomRef. Same finalizer-register pattern; thin separate helper rather
+// than overloading the shape.
+const subscribeAtomScoped = <A>(
+  registry: AtomRegistry.AtomRegistry,
+  atom: Atom.Atom<A>,
+  fn: (v: A) => void,
+  scope: Scope.Scope,
+): void => {
+  const dispose = registry.subscribe(atom, fn)
+  Effect.runSync(Scope.addFinalizer(scope, Effect.sync(dispose)))
+}
 
-const applyProp = (el: Element, key: string, value: unknown): (() => void) | undefined => {
+const applyProp = (
+  el: Element,
+  key: string,
+  value: unknown,
+  scope: Scope.Scope,
+): void => {
   // Reactive prop: AtomRef → subscribe and re-apply on changes.
   if (isAtomRef(value)) {
     const ref = value as AtomRef.ReadonlyRef<unknown>
-    let lastCleanup: (() => void) | undefined
+    let lastChildScope: Scope.Closeable | null = null
     const apply = (v: unknown) => {
-      lastCleanup?.()
-      lastCleanup = applyProp(el, key, v)
+      if (lastChildScope) {
+        const e = Scope.closeUnsafe(lastChildScope, Exit.void)
+        if (e) Effect.runFork(e)
+      }
+      lastChildScope = Scope.forkUnsafe(scope, "sequential")
+      applyProp(el, key, v, lastChildScope)
     }
     apply(ref.value)
-    const dispose = ref.subscribe(apply)
-    return () => { dispose(); lastCleanup?.() }
+    subscribeRefScoped(ref, apply, scope)
+    return
   }
 
-  if (value == null || value === false) return undefined
+  if (value == null || value === false) return
   // Event handler: onClick, onInput, etc.
   if (key.startsWith("on") && key.length > 2 && typeof value === "function") {
     const event = key.slice(2).toLowerCase()
     const handler = value as EventListener
     el.addEventListener(event, handler)
-    return () => el.removeEventListener(event, handler)
+    Effect.runSync(
+      Scope.addFinalizer(scope, Effect.sync(() => el.removeEventListener(event, handler))),
+    )
+    return
   }
   // class / className
   if (key === "class" || key === "className") {
     el.setAttribute("class", String(value))
-    return undefined
+    return
   }
   // style object
   if (key === "style" && typeof value === "object") {
@@ -43,48 +73,39 @@ const applyProp = (el: Element, key: string, value: unknown): (() => void) | und
     for (const [k, v] of Object.entries(value as Record<string, string>)) {
       style.setProperty(k, v)
     }
-    return undefined
+    return
   }
   // Boolean true → presence attribute
   if (value === true) {
     el.setAttribute(key, "")
-    return undefined
+    return
   }
   // Default: setAttribute
   el.setAttribute(key, String(value))
-  return undefined
 }
 
-const applyProps = (el: Element, props: Props): Array<() => void> => {
-  const cleanups: Array<() => void> = []
+const applyProps = (el: Element, props: Props, scope: Scope.Scope): void => {
   for (const [k, v] of Object.entries(props)) {
     if (k === "children") continue
-    const c = applyProp(el, k, v)
-    if (c) cleanups.push(c)
+    applyProp(el, k, v, scope)
   }
-  return cleanups
 }
 
-const buildDom = (view: View, registry: AtomRegistry.AtomRegistry): Rendered => {
+const buildDom = (view: View, registry: AtomRegistry.AtomRegistry, scope: Scope.Scope): Node => {
   switch (view._tag) {
     case "Empty":
-      return { node: document.createComment(""), cleanup: noop }
+      return document.createComment("")
 
     case "Text":
-      return { node: document.createTextNode(view.value), cleanup: noop }
+      return document.createTextNode(view.value)
 
     case "Element": {
       const el = document.createElement(view.tag)
-      const cleanups = applyProps(el, view.props)
+      applyProps(el, view.props, scope)
       for (const child of view.children) {
-        const r = buildDom(child, registry)
-        el.appendChild(r.node)
-        cleanups.push(r.cleanup)
+        el.appendChild(buildDom(child, registry, scope))
       }
-      return {
-        node: el,
-        cleanup: () => { for (const c of cleanups) c() },
-      }
+      return el
     }
 
     case "Fragment": {
@@ -92,51 +113,48 @@ const buildDom = (view: View, registry: AtomRegistry.AtomRegistry): Rendered => 
       // requires a stable reference. Wrap in a span with display:contents.
       const wrapper = document.createElement("span")
       wrapper.style.display = "contents"
-      const cleanups: Array<() => void> = []
       for (const child of view.children) {
-        const r = buildDom(child, registry)
-        wrapper.appendChild(r.node)
-        cleanups.push(r.cleanup)
+        wrapper.appendChild(buildDom(child, registry, scope))
       }
-      return {
-        node: wrapper,
-        cleanup: () => { for (const c of cleanups) c() },
-      }
+      return wrapper
     }
 
     case "Reactive": {
       // Placeholder; will be replaced on first render.
       let currentNode: Node = document.createComment("reactive-pending")
-      let currentCleanup: () => void = noop
+      // Rolling child scope: tracks the in-flight subtree's finalizers.
+      // On parent close, the fork-cascade closes whatever is current — no
+      // explicit teardown needed here.
+      let renderChildScope: Scope.Closeable | null = null
 
       const render = (next: unknown): void => {
-        const r = buildDom(coerceSync(next), registry)
+        // Build NEW subtree first (subscribing any refs it needs), THEN tear
+        // down the OLD subtree. The reverse order would unsubscribe many
+        // listeners and resubscribe many — the documented "diff, not
+        // unsub-all-then-resub" hazard (see h.ts AGENTS.md) extends here.
+        const newScope = Scope.forkUnsafe(scope, "sequential")
+        const node = buildDom(coerceSync(next, newScope), registry, newScope)
         if (currentNode.parentNode) {
-          currentNode.parentNode.replaceChild(r.node, currentNode)
+          currentNode.parentNode.replaceChild(node, currentNode)
         }
-        currentCleanup()
-        currentNode = r.node
-        currentCleanup = r.cleanup
+        if (renderChildScope) {
+          const e = Scope.closeUnsafe(renderChildScope, Exit.void)
+          if (e) Effect.runFork(e)
+        }
+        renderChildScope = newScope
+        currentNode = node
       }
 
       // Initial synchronous render
       if (Atom.isAtom(view.source)) {
         render(registry.get(view.source))
+        subscribeAtomScoped(registry, view.source, render, scope)
       } else if (isAtomRef(view.source)) {
         render(view.source.value)
+        subscribeRefScoped(view.source, render, scope)
       }
 
-      // Subscribe for future updates
-      const dispose = Atom.isAtom(view.source)
-        ? registry.subscribe(view.source, render)
-        : isAtomRef(view.source)
-          ? view.source.subscribe(render)
-          : noop
-
-      return {
-        node: currentNode,
-        cleanup: () => { dispose(); currentCleanup() },
-      }
+      return currentNode
     }
 
     case "List": {
@@ -146,9 +164,12 @@ const buildDom = (view: View, registry: AtomRegistry.AtomRegistry): Rendered => 
       const wrapper = document.createElement("span")
       wrapper.style.display = "contents"
 
-      // Per-item: rendered DOM + cleanup, keyed by AtomRef identity so
+      // Per-item: rendered DOM node + the row's own scope (which holds all
+      // finalizers registered by the row component, including
+      // `Effect.acquireRelease` releases). Keyed by AtomRef identity so
       // reactivity is preserved across reorders/inserts.
-      const rendered = new Map<AtomRef.AtomRef<unknown>, Rendered>()
+      type Row = { readonly node: Node; readonly rowScope: Scope.Closeable }
+      const rendered = new Map<AtomRef.AtomRef<unknown>, Row>()
       // Snapshot the array (not just the reference!) — CollectionImpl mutates
       // its internal array in place on push/remove, so comparing references
       // would never detect structural changes.
@@ -157,38 +178,38 @@ const buildDom = (view: View, registry: AtomRegistry.AtomRegistry): Rendered => 
       const reconcile = (next: ReadonlyArray<AtomRef.AtomRef<unknown>>): void => {
         const nextSet = new Set(next)
 
-        // Drop rows whose ref is gone.
-        for (const [ref, r] of rendered) {
+        // Drop rows whose ref is gone. Close the row scope first (firing
+        // every finalizer the row registered: subscriptions, user
+        // `acquireRelease` releases), THEN detach the DOM. Matches the prior
+        // order so user releases that observe DOM still see it.
+        for (const [ref, row] of rendered) {
           if (!nextSet.has(ref)) {
-            r.cleanup()
-            if (r.node.parentNode === wrapper) wrapper.removeChild(r.node)
+            const e = Scope.closeUnsafe(row.rowScope, Exit.void)
+            if (e) Effect.runFork(e)
+            if (row.node.parentNode === wrapper) wrapper.removeChild(row.node)
             rendered.delete(ref)
           }
         }
 
-        // Build any new rows and place each in its current position.
-        // Each new row gets its own Scope so `Effect.acquireRelease` inside
-        // the row component registers releases that fire on row removal.
+        // Build any new rows and place each in its current position. Each new
+        // row gets its own scope, forked from the List's scope — so on full
+        // mount teardown the fork-cascade closes any rows that didn't get
+        // explicitly removed first.
         let cursor: ChildNode | null = wrapper.firstChild
         next.forEach((ref, i) => {
-          let r = rendered.get(ref)
-          if (!r) {
-            const rowScope = Scope.makeUnsafe()
-            const rowView = coerceSync(view.render(ref, i), rowScope)
-            const built = buildDom(rowView, registry)
-            r = {
-              node: built.node,
-              cleanup: () => {
-                built.cleanup()
-                // Close the row's scope, firing any acquireRelease releases.
-                const closeExit = Scope.closeUnsafe(rowScope, Exit.void)
-                if (closeExit) Effect.runFork(closeExit)
-              },
-            }
-            rendered.set(ref, r)
+          let row = rendered.get(ref)
+          if (!row) {
+            const rowScope = Scope.forkUnsafe(scope, "sequential")
+            const node = buildDom(
+              coerceSync(view.render(ref, i), rowScope),
+              registry,
+              rowScope,
+            )
+            row = { node, rowScope }
+            rendered.set(ref, row)
           }
-          if (cursor !== r.node) {
-            wrapper.insertBefore(r.node, cursor)
+          if (cursor !== row.node) {
+            wrapper.insertBefore(row.node, cursor)
           } else {
             cursor = cursor.nextSibling
           }
@@ -199,23 +220,21 @@ const buildDom = (view: View, registry: AtomRegistry.AtomRegistry): Rendered => 
 
       reconcile(view.source.value)
 
-      const dispose = view.source.subscribe((next) => {
-        // Re-reconcile only on structural changes. CollectionImpl also
-        // notifies on per-item value updates (which are handled separately
-        // by each row's own reactive bindings) — those are no-ops here.
-        const structural =
-          next.length !== snapshot.length ||
-          next.some((ref, i) => ref !== snapshot[i])
-        if (structural) reconcile(next)
-      })
-
-      return {
-        node: wrapper,
-        cleanup: () => {
-          dispose()
-          for (const r of rendered.values()) r.cleanup()
+      // Re-reconcile only on structural changes. CollectionImpl also notifies
+      // on per-item value updates (which are handled separately by each row's
+      // own reactive bindings) — those are no-ops here.
+      subscribeRefScoped(
+        view.source,
+        (next) => {
+          const structural =
+            next.length !== snapshot.length ||
+            next.some((ref, i) => ref !== snapshot[i])
+          if (structural) reconcile(next)
         },
-      }
+        scope,
+      )
+
+      return wrapper
     }
   }
 }
@@ -223,8 +242,10 @@ const buildDom = (view: View, registry: AtomRegistry.AtomRegistry): Rendered => 
 /**
  * Run the app Effect, build the DOM, and attach to the target element.
  *
- * The mount itself runs in a Scope; closing that scope tears down all
- * subscriptions and removes the rendered DOM.
+ * Cleanup is handled entirely through the ambient `Scope`. Every subscription,
+ * event listener, and per-row `acquireRelease` registers a finalizer on this
+ * scope (directly or via a forked child). Closing the surrounding scope
+ * cascades to every child scope and runs all finalizers.
  */
 export const mount = <E, R>(
   app: Effect.Effect<View, E, R>,
@@ -233,15 +254,13 @@ export const mount = <E, R>(
   Effect.gen(function* () {
     const registry = yield* AtomRegistry.AtomRegistry
     const view = yield* app
-    const rendered = buildDom(view, registry)
+    const scope = yield* Effect.scope
+    const node = buildDom(view, registry, scope)
     el.replaceChildren()
-    el.appendChild(rendered.node)
+    el.appendChild(node)
     yield* Effect.addFinalizer(() =>
       Effect.sync(() => {
-        rendered.cleanup()
-        if (rendered.node.parentNode === el) {
-          el.removeChild(rendered.node)
-        }
+        if (node.parentNode === el) el.removeChild(node)
       })
     )
   })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,10 @@ importers:
       effect:
         specifier: 4.0.0-beta.70
         version: 4.0.0-beta.70
+    devDependencies:
+      '@effect/vitest':
+        specifier: 4.0.0-beta.70
+        version: 4.0.0-beta.70(effect@4.0.0-beta.70)(vitest@4.1.7(@types/node@25.9.1)(vite@7.3.3(@types/node@25.9.1)(yaml@2.9.0)))
 
   packages/ts-plugin:
     dependencies:
@@ -427,66 +431,79 @@ packages:
     resolution: {integrity: sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.4':
     resolution: {integrity: sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.4':
     resolution: {integrity: sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.4':
     resolution: {integrity: sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.4':
     resolution: {integrity: sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.4':
     resolution: {integrity: sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.4':
     resolution: {integrity: sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.4':
     resolution: {integrity: sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.4':
     resolution: {integrity: sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.4':
     resolution: {integrity: sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.4':
     resolution: {integrity: sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.4':
     resolution: {integrity: sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.4':
     resolution: {integrity: sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.4':
     resolution: {integrity: sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==}

--- a/scripts/probe-lifecycle.mjs
+++ b/scripts/probe-lifecycle.mjs
@@ -1,9 +1,12 @@
-// Red test for per-component lifecycle scopes:
-//   - Component uses Effect.acquireRelease to log mount/unmount events.
-//   - Initial render produces N "mount:i" entries.
-//   - Adding a row produces one more "mount".
-//   - Removing a row should produce a matching "unmount" — this is what's
-//     currently missing.
+// Lifecycle probe — exercises Effect.acquireRelease's release through per-row
+// Scope, in three phases:
+//   1. Initial render produces N "mount:i" entries.
+//   2. Add/remove rows: removing a row fires its matching "unmount:i" via
+//      Scope.closeUnsafe on that row's per-row scope.
+//   3. Trigger a full teardown (__teardown interrupts the program fiber,
+//      closing the program scope). The parent-fork cascade closes every
+//      remaining row scope: every outstanding mount must have a matching
+//      unmount afterwards.
 import { chromium } from "playwright-core"
 
 const URL = process.env.EFX_URL ?? "http://localhost:5173/"
@@ -35,13 +38,28 @@ await page.waitForTimeout(50)
 const afterRemove = await read()
 console.log("after remove:", afterRemove)
 
+// Phase 3: leave several rows mounted, trigger full teardown via __teardown.
+// The fork-cascade through every row scope should fire each remaining
+// row's unmount.
+await page.locator(".lifecycle button", { hasText: "add row" }).click()
+await page.locator(".lifecycle button", { hasText: "add row" }).click()
+await page.waitForTimeout(50)
+const beforeTeardown = await read()
+console.log("before teardown:", beforeTeardown)
+
+await page.evaluate(() => globalThis.__teardown?.())
+await page.waitForTimeout(100)
+const afterTeardown = await read()
+console.log("after teardown:", afterTeardown)
+
 await browser.close()
 
 // Assertions
+const failures = []
+
+// Phase 1 + 2 assertions (preserved)
 const mountCount = afterRemove.filter((e) => e.startsWith("mount:")).length
 const unmountCount = afterRemove.filter((e) => e.startsWith("unmount:")).length
-
-const failures = []
 if (initial.length < 2) failures.push(`expected ≥2 initial mounts, got ${initial.length}`)
 if (afterAdd.length !== initial.length + 1)
   failures.push(`expected one new mount after add, events grew by ${afterAdd.length - initial.length}`)
@@ -49,6 +67,17 @@ if (unmountCount < 1)
   failures.push(`expected ≥1 unmount after remove, got 0`)
 if (mountCount - unmountCount !== afterRemove.filter((e) => e.startsWith("mount:")).length - 1)
   failures.push(`expected exactly 1 row's worth of unmount to fire`)
+
+// Phase 3 assertion: every outstanding mount has a matching unmount after
+// the cascade. Counts must be equal across the whole event log.
+const finalMounts = afterTeardown.filter((e) => e.startsWith("mount:")).length
+const finalUnmounts = afterTeardown.filter((e) => e.startsWith("unmount:")).length
+if (finalMounts !== finalUnmounts)
+  failures.push(`after teardown cascade: ${finalMounts} mounts vs ${finalUnmounts} unmounts (every row should be unmounted)`)
+const outstandingBefore = beforeTeardown.filter((e) => e.startsWith("mount:")).length -
+  beforeTeardown.filter((e) => e.startsWith("unmount:")).length
+if (outstandingBefore < 2)
+  failures.push(`expected ≥2 rows still mounted before teardown, got ${outstandingBefore}`)
 
 if (failures.length > 0) {
   console.error("FAIL:")


### PR DESCRIPTION
## Summary

- `buildDom` takes a `Scope` and returns `Node`. Every subscription, event listener, and `Effect.acquireRelease` release registers as a finalizer on that scope (or a forked child); closing the surrounding scope cascades through every child.
- Replaces four parallel cleanup conventions (Element cleanups array, Reactive `{node, cleanup}` tuple, applyProp closure chains, orphan `Scope.makeUnsafe()` per row with `Effect.runFork(closeExit)` dance) with one seam — `Scope.addFinalizer`. Row scopes are now parent-linked via `Scope.forkUnsafe(parent)`, so the fork-cascade closes any rows that escape explicit removal on teardown.
- `coerceSync(v, scope)` is now required (every caller already has a scope). Param type is `Scope.Scope` — `coerceSync` only provides the scope as a service, never closes it. `Rendered = { node, cleanup }` deleted. `subscribeRefScoped` / `subscribeAtomScoped` helpers consolidate three identical subscribe→register-finalizer patterns.
- `apps/demo/src/main.efx` exposes `__teardown` so the lifecycle probe can interrupt the program fiber and exercise the parent-fork cascade.
- `coerce.test.ts` adopts `@effect/vitest`'s `it.effect`: each test body runs inside `Effect.scoped`, so the ambient `Scope.Scope` is available via `yield* Effect.scope`. Drops the manual `Scope.makeUnsafe`/`closeUnsafe` dance.

## Invariants preserved

- Reactive ordering: build NEW → swap → close OLD (avoids the documented "diff, not unsub-all-then-resub" hazard inside `notify` loops).
- `coerceSync` still does NOT peel Option/Result/Chunk/Atom/AtomRef.
- Fragment wraps in `<span style="display:contents">` (stable parent for `replaceChild`).
- List reconciles by AtomRef identity; snapshot is a copy.
- Async-safe row close via `Effect.runFork(closeExit)` retained for user-supplied `acquireRelease` releases.

## Test plan

- [x] `pnpm -r typecheck` — 7 packages clean (demo via `@efx/check`)
- [x] `pnpm -r test` — runtime 38, compiler 45, language 16, ts-plugin 8, check
- [x] `scripts/probe-lifecycle.mjs` — phase 3 added: leaves 4 rows mounted, calls `__teardown`, asserts all 4 outstanding rows fire `unmount:N` via parent-fork cascade
- [x] `scripts/probe.mjs`, `probe-todos.mjs`, `probe-liveuser.mjs` — pass on dev server
- [x] `scripts/probe-prod.mjs` — pass on `vite build` output served from `dist/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)