### PR TITLE
refactor(ts-plugin): introduce JsxTagProvider interface for testability

### DIFF
--- a/packages/language/src/index.ts
+++ b/packages/language/src/index.ts
@@ -1,3 +1,4 @@
 export { createEfxLanguagePlugin, type TypeScriptConfig } from "./language-plugin.ts"
 export { convertSourceMap } from "./source-map.ts"
 export { EfxVirtualCode, VirtualCodeRegistry } from "./virtual-code.ts"
+export type { JsxRange } from "@efx/compiler"

--- a/packages/ts-plugin/src/jsx-tags.test.ts
+++ b/packages/ts-plugin/src/jsx-tags.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest"
+import type { JsxRange } from "@efx/language"
+import { findJsxTagPair, type JsxTagProvider } from "./jsx-tags.ts"
+
+const mockProvider = (ranges: ReadonlyArray<JsxRange>): JsxTagProvider => ({
+  getJsxRanges: () => ranges,
+})
+
+describe("findJsxTagPair", () => {
+  it("returns null when provider has no ranges for the file", () => {
+    const provider: JsxTagProvider = { getJsxRanges: () => undefined }
+    expect(findJsxTagPair(provider, "test.efx", 5)).toBeNull()
+  })
+
+  it("returns null for empty ranges", () => {
+    const provider = mockProvider([])
+    expect(findJsxTagPair(provider, "test.efx", 5)).toBeNull()
+  })
+
+  it("skips fragments (no name to highlight)", () => {
+    const provider = mockProvider([
+      {
+        kind: "fragment",
+        start: 0,
+        end: 20,
+        openingTag: { start: 0, end: 2 },
+        closingTag: { start: 17, end: 20 },
+      },
+    ])
+    expect(findJsxTagPair(provider, "test.efx", 1)).toBeNull()
+  })
+
+  it("returns tag pair when cursor is on opening tag name", () => {
+    // <div>...</div>
+    // 01234    ^cursor on 'd'
+    const provider = mockProvider([
+      {
+        kind: "element",
+        start: 0,
+        end: 14,
+        isSelfClosing: false,
+        openingTag: { start: 0, end: 5, nameStart: 1, nameEnd: 4 },
+        closingTag: { start: 8, end: 14, nameStart: 10, nameEnd: 13 },
+      },
+    ])
+    const result = findJsxTagPair(provider, "test.efx", 1)
+    expect(result).toEqual({
+      current: { start: 1, length: 3 },
+      partner: { start: 10, length: 3 },
+    })
+  })
+
+  it("returns tag pair when cursor is on closing tag", () => {
+    const provider = mockProvider([
+      {
+        kind: "element",
+        start: 0,
+        end: 14,
+        isSelfClosing: false,
+        openingTag: { start: 0, end: 5, nameStart: 1, nameEnd: 4 },
+        closingTag: { start: 8, end: 14, nameStart: 10, nameEnd: 13 },
+      },
+    ])
+    const result = findJsxTagPair(provider, "test.efx", 10)
+    expect(result).toEqual({
+      current: { start: 10, length: 3 },
+      partner: { start: 1, length: 3 },
+    })
+  })
+
+  it("returns null for self-closing tags (no partner)", () => {
+    // <div />
+    const provider = mockProvider([
+      {
+        kind: "element",
+        start: 0,
+        end: 7,
+        isSelfClosing: true,
+        openingTag: { start: 0, end: 7, nameStart: 1, nameEnd: 4 },
+      },
+    ])
+    expect(findJsxTagPair(provider, "test.efx", 1)).toBeNull()
+  })
+
+  it("returns null when cursor is on attributes (not tag name or brackets)", () => {
+    // <div class="x">
+    // 0123456789...
+    // attributes start at 5, end before the >
+    const provider = mockProvider([
+      {
+        kind: "element",
+        start: 0,
+        end: 25,
+        isSelfClosing: false,
+        openingTag: { start: 0, end: 15, nameStart: 1, nameEnd: 4 },
+        closingTag: { start: 18, end: 25, nameStart: 20, nameEnd: 23 },
+      },
+    ])
+    // Position 6 is in "class" attribute area
+    expect(findJsxTagPair(provider, "test.efx", 6)).toBeNull()
+  })
+
+  it("returns tag pair when cursor is on opening bracket <", () => {
+    const provider = mockProvider([
+      {
+        kind: "element",
+        start: 0,
+        end: 14,
+        isSelfClosing: false,
+        openingTag: { start: 0, end: 5, nameStart: 1, nameEnd: 4 },
+        closingTag: { start: 8, end: 14, nameStart: 10, nameEnd: 13 },
+      },
+    ])
+    const result = findJsxTagPair(provider, "test.efx", 0)
+    expect(result).toEqual({
+      current: { start: 1, length: 3 },
+      partner: { start: 10, length: 3 },
+    })
+  })
+})

