### PR TITLE
chore(runtime): bump effect to beta.71, drop h.track workaround

### DIFF
--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@efx/runtime": "workspace:*",
-    "effect": "4.0.0-beta.70"
+    "effect": "4.0.0-beta.71"
   },
   "devDependencies": {
     "@efx/check": "workspace:*",

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -19,7 +19,7 @@
     "@jridgewell/sourcemap-codec": "^1.5.5"
   },
   "devDependencies": {
-    "@effect/vitest": "4.0.0-beta.70",
+    "@effect/vitest": "4.0.0-beta.71",
     "@types/babel__generator": "^7",
     "@types/babel__traverse": "^7"
   }

--- a/packages/runtime/AGENTS.md
+++ b/packages/runtime/AGENTS.md
@@ -76,22 +76,11 @@ The compiler wraps `{expr}` JSX expressions in `h.track(() => expr)`
    its initial value to the thunk's result, subscribes to every
    tracked ref, re-runs the thunk on change.
 5. Deps are re-collected on every rerun (a ternary may read
-   different refs on its other branch) and **diffed** against the
-   prior set — only deps that disappeared are unsubscribed, only
-   newly-read deps are subscribed. Stable deps don't churn.
+   different refs on its other branch). Old subs are dropped first.
 
 **Invariant: the empty-deps early return is load-bearing.** Without
 it, every `<Row item={item} />` would erase `item`'s generic type to
 `unknown`.
-
-**Why diff, not unsub-all-then-resub.** `AtomRef.notify` iterates
-`listeners` while `subscribe`/unsub mutates that same array via
-swap-pop. When two JSX expressions in one component read the same
-ref (e.g. `<li class={done ? "done" : ""}><span>{done ? "✓" : "·"}</span></li>`),
-they both subscribe on the row ref's listener array. A blanket
-"drop all subs, re-add them" inside one listener's rerun reshuffles
-the array under `notify`'s loop and the sibling listener is
-skipped. Diffing means stable-deps reruns leave the array alone.
 
 ## View IR
 

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -12,9 +12,9 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "effect": "4.0.0-beta.70"
+    "effect": "4.0.0-beta.71"
   },
   "devDependencies": {
-    "@effect/vitest": "4.0.0-beta.70"
+    "@effect/vitest": "4.0.0-beta.71"
   }
 }

