### PR TITLE
fix(compiler,ts-plugin): keep mid-edit completions working in .efx

### DIFF
--- a/packages/compiler/AGENTS.md
+++ b/packages/compiler/AGENTS.md
@@ -221,6 +221,22 @@ attributes, source maps. Run with `pnpm --filter @efx/compiler test`.
 - No file watching, no caching. Pure function of `(source, filename)`.
   Callers cache.
 
+## Parse-error tolerance
+
+`@babel/parser` runs with `errorRecovery: true`. The editor calls
+`transformEfx` on every keystroke; mid-edit source is routinely
+unparseable (`count.` with no property name yet). Without recovery,
+Babel throws → `createVirtualCode` propagates → Volar has no virtual
+code for the file → tsserver returns the project's *global scope*
+(999 entries — every DOM ambient declaration) for completion
+requests instead of the member list the user expects.
+
+With recovery, Babel emits a partial AST and attaches parse errors
+to `ast.errors`. We don't read that array — downstream `tsc` will
+surface real errors as diagnostics. Recovery isn't omnipotent: some
+mid-edit states inside JSX expressions (`<div>{x.}</div>`) still
+throw. The common case — typing a `.` in plain user code — works.
+
 ## Anti-patterns
 
 - Don't add a rewrite that fires on composite expressions
@@ -233,3 +249,6 @@ attributes, source maps. Run with `pnpm --filter @efx/compiler test`.
 - Don't depend on `@babel/preset-*`. We use parser + traverse +
   generate directly to keep the bundle small (the ts-plugin ships
   this transform inside its dist).
+- Don't remove `errorRecovery: true` from the parser options. See
+  "Parse-error tolerance" above — completions silently regress to
+  the project global scope without it.

--- a/packages/compiler/src/transform.test.ts
+++ b/packages/compiler/src/transform.test.ts
@@ -240,3 +240,28 @@ describe("TypeScript syntax survives", () => {
       .toMatch(/<T(,)?>/)
   })
 })
+
+describe("parse-error tolerance (mid-edit source)", () => {
+  // The editor calls transformEfx on every keystroke; mid-edit source is
+  // routinely unparseable. Throwing would leave the language plugin without a
+  // virtual code, and completion requests would fall back to the project's
+  // global scope (999 entries of DOM ambient declarations instead of the
+  // expected member list). errorRecovery: true on @babel/parser keeps the AST
+  // coming. Note: recovery isn't omnipotent — JSX-interior parse errors like
+  // `<div>{x.}</div>` still throw — but the common "type a dot in user code"
+  // case works.
+  it("does not throw on `obj.` followed by a keyword", () => {
+    const src = `function* f() { const x = { a: 1 }; x.\n\nreturn yield* g() }`
+    expect(() => transformEfx(src, "test.efx")).not.toThrow()
+  })
+
+  it("emits a recognizable member access for `obj.` recovery", () => {
+    // Babel's recovery turns `x.\n\nreturn` into `x.return` (next keyword
+    // becomes the property name). The exact property name doesn't matter
+    // — what matters is that `x.` lands inside a member-access shape so the
+    // source map covers it and tsserver returns members of `x`.
+    const src = `function* f() { const x = { a: 1 }; x.\n\nreturn yield* g() }`
+    const out = compile(src)
+    expect(out).toMatch(/x\.\w+/)
+  })
+})