--- a/packages/ts-plugin/src/jsx-tags.ts
+++ b/packages/ts-plugin/src/jsx-tags.ts
@@ -1,8 +1,17 @@
-import type { VirtualCodeRegistry } from "@efx/language"
+import type { JsxRange } from "@efx/language"
 
 export interface NameSpan {
   readonly start: number
   readonly length: number
+}
+
+/**
+ * Provides JSX range data for a `.efx` file. Abstracts how ranges are stored
+ * (registry, in-memory map, etc.) so `findJsxTagPair` can be tested and reused
+ * without coupling to a specific cache implementation.
+ */
+export interface JsxTagProvider {
+  getJsxRanges(efxPath: string): ReadonlyArray<JsxRange> | undefined
 }
 
 /**
@@ -19,16 +28,19 @@ export interface NameSpan {
  *   - NOT on attributes (e.g. inside `class="x"`)
  *
  * Fragments (`<>...</>`) have no names — skipped.
+ *
+ * Callers should gate on `.efx` files before calling — this function doesn't
+ * validate the file extension.
  */
 export function findJsxTagPair(
-  registry: VirtualCodeRegistry,
+  provider: JsxTagProvider,
   efxPath: string,
   position: number,
 ): { current: NameSpan; partner: NameSpan } | null {
-  const vc = registry.get(efxPath)
-  if (!vc) return null
+  const ranges = provider.getJsxRanges(efxPath)
+  if (!ranges) return null
 
-  for (const r of vc.jsxRanges) {
+  for (const r of ranges) {
     if (r.kind === "fragment") continue
 
     // On the opening tag?

--- a/packages/ts-plugin/src/service-proxy.ts
+++ b/packages/ts-plugin/src/service-proxy.ts
@@ -1,13 +1,17 @@
 import { createLanguageServicePlugin } from "@volar/typescript/lib/quickstart/createLanguageServicePlugin"
 import type * as ts from "typescript"
 import { createEfxLanguagePlugin, VirtualCodeRegistry } from "@efx/language"
-import { findJsxTagPair } from "./jsx-tags.ts"
+import { findJsxTagPair, type JsxTagProvider } from "./jsx-tags.ts"
 import { classifyRefs } from "./classify-references.ts"
 
 // One registry per tsserver session. tsserver loads this plugin module once,
 // so this single instance is the cache for the editor's lifetime — and is
-// passed to both the LanguagePlugin (writer) and findJsxTagPair (reader).
+// passed to both the LanguagePlugin (writer) and the JsxTagProvider (reader).
 const registry = new VirtualCodeRegistry()
+
+const jsxTagProvider: JsxTagProvider = {
+  getJsxRanges: (efxPath) => registry.get(efxPath)?.jsxRanges,
+}
 
 // tsserver identifies scripts by file path strings — asFileName is identity.
 const efxLanguagePlugin = createEfxLanguagePlugin<string>((scriptId) => scriptId, registry)
@@ -110,7 +114,7 @@ export const pluginFactory: ts.server.PluginModuleFactory = (modules) => {
               }
 
               // JSX tag-pair highlight, backed by compiler jsxRanges
-              const pair = findJsxTagPair(registry, fileName, position)
+              const pair = findJsxTagPair(jsxTagProvider, fileName, position)
               if (pair) {
                 return [{
                   fileName,


### PR DESCRIPTION
## Summary
- Introduce `JsxTagProvider` interface to decouple `findJsxTagPair` from `VirtualCodeRegistry`
- Re-export `JsxRange` type from `@efx/language` for downstream consumers
- Add comprehensive unit tests for `findJsxTagPair` covering tag detection, fragments, self-closing tags, and edge cases

## Test plan
- [x] `pnpm --filter @efx/ts-plugin test` — all 16 tests pass
- [x] `pnpm -r typecheck` — passes across all packages
- [x] Integration test confirms end-to-end behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)