### PR TITLE
refactor(scripts): collapse Playwright probes through shared harness

### DIFF
--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -14,7 +14,7 @@ re-renders when you click +".
 | `probe.mjs` | Counter increments; UserPage's async fetch resolves; screenshots saved to `/tmp/efx-verify/`. |
 | `probe-liveuser.mjs` | `Atom` + `AsyncResult` cycles Initial → Success → Failure → recovery as the user clicks the LiveUser actions. |
 | `probe-todos.mjs` | Keyed reactive list: add/remove/toggle a row leaves sibling DOM nodes untouched (tagged-node identity check). |
-| `probe-lifecycle.mjs` | Per-component lifecycle scope: `Effect.acquireRelease` inside a row component fires its release when the row is removed. The red-test for `mount`'s per-row `Scope`. |
+| `probe-lifecycle.mjs` | Per-component lifecycle scope, three phases: (1) initial mount-event count, (2) removing a row fires its matching unmount via `Scope.closeUnsafe`, (3) full teardown via `__teardown` cascades through every row scope so every outstanding mount has a matching unmount. |
 | `probe-hmr.mjs` | Vite HMR on a `.efx` edit propagates without a full reload. |
 | `probe-prod.mjs` | Production bundle (built via `pnpm build`) is interactive end-to-end on port 8765. |
 
@@ -23,6 +23,33 @@ browser." If you change anything in `mount`, `coerce`, the compiler's
 output shape, or the Vite plugin, run the relevant probe before
 declaring the change good. Type checks won't catch render-path
 regressions.
+
+## Probe shape: harness + spec
+
+Every probe is split in two:
+
+- **`probe-harness.mjs`** — owns the boilerplate every probe shares:
+  chromium launch, context + viewport, the default `pageerror`
+  listener, `page.goto(..., { waitUntil: "networkidle" })`, and
+  `browser.close()` in a `finally` block. Exports `runProbe({ url,
+  viewport, onConsole, onPageError, run })`; returns whatever `run`
+  returns so specs can hoist values out for post-close assertions
+  (see `probe-lifecycle.mjs`).
+- **`probe-*.mjs`** — the **spec**: per-probe assertions inside the
+  `run(page, ctx)` callback. Defaults: `url` is
+  `http://localhost:5173/`, `viewport` is `900×1100`, `pageerror`
+  logs to stderr. Override any per-spec (e.g. `probe-prod.mjs` sets
+  `url` from `EFX_URL`; `probe.mjs` redirects both `onConsole` and
+  `onPageError` into a buffer for `/tmp/efx-verify/console.log`).
+
+The harness does **not** force an exit-code or terminator convention.
+Some specs end with `console.log("DONE")`, `probe-lifecycle.mjs`
+prints `PASS` / `FAIL`, `probe-hmr.mjs` prints `HMR PASS` / `HMR FAIL`
+and `process.exit(0|1)`. The spec decides.
+
+Specs that mutate repo files (e.g. `probe-hmr.mjs` editing
+`Counter.efx`) wrap `runProbe` in their own `try/finally` for cleanup.
+The harness's `finally` only closes the browser.
 
 ## Compiler smoke test
 

--- a/scripts/probe-harness.mjs
+++ b/scripts/probe-harness.mjs
@@ -1,0 +1,26 @@
+// Shared Playwright harness for probe-*.mjs specs.
+import { chromium } from "playwright-core"
+
+export async function runProbe({
+  url = "http://localhost:5173/",
+  viewport = { width: 900, height: 1100 },
+  onConsole,
+  onPageError = (e) => console.error("[pageerror]", e.message),
+  run,
+}) {
+  const browser = await chromium.launch({
+    executablePath: process.env.EFX_CHROMIUM,
+    headless: true,
+    args: ["--no-sandbox", "--disable-gpu"],
+  })
+  try {
+    const ctx = await browser.newContext({ viewport })
+    const page = await ctx.newPage()
+    page.on("pageerror", onPageError)
+    if (onConsole) page.on("console", onConsole)
+    await page.goto(url, { waitUntil: "networkidle" })
+    return await run(page, ctx)
+  } finally {
+    await browser.close()
+  }
+}

