### PR TITLE
refactor(runtime): use Effect's AtomRef.TypeId for the brand check

### DIFF
--- a/packages/runtime/AGENTS.md
+++ b/packages/runtime/AGENTS.md
@@ -30,8 +30,8 @@ the editor margin. If you rename them, update the regex.
 
 | File | Purpose |
 |---|---|
-| `src/h.ts` | `h()` factory + `track`/`read`/`peek` reactivity-tracking machinery. Re-exports `isAtomRef` from `coerce.ts` for back-compat |
-| `src/coerce.ts` | `coerceAsync` (any child shape → `Effect<View>`) and `coerceSync` (render-time emission → `View`). Internal; not re-exported from `index.ts`. Also owns `isAtomRef` / `ATOM_REF_TYPE_ID` |
+| `src/h.ts` | `h()` factory + `track`/`read`/`peek` reactivity-tracking machinery |
+| `src/coerce.ts` | `coerceAsync` (any child shape → `Effect<View>`) and `coerceSync` (render-time emission → `View`). Internal; not re-exported from `index.ts`. Owns `isAtomRef` (brand check against `AtomRef.TypeId` from `effect/unstable/reactivity`) |
 | `src/View.ts` | `View` IR (intermediate representation) — hand-written union of 6 named interfaces (`ViewText`, `ViewElement`, `ViewFragment`, `ViewReactive`, `ViewList`, `ViewEmpty`); constructors via `Data.taggedEnum<View>()`. The normalized DOM-materialization shape `mount` switches on. Plus `isView`, `VIEW_TAGS` |
 | `src/mount.ts` | DOM renderer. `buildDom(View, registry) → { node, cleanup }`, `mount(app, el)` |
 | `src/index.ts` | Public exports + `list`, `Fragment`, `EfxLive` |

--- a/packages/runtime/src/coerce.ts
+++ b/packages/runtime/src/coerce.ts
@@ -3,10 +3,8 @@ import { Atom, AtomRef } from "effect/unstable/reactivity"
 import type { ChildE, ChildR } from "./types/Fold.ts"
 import { isView, View } from "./View.ts"
 
-export const ATOM_REF_TYPE_ID = "~effect/reactivity/AtomRef"
-
 export const isAtomRef = (u: unknown): u is AtomRef.ReadonlyRef<unknown> =>
-  typeof u === "object" && u !== null && ATOM_REF_TYPE_ID in u
+  typeof u === "object" && u !== null && AtomRef.TypeId in u
 
 const Empty = View.Empty()
 

--- a/packages/runtime/src/h.ts
+++ b/packages/runtime/src/h.ts
@@ -4,8 +4,6 @@ import { coerceAsync, isAtomRef } from "./coerce.ts"
 import type { FoldE, FoldR, TagE, TagProps, TagR } from "./types/Fold.ts"
 import { type Props, View } from "./View.ts"
 
-export { isAtomRef }
-
 // ─── Tracking scope for h.track / h.read ─────────────────────────────────
 //
 // When the compiler wraps a JSX expression in `h.track(() => ...)`, that


### PR DESCRIPTION
## Summary

- Replace the hand-rolled `ATOM_REF_TYPE_ID = "~effect/reactivity/AtomRef"` magic string in `packages/runtime/src/coerce.ts` with a direct check against `AtomRef.TypeId` (exported from `effect/unstable/reactivity`). Stops mirroring an Effect internal by hand.
- Drop the `export { isAtomRef }` re-export from `packages/runtime/src/h.ts`. The predicate is not part of the public `@efx/runtime` surface (`src/index.ts` doesn't re-export it), and the three internal callers (`coerce.ts`, `h.ts`, `mount.ts`) all import it from `coerce.ts` directly.
- Refresh the `packages/runtime/AGENTS.md` files table to reflect the new shape — drop the back-compat re-export note and the `ATOM_REF_TYPE_ID` mention; note that `isAtomRef` checks for `AtomRef.TypeId`.

Net diff: 3 files, +3/-7. No behavioral change — the brand string is byte-for-byte identical, sourced from Effect instead of declared locally.

## Test plan

- [x] `pnpm --filter @efx/runtime test` — 38/38 (includes the 5 `isAtomRef` predicate pins at `coerce.test.ts:208-218`).
- [x] `pnpm -r test` — compiler 45, runtime 38, language 16, ts-plugin 8, check passes.
- [x] `pnpm -r typecheck` — 7/7 packages clean; `apps/demo` via `@efx/check` 0 errors.
- [x] `scripts/probe.mjs` — Counter `AtomRef` increments + UserPage `Atom`/`AsyncResult` resolve.
- [x] `scripts/probe-todos.mjs` — AtomRef.Collection identity reconciliation intact: toggling row #2 leaves row #1's tagged DOM node in place (no full rebuild); add/remove update counts as expected.