### PR TITLE
chore: add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Every file in this repo is owned by @m9tdev.
+# Branch protection rules that require Code Owner review will demand
+# approval from @m9tdev on any PR touching matched paths.
+* @m9tdev


### PR DESCRIPTION
## Summary
- Adds `.github/CODEOWNERS` mapping all paths to `@m9tdev`.
- Pairs with the branch-protection rule just enabled on `main` (PR required, `ci` must pass, 0 approvals required). The file is documentation today; it becomes load-bearing if "Require review from Code Owners" is ever flipped on.

## Test plan
- [ ] `ci` workflow passes on this PR.
- [ ] After merge, confirm GitHub recognizes the owner on the Files-changed tab of a future PR (small "Owned by @m9tdev" indicator).