--- a/scripts/probe-hmr.mjs
+++ b/scripts/probe-hmr.mjs
@@ -1,49 +1,45 @@
 // HMR probe: open the demo, edit Counter.efx in place, confirm the change
 // appears in the browser without manual reload.
-import { chromium } from "playwright-core"
 import { readFileSync, writeFileSync } from "node:fs"
 import { fileURLToPath } from "node:url"
 import { dirname, resolve } from "node:path"
+import { runProbe } from "./probe-harness.mjs"
 
 const COUNTER_PATH = resolve(
   dirname(fileURLToPath(import.meta.url)),
   "../apps/demo/src/Counter.efx",
 )
 
-const browser = await chromium.launch({
-  executablePath: process.env.EFX_CHROMIUM,
-  headless: true,
-  args: ["--no-sandbox", "--disable-gpu"],
-})
-const ctx = await browser.newContext({ viewport: { width: 900, height: 700 } })
-const page = await ctx.newPage()
-page.on("pageerror", (e) => console.error("[pageerror]", e.message))
-
-await page.goto("http://localhost:5173/", { waitUntil: "networkidle" })
-await page.waitForSelector(".counter")
-
-const initialText = await page.locator(".counter .count").innerText()
-console.log("initial text:", JSON.stringify(initialText))
-
-// Mutate the .efx file: change "clicks" to "CLICKED"
 const original = readFileSync(COUNTER_PATH, "utf8")
-const mutated = original.replace("clicks:", "CLICKED:")
-writeFileSync(COUNTER_PATH, mutated, "utf8")
 
-// Wait for Vite HMR to propagate
-await page.waitForFunction(
-  () => document.querySelector(".counter .count")?.textContent?.includes("CLICKED"),
-  { timeout: 5000 },
-).catch(() => null)
+let afterEdit
+try {
+  await runProbe({
+    viewport: { width: 900, height: 700 },
+    run: async (page) => {
+      await page.waitForSelector(".counter")
 
-const afterEdit = await page.locator(".counter .count").innerText()
-console.log("after edit text:", JSON.stringify(afterEdit))
+      const initialText = await page.locator(".counter .count").innerText()
+      console.log("initial text:", JSON.stringify(initialText))
 
-// Restore the file
-writeFileSync(COUNTER_PATH, original, "utf8")
+      // Mutate the .efx file: change "clicks" to "CLICKED"
+      writeFileSync(COUNTER_PATH, original.replace("clicks:", "CLICKED:"), "utf8")
 
-await browser.close()
+      // Wait for Vite HMR to propagate
+      await page.waitForFunction(
+        () => document.querySelector(".counter .count")?.textContent?.includes("CLICKED"),
+        { timeout: 5000 },
+      ).catch(() => null)
 
-const ok = afterEdit.includes("CLICKED")
+      afterEdit = await page.locator(".counter .count").innerText()
+      console.log("after edit text:", JSON.stringify(afterEdit))
+    },
+  })
+} finally {
+  // Restore the file even if the probe (or harness) threw.
+  writeFileSync(COUNTER_PATH, original, "utf8")
+}
+
+const ok = afterEdit?.includes("CLICKED")
 console.log(ok ? "HMR PASS" : "HMR FAIL")
 process.exit(ok ? 0 : 1)

--- a/scripts/probe-lifecycle.mjs
+++ b/scripts/probe-lifecycle.mjs
@@ -7,52 +7,46 @@
 //      closing the program scope). The parent-fork cascade closes every
 //      remaining row scope: every outstanding mount must have a matching
 //      unmount afterwards.
-import { chromium } from "playwright-core"
+import { runProbe } from "./probe-harness.mjs"
 
