### PR TITLE
chore(demo): add preview script

### DIFF
--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "preview": "vite preview",
     "typecheck": "node --experimental-strip-types ../../packages/check/src/cli.ts"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- Add `"preview": "vite preview"` to `apps/demo/package.json`. The documented `probe-prod.mjs` verification flow (`scripts/AGENTS.md`) calls `pnpm --filter @efx/demo preview --port 8765`, but the script was missing — it errored with `ERR_PNPM_RECURSIVE_RUN_NO_SCRIPT` and required a `pnpm exec vite preview` workaround.

Found while verifying #31.

## Test plan
- [x] `pnpm --filter @efx/demo build && pnpm --filter @efx/demo preview --port 8765` serves the demo on `:8765`.
- [x] `EFX_CHROMIUM=... node scripts/probe-prod.mjs` against that preview prints `DONE` (counter increments, LiveUser resolves Grace, todos toggle correctly).