--- a/packages/runtime/src/h.ts
+++ b/packages/runtime/src/h.ts
@@ -28,34 +28,18 @@ const trackImpl = (thunk: () => unknown): unknown => {
 
   // At least one ref was read — wrap in a derived AtomRef that re-runs
   // the thunk whenever any tracked ref changes. Deps may change between
-  // runs (a ternary's "other branch" reads different refs), so we diff
-  // them: unsubscribe only deps no longer read, subscribe only newly-read
-  // ones. Stable deps (the common case) cause no listener-array churn.
-  //
-  // Why diff instead of unsub-all-then-resub: AtomRef's `notify` iterates
-  // `listeners` while `subscribe`/unsub mutates that same array via
-  // swap-pop. When several JSX expressions in one component all read the
-  // same ref (e.g. `{done ? ...}` in two places), a blanket resubscribe
-  // inside one listener's rerun would shuffle the array under the
-  // iteration and skip sibling listeners.
+  // runs (a ternary's "other branch" reads different refs), so we
+  // re-subscribe fresh on each run.
   const derived = AtomRef.make<unknown>(result)
-  const currentSubs = new Map<AtomRef.ReadonlyRef<unknown>, () => void>()
+  let unsubs: Array<() => void> = []
 
-  const syncSubs = (next: Set<AtomRef.ReadonlyRef<unknown>>) => {
-    for (const [dep, unsub] of currentSubs) {
-      if (!next.has(dep)) {
-        unsub()
-        currentSubs.delete(dep)
-      }
-    }
-    for (const dep of next) {
-      if (!currentSubs.has(dep)) {
-        currentSubs.set(dep, dep.subscribe(rerun))
-      }
-    }
+  const subscribeAll = (set: Set<AtomRef.ReadonlyRef<unknown>>) => {
+    for (const dep of set) unsubs.push(dep.subscribe(rerun))
   }
 
   const rerun = () => {
+    for (const u of unsubs) u()
+    unsubs = []
     const nextDeps = new Set<AtomRef.ReadonlyRef<unknown>>()
     const prevTracker = currentTracker
     currentTracker = nextDeps
@@ -64,10 +48,10 @@ const trackImpl = (thunk: () => unknown): unknown => {
     } finally {
       currentTracker = prevTracker
     }
-    syncSubs(nextDeps)
+    subscribeAll(nextDeps)
   }
 
-  syncSubs(deps)
+  subscribeAll(deps)
   return derived
 }
 

--- a/packages/ts-plugin/package.json
+++ b/packages/ts-plugin/package.json
@@ -17,7 +17,7 @@
     "typescript": "^5.7.0"
   },
   "devDependencies": {
-    "@effect/vitest": "4.0.0-beta.70",
+    "@effect/vitest": "4.0.0-beta.71",
     "esbuild": "^0.27.0",
     "typescript": "^5.7.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/runtime
       effect:
-        specifier: 4.0.0-beta.70
-        version: 4.0.0-beta.70
+        specifier: 4.0.0-beta.71
+        version: 4.0.0-beta.71
     devDependencies:
       '@efx/check':
         specifier: workspace:*
@@ -84,8 +84,8 @@ importers:
         version: 1.5.5
     devDependencies:
       '@effect/vitest':
-        specifier: 4.0.0-beta.70
-        version: 4.0.0-beta.70(effect@4.0.0-beta.70)(vitest@4.1.7(@types/node@25.9.1)(vite@7.3.3(@types/node@25.9.1)(yaml@2.9.0)))
+        specifier: 4.0.0-beta.71
+        version: 4.0.0-beta.71(effect@4.0.0-beta.71)(vitest@4.1.7(@types/node@25.9.1)(vite@7.3.3(@types/node@25.9.1)(yaml@2.9.0)))
       '@types/babel__generator':
         specifier: ^7
         version: 7.27.0
@@ -115,12 +115,12 @@ importers:
   packages/runtime:
     dependencies:
       effect:
-        specifier: 4.0.0-beta.70
-        version: 4.0.0-beta.70
+        specifier: 4.0.0-beta.71
+        version: 4.0.0-beta.71
     devDependencies:
       '@effect/vitest':
-        specifier: 4.0.0-beta.70
-        version: 4.0.0-beta.70(effect@4.0.0-beta.70)(vitest@4.1.7(@types/node@25.9.1)(vite@7.3.3(@types/node@25.9.1)(yaml@2.9.0)))
+        specifier: 4.0.0-beta.71
+        version: 4.0.0-beta.71(effect@4.0.0-beta.71)(vitest@4.1.7(@types/node@25.9.1)(vite@7.3.3(@types/node@25.9.1)(yaml@2.9.0)))
 
   packages/ts-plugin:
     dependencies:
@@ -135,8 +135,8 @@ importers:
         version: 2.4.28
     devDependencies:
       '@effect/vitest':
-        specifier: 4.0.0-beta.70
-        version: 4.0.0-beta.70(effect@4.0.0-beta.70)(vitest@4.1.7(@types/node@25.9.1)(vite@7.3.3(@types/node@25.9.1)(yaml@2.9.0)))
+        specifier: 4.0.0-beta.71
+        version: 4.0.0-beta.71(effect@4.0.0-beta.71)(vitest@4.1.7(@types/node@25.9.1)(vite@7.3.3(@types/node@25.9.1)(yaml@2.9.0)))
       esbuild:
         specifier: ^0.27.0
         version: 0.27.7
@@ -192,10 +192,10 @@ packages:
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
-  '@effect/vitest@4.0.0-beta.70':
-    resolution: {integrity: sha512-XDteNN0xfOgoMauAVoN5iylxVgEjp7kFsGFq18tZ5XYjek0eOZa0nOoes5s7Bs71VvwjnCeCbFMD7IhxswEt8A==}
+  '@effect/vitest@4.0.0-beta.71':
+    resolution: {integrity: sha512-URADF7bj/CXfyq8Nut1Xi/OeBI+WCl4Gij4rdo7Mxd75/BIeQWOQHUxv9fsRRbo7K5Nh2SWpX0UrbrYiTgbprA==}
     peerDependencies:
-      effect: ^4.0.0-beta.70
+      effect: ^4.0.0-beta.71
       vitest: ^3.0.0 || ^4.0.0
 
   '@esbuild/aix-ppc64@0.27.7':
@@ -626,8 +626,8 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
-  effect@4.0.0-beta.70:
-    resolution: {integrity: sha512-8AwGTRiNriirHGEYHrOS0E9fzdhIqCdZjiHP1YXmNo2UyPGS43ILsymsSHT7V0DJS+8dvlKq2RxnrDBUhDNZHg==}
+  effect@4.0.0-beta.71:
+    resolution: {integrity: sha512-DKnsUK3/DnCU4GfiOnw7DVXkKeg+UTh2J92rgVLpLZYUrfvQd5h7FasFm125/613Cbn/P0iPXkMnmFCd0fxV4g==}
 
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
@@ -960,9 +960,9 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@effect/vitest@4.0.0-beta.70(effect@4.0.0-beta.70)(vitest@4.1.7(@types/node@25.9.1)(vite@7.3.3(@types/node@25.9.1)(yaml@2.9.0)))':
+  '@effect/vitest@4.0.0-beta.71(effect@4.0.0-beta.71)(vitest@4.1.7(@types/node@25.9.1)(vite@7.3.3(@types/node@25.9.1)(yaml@2.9.0)))':
     dependencies:
-      effect: 4.0.0-beta.70
+      effect: 4.0.0-beta.71
       vitest: 4.1.7(@types/node@25.9.1)(vite@7.3.3(@types/node@25.9.1)(yaml@2.9.0))
 
   '@esbuild/aix-ppc64@0.27.7':
@@ -1255,7 +1255,7 @@ snapshots:
   detect-libc@2.1.2:
     optional: true
 
-  effect@4.0.0-beta.70:
+  effect@4.0.0-beta.71:
     dependencies:
       '@standard-schema/spec': 1.1.0
       fast-check: 4.8.0


### PR DESCRIPTION
## Summary

- Upstream commit `730afb66` (effect `4.0.0-beta.71`) switched `AtomRef`'s listener storage from a swap-pop array to a doubly-linked list, so subscribe/unsubscribe during `notify` iteration is now safe.
- That obsoletes the `h.track` diff-based subscription workaround landed in #14. Revert to the simpler unsub-all-then-resubscribe form in `packages/runtime/src/h.ts` and prune the "Why diff" justification from `packages/runtime/AGENTS.md`.
- Bumps `effect` + `@effect/vitest` from `4.0.0-beta.70` → `4.0.0-beta.71` across `apps/demo`, `packages/runtime`, `packages/ts-plugin`, `packages/compiler`.

## Test plan

- [x] `pnpm install` accepts beta.71 without any `minimumReleaseAgeExclude` additions (well past the 24h pnpm 11 default)
- [x] `pnpm -r typecheck` clean across all 7 packages
- [x] `pnpm -r test` green (compiler 45/45, runtime 38/38, language 16/16, ts-plugin 8/8, check all)
- [x] `probe-todos.mjs` confirms the row-binding regression #14 fixed stays fixed via the upstream change