-const URL = process.env.EFX_URL ?? "http://localhost:5173/"
+const { initial, afterAdd, afterRemove, beforeTeardown, afterTeardown } = await runProbe({
+  url: process.env.EFX_URL ?? "http://localhost:5173/",
+  viewport: { width: 900, height: 1400 },
+  run: async (page) => {
+    await page.waitForSelector(".lifecycle")
 
-const browser = await chromium.launch({
-  executablePath: process.env.EFX_CHROMIUM,
-  headless: true,
-  args: ["--no-sandbox", "--disable-gpu"],
+    const read = () => page.evaluate(() => window.__lifecycle ?? [])
+
+    const initial = await read()
+    console.log("initial:", initial)
+
+    await page.locator(".lifecycle button", { hasText: "add row" }).click()
+    await page.waitForTimeout(50)
+    const afterAdd = await read()
+    console.log("after add:", afterAdd)
+
+    await page.locator(".lifecycle button", { hasText: "remove last" }).click()
+    await page.waitForTimeout(50)
+    const afterRemove = await read()
+    console.log("after remove:", afterRemove)
+
+    // Phase 3: leave several rows mounted, trigger full teardown via __teardown.
+    // The fork-cascade through every row scope should fire each remaining
+    // row's unmount.
+    await page.locator(".lifecycle button", { hasText: "add row" }).click()
+    await page.locator(".lifecycle button", { hasText: "add row" }).click()
+    await page.waitForTimeout(50)
+    const beforeTeardown = await read()
+    console.log("before teardown:", beforeTeardown)
+
+    await page.evaluate(() => globalThis.__teardown?.())
+    await page.waitForTimeout(100)
+    const afterTeardown = await read()
+    console.log("after teardown:", afterTeardown)
+
+    return { initial, afterAdd, afterRemove, beforeTeardown, afterTeardown }
+  },
 })
-const ctx = await browser.newContext({ viewport: { width: 900, height: 1400 } })
-const page = await ctx.newPage()
-page.on("pageerror", (e) => console.error("[pageerror]", e.message))
-
-await page.goto(URL, { waitUntil: "networkidle" })
-await page.waitForSelector(".lifecycle")
-
-const read = () => page.evaluate(() => window.__lifecycle ?? [])
-
-const initial = await read()
-console.log("initial:", initial)
-
-await page.locator(".lifecycle button", { hasText: "add row" }).click()
-await page.waitForTimeout(50)
-const afterAdd = await read()
-console.log("after add:", afterAdd)
-
-await page.locator(".lifecycle button", { hasText: "remove last" }).click()
-await page.waitForTimeout(50)
-const afterRemove = await read()
-console.log("after remove:", afterRemove)
-
-// Phase 3: leave several rows mounted, trigger full teardown via __teardown.
-// The fork-cascade through every row scope should fire each remaining
-// row's unmount.
-await page.locator(".lifecycle button", { hasText: "add row" }).click()
-await page.locator(".lifecycle button", { hasText: "add row" }).click()
-await page.waitForTimeout(50)
-const beforeTeardown = await read()
-console.log("before teardown:", beforeTeardown)
-
-await page.evaluate(() => globalThis.__teardown?.())
-await page.waitForTimeout(100)
-const afterTeardown = await read()
-console.log("after teardown:", afterTeardown)
-
-await browser.close()
 
 // Assertions
 const failures = []

--- a/scripts/probe-liveuser.mjs
+++ b/scripts/probe-liveuser.mjs
@@ -1,46 +1,39 @@
-import { chromium } from "playwright-core"
+import { runProbe } from "./probe-harness.mjs"
 
-const browser = await chromium.launch({
-  executablePath: process.env.EFX_CHROMIUM,
-  headless: true,
-  args: ["--no-sandbox", "--disable-gpu"],
+await runProbe({
+  viewport: { width: 900, height: 1300 },
+  run: async (page) => {
+    await page.waitForSelector(".live-user")
+
+    // Initial state — should show Ada
+    let live = await page.locator(".live-user .user-card strong").innerText()
+    console.log("initial:", live)
+
+    await page.screenshot({ path: "/tmp/efx-verify/04-live-initial.png" })
+
+    // Click Grace (7)
+    await page.locator(".live-user button", { hasText: "Grace (7)" }).click()
+    await page.waitForTimeout(400)
+    live = await page.locator(".live-user .user-card strong").innerText()
+    console.log("after Grace click:", live)
+    await page.screenshot({ path: "/tmp/efx-verify/05-live-grace.png" })
+
+    // Click Bad id — should produce a failure state, no .user-card
+    await page.locator(".live-user button", { hasText: "Bad id" }).click()
+    await page.waitForTimeout(400)
+    const errEl = await page.locator(".live-user .error").count()
+    console.log("error state visible:", errEl > 0)
+    const errText = errEl > 0 ? await page.locator(".live-user .error").first().innerText() : "(no error element)"
+    console.log("error text:", errText.slice(0, 80))
+    await page.screenshot({ path: "/tmp/efx-verify/06-live-error.png" })
+
+    // Click Ada (42) again — should recover to success
+    await page.locator(".live-user button", { hasText: "Ada (42)" }).click()
+    await page.waitForTimeout(400)
+    live = await page.locator(".live-user .user-card strong").innerText().catch(() => "(none)")
+    console.log("after Ada recovery:", live)
+    await page.screenshot({ path: "/tmp/efx-verify/07-live-recover.png" })
+  },
 })
 
-const ctx = await browser.newContext({ viewport: { width: 900, height: 1300 } })
-const page = await ctx.newPage()
-page.on("pageerror", (e) => console.error("[pageerror]", e.message))
-
-await page.goto("http://localhost:5173/", { waitUntil: "networkidle" })
-await page.waitForSelector(".live-user")
-
-// Initial state — should show Ada
-let live = await page.locator(".live-user .user-card strong").innerText()
-console.log("initial:", live)
-
-await page.screenshot({ path: "/tmp/efx-verify/04-live-initial.png" })
-
-// Click Grace (7)
-await page.locator(".live-user button", { hasText: "Grace (7)" }).click()
-await page.waitForTimeout(400)
-live = await page.locator(".live-user .user-card strong").innerText()
-console.log("after Grace click:", live)
-await page.screenshot({ path: "/tmp/efx-verify/05-live-grace.png" })
-
-// Click Bad id — should produce a failure state, no .user-card
-await page.locator(".live-user button", { hasText: "Bad id" }).click()
-await page.waitForTimeout(400)
-const errEl = await page.locator(".live-user .error").count()
-console.log("error state visible:", errEl > 0)
-const errText = errEl > 0 ? await page.locator(".live-user .error").first().innerText() : "(no error element)"
-console.log("error text:", errText.slice(0, 80))
-await page.screenshot({ path: "/tmp/efx-verify/06-live-error.png" })
-
-// Click Ada (42) again — should recover to success
-await page.locator(".live-user button", { hasText: "Ada (42)" }).click()
-await page.waitForTimeout(400)
-live = await page.locator(".live-user .user-card strong").innerText().catch(() => "(none)")
-console.log("after Ada recovery:", live)
-await page.screenshot({ path: "/tmp/efx-verify/07-live-recover.png" })
-
-await browser.close()
 console.log("DONE")

--- a/scripts/probe-prod.mjs
+++ b/scripts/probe-prod.mjs
@@ -1,39 +1,32 @@
 // Verifies the production bundle works end-to-end (port 8765).
-import { chromium } from "playwright-core"
+import { runProbe } from "./probe-harness.mjs"
 
-const URL = process.env.EFX_URL ?? "http://localhost:8765/"
+await runProbe({
+  url: process.env.EFX_URL ?? "http://localhost:8765/",
+  viewport: { width: 900, height: 1400 },
+  run: async (page) => {
+    await page.waitForSelector(".todos ul")
 
-const browser = await chromium.launch({
-  executablePath: process.env.EFX_CHROMIUM,
-  headless: true,
-  args: ["--no-sandbox", "--disable-gpu"],
+    // Counter
+    const plus = page.locator(".counter button").first()
+    await plus.click(); await plus.click(); await plus.click()
+    const counterText = await page.locator(".counter .count").innerText()
+    console.log("counter after 3 clicks:", counterText.trim())
+
+    // LiveUser
+    await page.locator(".live-user button", { hasText: "Grace (7)" }).click()
+    await page.waitForTimeout(300)
+    const liveUser = await page.locator(".live-user .user-card strong").innerText()
+    console.log("liveuser after Grace:", liveUser)
+
+    // Todos
+    const todoCount = await page.locator(".todos ul li").count()
+    await page.locator(".todos ul li").nth(1).locator(".toggle").click()
+    await page.waitForTimeout(50)
+    const toggledClass = await page.locator(".todos ul li").nth(1).getAttribute("class")
+    console.log("todos initial count:", todoCount)
+    console.log("todos #2 class after toggle:", toggledClass)
+  },
 })
-const ctx = await browser.newContext({ viewport: { width: 900, height: 1400 } })
-const page = await ctx.newPage()
-page.on("pageerror", (e) => console.error("[pageerror]", e.message))
 
-await page.goto(URL, { waitUntil: "networkidle" })
-await page.waitForSelector(".todos ul")
-
-// Counter
-const plus = page.locator(".counter button").first()
-await plus.click(); await plus.click(); await plus.click()
-const counterText = await page.locator(".counter .count").innerText()
-console.log("counter after 3 clicks:", counterText.trim())
-
-// LiveUser
-await page.locator(".live-user button", { hasText: "Grace (7)" }).click()
-await page.waitForTimeout(300)
-const liveUser = await page.locator(".live-user .user-card strong").innerText()
-console.log("liveuser after Grace:", liveUser)
-
-// Todos
-const todoCount = await page.locator(".todos ul li").count()
-await page.locator(".todos ul li").nth(1).locator(".toggle").click()
-await page.waitForTimeout(50)
-const toggledClass = await page.locator(".todos ul li").nth(1).getAttribute("class")
-console.log("todos initial count:", todoCount)
-console.log("todos #2 class after toggle:", toggledClass)
-
-await browser.close()
 console.log("DONE")

--- a/scripts/probe-todos.mjs
+++ b/scripts/probe-todos.mjs
@@ -1,61 +1,55 @@
-import { chromium } from "playwright-core"
+import { runProbe } from "./probe-harness.mjs"
 
-const browser = await chromium.launch({
-  executablePath: process.env.EFX_CHROMIUM,
-  headless: true,
-  args: ["--no-sandbox", "--disable-gpu"],
+await runProbe({
+  viewport: { width: 900, height: 1500 },
+  onConsole: (m) => { if (m.type() === "error") console.error("[console]", m.text()) },
+  run: async (page) => {
+    await page.waitForSelector(".todos ul")
+
+    const list = page.locator(".todos ul li")
+
+    console.log("initial item count:", await list.count())
+    const initialTexts = await list.locator(".text").allInnerTexts()
+    console.log("initial texts:", initialTexts)
+    console.log("initial remaining:", (await page.locator(".todos .remaining").innerText()).trim())
+
+    await page.screenshot({ path: "/tmp/efx-verify/08-todos-initial.png" })
+
+    // Capture the DOM node of the first item BEFORE we touch anything else,
+    // so we can confirm later that toggling didn't replace it.
+    const firstNodeId = await list.first().evaluate((el) => {
+      el.setAttribute("data-probe-id", "first-row")
+      return el.getAttribute("data-probe-id")
+    })
+    console.log("tagged first row:", firstNodeId)
+
+    // Toggle the second item (index 1 — "use it for something")
+    await list.nth(1).locator(".toggle").click()
+    await page.waitForTimeout(50)
+    const secondClass = await list.nth(1).getAttribute("class")
+    console.log("after toggling #2, its class:", secondClass)
+    console.log("remaining after toggle:", (await page.locator(".todos .remaining").innerText()).trim())
+
+    // Verify first row's DOM node was NOT touched
+    const firstStillTagged = await list.first().getAttribute("data-probe-id")
+    console.log("first row still tagged (proves no full rebuild):", firstStillTagged === "first-row")
+
+    // Add a todo
+    await page.locator(".todos .controls button", { hasText: "add todo" }).click()
+    await page.waitForTimeout(50)
+    console.log("after add, item count:", await list.count())
+    const addedText = await list.last().locator(".text").innerText()
+    console.log("added text:", addedText)
+
+    // Remove first item
+    await list.first().locator(".remove").click()
+    await page.waitForTimeout(50)
+    console.log("after remove first, item count:", await list.count())
+    const newFirstText = await list.first().locator(".text").innerText()
+    console.log("new first text:", newFirstText)
+
+    await page.screenshot({ path: "/tmp/efx-verify/09-todos-after.png" })
+  },
 })
-const ctx = await browser.newContext({ viewport: { width: 900, height: 1500 } })
-const page = await ctx.newPage()
-page.on("pageerror", (e) => console.error("[pageerror]", e.message))
-page.on("console", (m) => { if (m.type() === "error") console.error("[console]", m.text()) })
 
-await page.goto("http://localhost:5173/", { waitUntil: "networkidle" })
-await page.waitForSelector(".todos ul")
-
-const list = page.locator(".todos ul li")
-
-console.log("initial item count:", await list.count())
-const initialTexts = await list.locator(".text").allInnerTexts()
-console.log("initial texts:", initialTexts)
-console.log("initial remaining:", (await page.locator(".todos .remaining").innerText()).trim())
-
-await page.screenshot({ path: "/tmp/efx-verify/08-todos-initial.png" })
-
-// Capture the DOM node of the first item BEFORE we touch anything else,
-// so we can confirm later that toggling didn't replace it.
-const firstNodeId = await list.first().evaluate((el) => {
-  el.setAttribute("data-probe-id", "first-row")
-  return el.getAttribute("data-probe-id")
-})
-console.log("tagged first row:", firstNodeId)
-
-// Toggle the second item (index 1 — "use it for something")
-await list.nth(1).locator(".toggle").click()
-await page.waitForTimeout(50)
-const secondClass = await list.nth(1).getAttribute("class")
-console.log("after toggling #2, its class:", secondClass)
-console.log("remaining after toggle:", (await page.locator(".todos .remaining").innerText()).trim())
-
-// Verify first row's DOM node was NOT touched
-const firstStillTagged = await list.first().getAttribute("data-probe-id")
-console.log("first row still tagged (proves no full rebuild):", firstStillTagged === "first-row")
-
-// Add a todo
-await page.locator(".todos .controls button", { hasText: "add todo" }).click()
-await page.waitForTimeout(50)
-console.log("after add, item count:", await list.count())
-const addedText = await list.last().locator(".text").innerText()
-console.log("added text:", addedText)
-
-// Remove first item
-await list.first().locator(".remove").click()
-await page.waitForTimeout(50)
-console.log("after remove first, item count:", await list.count())
-const newFirstText = await list.first().locator(".text").innerText()
-console.log("new first text:", newFirstText)
-
-await page.screenshot({ path: "/tmp/efx-verify/09-todos-after.png" })
-
-await browser.close()
 console.log("DONE")

--- a/scripts/probe.mjs
+++ b/scripts/probe.mjs
@@ -1,54 +1,47 @@
 // Drive the demo with Playwright to verify reactivity + capture screenshots.
-import { chromium } from "playwright-core"
 import { writeFileSync } from "node:fs"
-
-const browser = await chromium.launch({
-  executablePath: process.env.EFX_CHROMIUM,
-  headless: true,
-  args: ["--no-sandbox", "--disable-gpu"],
-})
-
-const ctx = await browser.newContext({ viewport: { width: 900, height: 1100 } })
-const page = await ctx.newPage()
+import { runProbe } from "./probe-harness.mjs"
 
 const consoleLog = []
-page.on("console", (m) => consoleLog.push(`[${m.type()}] ${m.text()}`))
-page.on("pageerror", (e) => consoleLog.push(`[pageerror] ${e.message}`))
 
-await page.goto("http://localhost:5173/", { waitUntil: "networkidle" })
-// Wait for the async fetch + Counter to render
-await page.waitForSelector(".user-page h1")
-await page.waitForSelector(".counter")
+await runProbe({
+  viewport: { width: 900, height: 1100 },
+  onConsole: (m) => consoleLog.push(`[${m.type()}] ${m.text()}`),
+  onPageError: (e) => consoleLog.push(`[pageerror] ${e.message}`),
+  run: async (page) => {
+    // Wait for the async fetch + Counter to render
+    await page.waitForSelector(".user-page h1")
+    await page.waitForSelector(".counter")
 
-await page.screenshot({ path: "/tmp/efx-verify/00-initial.png" })
+    await page.screenshot({ path: "/tmp/efx-verify/00-initial.png" })
 
-const countBefore = await page.locator(".counter .count").innerText()
-console.log("count before:", JSON.stringify(countBefore))
+    const countBefore = await page.locator(".counter .count").innerText()
+    console.log("count before:", JSON.stringify(countBefore))
 
-// Click the [+] button three times
-const plusBtn = page.locator(".counter button").first()
-await plusBtn.click()
-await plusBtn.click()
-await plusBtn.click()
+    // Click the [+] button three times
+    const plusBtn = page.locator(".counter button").first()
+    await plusBtn.click()
+    await plusBtn.click()
+    await plusBtn.click()
 
-await page.screenshot({ path: "/tmp/efx-verify/01-after-3-clicks.png" })
-const countAfter3 = await page.locator(".counter .count").innerText()
-console.log("count after 3 clicks:", JSON.stringify(countAfter3))
+    await page.screenshot({ path: "/tmp/efx-verify/01-after-3-clicks.png" })
+    const countAfter3 = await page.locator(".counter .count").innerText()
+    console.log("count after 3 clicks:", JSON.stringify(countAfter3))
 
-// Click reset
-await page.locator(".counter button").nth(1).click()
-await page.waitForTimeout(50)
-const countAfterReset = await page.locator(".counter .count").innerText()
-console.log("count after reset:", JSON.stringify(countAfterReset))
-await page.screenshot({ path: "/tmp/efx-verify/02-after-reset.png" })
+    // Click reset
+    await page.locator(".counter button").nth(1).click()
+    await page.waitForTimeout(50)
+    const countAfterReset = await page.locator(".counter .count").innerText()
+    console.log("count after reset:", JSON.stringify(countAfterReset))
+    await page.screenshot({ path: "/tmp/efx-verify/02-after-reset.png" })
 
-// Dump UserPage content
-const userName = await page.locator(".user-page h1").innerText()
-const postCount = await page.locator(".user-page .posts li").count()
-console.log("user name:", JSON.stringify(userName))
-console.log("post count:", postCount)
+    // Dump UserPage content
+    const userName = await page.locator(".user-page h1").innerText()
+    const postCount = await page.locator(".user-page .posts li").count()
+    console.log("user name:", JSON.stringify(userName))
+    console.log("post count:", postCount)
+  },
+})
 
 writeFileSync("/tmp/efx-verify/console.log", consoleLog.join("\n"))
-
-await browser.close()
 console.log("DONE")


### PR DESCRIPTION
## Summary
- Extract shared Playwright boilerplate from the six `probe-*.mjs` scripts into a single `scripts/probe-harness.mjs` exposing `runProbe({ url, viewport, onConsole, onPageError, run })`. The `run(page, ctx)` callback returns whatever the spec wants — `probe-lifecycle.mjs` uses this to hoist five snapshots out for post-close assertions.
- Per-probe assertion logic, terminator conventions (`DONE`, `PASS`/`FAIL`, `HMR PASS`/`HMR FAIL`), and exit-code handling are unchanged. The harness only owns chromium launch + context + `goto` + `close`.
- `probe-hmr.mjs` wraps `runProbe` in an outer `try/finally` so `apps/demo/src/Counter.efx` is restored even when the harness throws (the harness's own `finally` only closes the browser).
- `scripts/AGENTS.md` documents the new harness/spec convention and refreshes the `probe-lifecycle.mjs` table row to mention all three phases (PR #25 added Phase 3 without updating the description).

Net diff: +269 / -253 across 8 files. The savings concentrate the ~25 LOC of chromium boilerplate that each probe was repeating — per-spec drops 4–7 LOC each.

## Test plan
- [x] All six probes pass against `pnpm --filter @efx/demo dev` on `:5173`. `probe-prod.mjs` verified against `vite preview --port 8766` with `EFX_URL=http://localhost:8766/`.
- [x] `probe-lifecycle.mjs` returns `0` on PASS; Phase 3 cascade fires 5 unmounts for 5 outstanding mounts in correct LIFO order (`unmount:5,4,2,1`).
- [x] `probe-hmr.mjs` returns `0` on `HMR PASS`; `git diff apps/demo/src/Counter.efx` clean afterwards.
- [x] `node --check` clean on all 7 `scripts/probe*.mjs` files.

## Follow-ups (out of scope for this PR)
- `apps/demo/package.json` has no `preview` script, so the documented `pnpm --filter @efx/demo preview --port 8765` errors with `ERR_PNPM_RECURSIVE_RUN_NO_SCRIPT`. Adding `\"preview\": \"vite preview\"` would make the verification flow Just Work.