--- a/packages/compiler/src/transform.ts
+++ b/packages/compiler/src/transform.ts
@@ -71,6 +71,14 @@ export type JsxRange = JsxElementRange | JsxFragmentRange
 const PARSER_OPTIONS: ParserOptions = {
   sourceType: "module",
   plugins: ["typescript", "jsx"],
+  // Editor calls this on every keystroke; mid-edit source is routinely
+  // unparseable (`count.` with no property name yet). Without recovery,
+  // Babel throws → createVirtualCode propagates the throw → Volar has no
+  // virtual code for the file → tsserver returns the project's global scope
+  // for completion requests instead of the expected member list. With
+  // recovery, Babel emits a partial AST and attaches errors to `ast.errors`
+  // (which we don't read — downstream tsc surfaces real errors).
+  errorRecovery: true,
 }
 
 /**

--- a/packages/ts-plugin/AGENTS.md
+++ b/packages/ts-plugin/AGENTS.md
@@ -50,10 +50,11 @@ live in [`@efx/language`](../language/AGENTS.md) — shared with
         LanguageService results in .efx coords
                │
                ▼  our Proxy wrapper
-               │    filterRuntimeHit()        — drop hits in runtime/h.ts
-               │    getDocumentHighlights()   — JSX tag pair custom path
-               │    provideInlayHints()       — filter _tag/_props/_children
-               │    get/findReferences()      — dedupe + sort
+               │    filterRuntimeHit()         — drop hits in runtime/h.ts
+               │    getDocumentHighlights()    — JSX tag pair custom path
+               │    provideInlayHints()        — filter _tag/_props/_children
+               │    getCompletionsAtPosition() — clamp cross-line replacementSpans
+               │    get/findReferences()       — dedupe + sort
                ▼
         Final LanguageService results
 ```
@@ -93,13 +94,15 @@ proxy wrapper below doesn't translate offsets itself: Volar's own
 `SourceMap` indexes `mappings` and maps virtual-code coordinates back
 to `.efx` source before results reach us. We resolve the
 `EfxVirtualCode` only for `jsxRanges` (via the `JsxTagProvider` handed
-to `jsx-tags.ts`) and `source` (whitespace-at-cursor suppression).
+to `jsx-tags.ts`) and `source` (whitespace-at-cursor suppression in
+`getDocumentHighlights`, cross-line span detection in
+`getCompletionsAtPosition`).
 
 ## The proxy wrapper
 
 Volar produces a working LanguageService. We then wrap it in a
-`Proxy` (in the outer `pluginFactory`) and override four groups of
-methods. Six of the seven overrides route through a local
+`Proxy` (in the outer `pluginFactory`) and override five groups of
+methods. Seven of the eight overrides route through a local
 `wrapMethod(name, transform)` helper — it calls the underlying
 LanguageService method eagerly and hands the result plus the
 original args to `transform`. `getDocumentHighlights` is the
@@ -135,6 +138,20 @@ hand-rolled.
   `_children`). We drop any hint whose text matches
   `/^_?(tag|props|children):?$/i`. Reads `hint.text` AND
   `hint.displayParts` (newer TS uses the latter).
+
+- **`getCompletionsAtPosition`** — `.efx`-only span clamp. When the
+  user types `count.` mid-edit and triggers completions, Babel's
+  `errorRecovery: true` (in `@efx/compiler`) parses
+  `count.\n\nreturn yield*` as `count.return` (the next keyword
+  becomes the synthesized property name). That gives us the right
+  completion list — members of `count` — but tsserver's
+  `optionalReplacementSpan` covers the `return` keyword on the
+  next line. Applying it would delete `return`. We detect spans
+  whose range crosses a newline relative to the cursor position
+  and clamp them to a zero-width span at the cursor, so the
+  editor inserts the picked entry rather than replacing the
+  next-line token. Same treatment for per-entry `replacementSpan`
+  in case tsserver populates it.
 
 - **`getReferencesAtPosition` / `findReferences`** — dedupe + sort:
   - Filter out hits in `@efx/runtime`'s `h.ts` (same reason as the

--- a/packages/ts-plugin/src/service-proxy.ts
+++ b/packages/ts-plugin/src/service-proxy.ts
@@ -152,6 +152,45 @@ export const pluginFactory: ts.server.PluginModuleFactory = (modules) => {
             }
           }
 
+          if (prop === "getCompletionsAtPosition") {
+            return wrapMethod("getCompletionsAtPosition", (result, fileName, position) => {
+              if (!fileName.endsWith(".efx") || !result) return result
+              const source = getEfxVirtualCode(fileName)?.source
+              if (!source) return result
+              // Babel's errorRecovery turns mid-edit `count.\n...return` into a
+              // `count.return` MemberExpression — convenient for letting
+              // tsserver enumerate `count`'s members, but the resulting
+              // replacementSpan covers `return` on the next line. If the
+              // editor applied it, picking `set` would delete `return`.
+              // Clamp any span that sits across a newline from the cursor to
+              // an insert-at-cursor (zero-width at position). Deliberately
+              // coarse: we don't try to identify the synthesized property
+              // text — any cross-line span gets clamped. In practice, no
+              // legitimate completion wants to delete content from a
+              // different line than the cursor.
+              const crossesNewlineFromCursor = (span: ts.TextSpan): boolean => {
+                const lo = Math.min(position, span.start)
+                const hi = Math.max(position, span.start + span.length)
+                return source.slice(lo, hi).includes("\n")
+              }
+              const insertAtCursor: ts.TextSpan = { start: position, length: 0 }
+
+              const entries = result.entries.map((e) => {
+                if (e.replacementSpan && crossesNewlineFromCursor(e.replacementSpan)) {
+                  return { ...e, replacementSpan: insertAtCursor }
+                }
+                return e
+              })
+              const orig = result.optionalReplacementSpan
+              const clamped = orig && crossesNewlineFromCursor(orig) ? insertAtCursor : orig
+              // Spread the optional field only when defined — exactOptionalPropertyTypes
+              // rejects `optionalReplacementSpan: undefined` as a value.
+              return clamped
+                ? { ...result, optionalReplacementSpan: clamped, entries }
+                : { ...result, entries }
+            })
+          }
+
           if (prop === "provideInlayHints") {
             return wrapMethod("provideInlayHints", (hints, fileName) => {
               if (!fileName.endsWith(".efx")) return hints

--- a/packages/ts-plugin/test/integration.mjs
+++ b/packages/ts-plugin/test/integration.mjs
@@ -11,6 +11,7 @@ import { spawn } from "node:child_process"
 import { dirname, join } from "node:path"
 import { fileURLToPath } from "node:url"
 import { createInterface } from "node:readline"
+import { readFileSync } from "node:fs"
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const repoRoot = join(__dirname, "../../..")
@@ -315,6 +316,50 @@ async function main() {
     console.log("   FAIL: No .efx files in project (getExternalFiles not working)")
     process.exitCode = 1
   }
+
+  console.log("\n10. Test mid-edit completions don't replace next-line tokens...")
+  // The user reported: typing `count.` and picking an entry glued onto the
+  // `return` keyword on the next line. Babel's errorRecovery parses
+  // `count.\n\nreturn` as `count.return`, so tsserver's replacementSpan
+  // covers `return` — picking `set` would delete it. The proxy clamps any
+  // cross-line span to insert-at-cursor.
+  const lines = readFileSync(counterEfx, "utf-8").split("\n")
+  // Insert "  count." at index 16 → 1-based line 17, with `return yield* (`
+  // shifted to line 18.
+  lines.splice(16, 0, "  count.")
+  const modified = lines.join("\n")
+  await client.send("open", {
+    file: counterEfx,
+    fileContent: modified,
+    projectRootPath: demoRoot,
+  })
+  await new Promise((r) => setTimeout(r, 500))
+
+  const complResp = await client.send("completionInfo", {
+    file: counterEfx,
+    line: 17,
+    offset: 9, // right after the `.` in "  count."
+    triggerCharacter: ".",
+    includeExternalModuleExports: false,
+  })
+  const replSpan = complResp.body?.optionalReplacementSpan
+  if (!replSpan) {
+    console.log("   No optionalReplacementSpan returned — likely OK (editor inserts at cursor).")
+  } else if (replSpan.start.line === replSpan.end.line && replSpan.start.line === 17) {
+    console.log(`   PASS: replacementSpan stays on line 17 (cursor line), cols ${replSpan.start.offset}-${replSpan.end.offset}`)
+  } else {
+    console.log(`   FAIL: replacementSpan crosses lines: ${JSON.stringify(replSpan)}`)
+    process.exitCode = 1
+  }
+  const setEntry = (complResp.body?.entries || []).find((e) => e.name === "set")
+  if (setEntry) {
+    console.log("   PASS: 'set' entry present (AtomRef members enumerated)")
+  } else {
+    console.log("   FAIL: 'set' entry missing — completion didn't enumerate count's members")
+    process.exitCode = 1
+  }
+  // Close the modified file so other test runs don't see it
+  await client.send("close", { file: counterEfx })
 
   await client.close()
   console.log("\nDone.")


### PR DESCRIPTION
## Summary

Two-part fix for autocomplete in `.efx` files. Typing `count.` and triggering completions was either returning the global DOM scope (999 ambients) or — after the first fix — gluing the picked entry onto the next-line `return` keyword.

- **`@efx/compiler`** — enable `errorRecovery: true` on `@babel/parser`. The editor calls `transformEfx` on every keystroke; without recovery, Babel threw on `count.` → `createVirtualCode` propagated → Volar had no virtual code → tsserver returned the project's global scope.
- **`@efx/ts-plugin`** — new `getCompletionsAtPosition` proxy override. Babel's recovery parses `count.\n\nreturn yield*` as `count.return`, which gives the right completion list but anchors `optionalReplacementSpan` on the next-line `return`. Picking `set` would delete `return`. The override clamps any `replacementSpan` that crosses a newline relative to the cursor to a zero-width insert-at-cursor span.

Each half is necessary: without the compiler change, completions don't fire at all; without the proxy clamp, accepting one mangles the source.

## Test plan

- [x] `pnpm --filter @efx/compiler test` — 47/47 (new `parse-error tolerance` describe block: 2 cases).
- [x] `pnpm --filter @efx/ts-plugin test` — 16/16 vitest + 10/10 integration steps including new step 10 asserting both span clamp and AtomRef member enumeration.
- [x] `pnpm -r typecheck` — clean across all 6 packages.
- [x] Manually reproduced via tsserver subprocess: before, `count.` returned 999 entries (global scope); after, 7 entries (AtomRef members `set`, `update`, `subscribe`, etc.) with `optionalReplacementSpan` clamped to the cursor line.

## Notes

- `@efx/compiler/AGENTS.md` gains a "Parse-error tolerance" section plus an anti-pattern bullet pinning `errorRecovery: true` in place. `@efx/ts-plugin/AGENTS.md` documents the new override in its existing proxy-wrapper section (counts bumped from "four groups / six of seven" to "five groups / seven of eight") and lists `getCompletionsAtPosition` in the ASCII fit-together diagram.
- Known limitation called out in the compiler AGENTS.md: Babel's recovery doesn't cover JSX-interior parse errors like `<div>{x.}</div>` — those still throw. A previous-code fallback in `createVirtualCode` could close that gap if it surfaces as a real pain point.
- Rebased onto current main (post #34). The proxy override now resolves source content via the new `getEfxVirtualCode(fileName)` closure (which reads from `language.scripts.get(fileName).generated.root` instead of the dropped `VirtualCodeRegistry`).