### PR TITLE
chore: add flake.nix providing node + corepack + chromium devshell

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,6 +163,9 @@ compiler eats and converts into `h()` calls." Not the React thing.
   tsserver can `require()`.
 - No bundler in the framework itself; consumers bring Vite (or
   whatever) plus the Vite plugin.
+- Nix devshell (`flake.nix`) provides Node, Corepack (which resolves
+  pnpm via the `packageManager` field), and Chromium with
+  `EFX_CHROMIUM` pre-exported for the probe scripts.
 
 ## How to verify a change end-to-end
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ pnpm dev
 The demo exercises every primitive — counter, async data fetch, async-state
 pattern matching, keyed reactive list.
 
+On Nix, `nix develop` drops you into a shell with Node, Corepack (for
+`pnpm` via the `packageManager` field), and Chromium (with `EFX_CHROMIUM`
+pre-exported for the probe scripts).
+
 ## Smallest possible example
 
 ```tsx

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1779694939,
+        "narHash": "sha256-Ly4j75O8ICaSQx3uxPnwk2x7PMF0XQvn5r0c3yBA7FI=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "f9d8b65950353691ab56561e7c73d2e1063d810b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,26 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+  };
+  outputs = {nixpkgs, ...}: let
+    forAllSystems = function:
+      nixpkgs.lib.genAttrs nixpkgs.lib.systems.flakeExposed (
+        system: function nixpkgs.legacyPackages.${system}
+      );
+  in {
+    formatter = forAllSystems (pkgs: pkgs.alejandra);
+    devShells = forAllSystems (pkgs: {
+      default = pkgs.mkShell {
+        packages = with pkgs;
+          [
+            corepack
+            nodejs_24
+          ]
+          ++ lib.optionals stdenv.isLinux [chromium];
+        shellHook = pkgs.lib.optionalString pkgs.stdenv.isLinux ''
+          export EFX_CHROMIUM="${pkgs.chromium}/bin/chromium"
+        '';
+      };
+    });
+  };
+}


### PR DESCRIPTION
## Summary
- `nix develop` gives contributors Node 24, Corepack (resolves `pnpm` via the `packageManager` field), and Chromium with `EFX_CHROMIUM` pre-exported for the Playwright probe scripts.
- Style mirrors `refs/effect-smol/flake.nix`: plain `nixpkgs.lib.genAttrs` (no flake-utils dep), `nixpkgs-unstable`, `alejandra` for `nix fmt`.
- Chromium is `lib.optionals stdenv.isLinux`-gated so the flake still evaluates on darwin (where `pkgs.chromium` is not built). Darwin users would need to install Chrome separately and export `EFX_CHROMIUM` themselves.
- One-line mention in README's Quick Start and root AGENTS.md "Tooling at a glance".

## Test plan
- [x] `nix flake check --no-build` passes on x86_64-linux.
- [x] `nix develop -c bash -c 'node --version && corepack --version && which chromium'` resolves all three; `$EFX_CHROMIUM` points at the chromium store path.
- [x] `nix develop -c pnpm install` triggers corepack to download `pnpm@11.3.0` on first run; `pnpm typecheck` then passes across all 7 packages.
- [x] With `pnpm dev` running in the devshell, `node scripts/probe.mjs` drives Chromium via `$EFX_CHROMIUM`, increments the counter 0→3, resets to 0, and resolves the LiveUser async fetch (Ada Lovelace + 3 posts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)