### PR TITLE
fix(scripts): make probe paths portable across machines

### DIFF
--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -34,10 +34,15 @@ regressions.
 
 - Probes write screenshots to `/tmp/efx-verify/` — convenient for
   visual diffing across runs; not committed.
-- Probes use `playwright-core` (devDep at the workspace root) plus a
-  hard-coded chromium path that works on the maintainer's NixOS box.
-  If you run on a different machine, override `executablePath` at the
-  top of the script or use `playwright` (full) instead.
+- Probes use `playwright-core` (devDep at the workspace root), which
+  does not bundle a browser. Set `EFX_CHROMIUM` to your Chromium binary
+  before running, e.g. `EFX_CHROMIUM=/usr/bin/chromium node scripts/probe.mjs`.
+  Leaving it unset will produce a "browser not found" error from
+  `playwright-core`; swap to `playwright` (full) if you prefer a bundled
+  browser instead.
+- Probes that read repo files (e.g. `probe-hmr.mjs` mutating
+  `Counter.efx`) resolve paths relative to the script via
+  `import.meta.url`, so they work from any clone or worktree.
 - Don't promote these to `pnpm test` without first wrapping them in a
   process supervisor that starts/stops the dev server. The probes
   assume the server is already up.

--- a/scripts/probe-hmr.mjs
+++ b/scripts/probe-hmr.mjs
@@ -2,11 +2,16 @@
 // appears in the browser without manual reload.
 import { chromium } from "playwright-core"
 import { readFileSync, writeFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+import { dirname, resolve } from "node:path"
 
-const COUNTER_PATH = "/home/mathieu/playground/apps/demo/src/Counter.efx"
+const COUNTER_PATH = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../apps/demo/src/Counter.efx",
+)
 
 const browser = await chromium.launch({
-  executablePath: "/etc/profiles/per-user/mathieu/bin/chromium",
+  executablePath: process.env.EFX_CHROMIUM,
   headless: true,
   args: ["--no-sandbox", "--disable-gpu"],
 })

--- a/scripts/probe-lifecycle.mjs
+++ b/scripts/probe-lifecycle.mjs
@@ -9,7 +9,7 @@ import { chromium } from "playwright-core"
 const URL = process.env.EFX_URL ?? "http://localhost:5173/"
 
 const browser = await chromium.launch({
-  executablePath: "/etc/profiles/per-user/mathieu/bin/chromium",
+  executablePath: process.env.EFX_CHROMIUM,
   headless: true,
   args: ["--no-sandbox", "--disable-gpu"],
 })

--- a/scripts/probe-liveuser.mjs
+++ b/scripts/probe-liveuser.mjs
@@ -1,7 +1,7 @@
 import { chromium } from "playwright-core"
 
 const browser = await chromium.launch({
-  executablePath: "/etc/profiles/per-user/mathieu/bin/chromium",
+  executablePath: process.env.EFX_CHROMIUM,
   headless: true,
   args: ["--no-sandbox", "--disable-gpu"],
 })

--- a/scripts/probe-prod.mjs
+++ b/scripts/probe-prod.mjs
@@ -4,7 +4,7 @@ import { chromium } from "playwright-core"
 const URL = process.env.EFX_URL ?? "http://localhost:8765/"
 
 const browser = await chromium.launch({
-  executablePath: "/etc/profiles/per-user/mathieu/bin/chromium",
+  executablePath: process.env.EFX_CHROMIUM,
   headless: true,
   args: ["--no-sandbox", "--disable-gpu"],
 })

--- a/scripts/probe-todos.mjs
+++ b/scripts/probe-todos.mjs
@@ -1,7 +1,7 @@
 import { chromium } from "playwright-core"
 
 const browser = await chromium.launch({
-  executablePath: "/etc/profiles/per-user/mathieu/bin/chromium",
+  executablePath: process.env.EFX_CHROMIUM,
   headless: true,
   args: ["--no-sandbox", "--disable-gpu"],
 })

--- a/scripts/probe.mjs
+++ b/scripts/probe.mjs
@@ -3,7 +3,7 @@ import { chromium } from "playwright-core"
 import { writeFileSync } from "node:fs"
 
 const browser = await chromium.launch({
-  executablePath: "/etc/profiles/per-user/mathieu/bin/chromium",
+  executablePath: process.env.EFX_CHROMIUM,
   headless: true,
   args: ["--no-sandbox", "--disable-gpu"],
 })


### PR DESCRIPTION
## Summary
- Probe scripts no longer hardcode `/etc/profiles/per-user/mathieu/bin/chromium`. They read `process.env.EFX_CHROMIUM` instead; unset gives a clear "browser not found" error from `playwright-core`.
- `probe-hmr.mjs` resolves `Counter.efx` from `import.meta.url` rather than an absolute path under `/home/mathieu/playground/...` (which was wrong in *any* worktree, including this one).
- `scripts/AGENTS.md` documents the new convention.

## Test plan
- [ ] `EFX_CHROMIUM=/path/to/chromium node scripts/probe.mjs` runs against a live `pnpm dev`.
- [ ] `EFX_CHROMIUM=/path/to/chromium node scripts/probe-hmr.mjs` runs (and `Counter.efx` is restored after the run).
- [ ] Unset `EFX_CHROMIUM`: launch fails with a `playwright-core` "Executable doesn't exist" message — no path leak from the maintainer's machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)