### PR TITLE
feat(compiler): drop h.peek, add .value.map(arrow → JSX) → list(...) rewrite

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,7 @@ compiler eats and converts into `h()` calls." Not the React thing.
   components import from.
 - **[`packages/compiler/`](./packages/compiler/AGENTS.md)** — the Babel
   transform. Three rewrites: JSX → `h()`, `.value` → `h.read()`,
-  bare test-position identifiers → `h.peek()`. Smart-skip wrap.
+  `<expr>.value.map(arrow → JSX)` → `list(<expr>, arrow)`. Smart-skip wrap.
 - **[`packages/language/`](./packages/language/AGENTS.md)** — the Volar
   `LanguagePlugin` describing `.efx` files (file id, virtual code,
   source-map conversion, JSX region tagging). Shared by `ts-plugin`

--- a/README.md
+++ b/README.md
@@ -105,8 +105,10 @@ apps/
 | `effect`             | `Effect`, `Layer`, `Context.Service`, `Data.TaggedError`, `Cause`, `Option`, `Result`, …  |
 | `effect/unstable/reactivity` | `AtomRef`, `Atom`, `AtomRegistry`, `AsyncResult`                                  |
 
-`h.track` / `h.read` / `h.peek` are compiler-emitted; you generally never
-write them by hand.
+`h.track` / `h.read` are compiler-emitted; you generally never write them
+by hand. Reactive reads are always explicit through `.value` — the compiler
+rewrites those calls into tracked reads under the hood, and the surrounding
+JSX expression is automatically wrapped in a tracking scope.
 
 ## Workflow
 

--- a/apps/demo/AGENTS.md
+++ b/apps/demo/AGENTS.md
@@ -15,7 +15,7 @@ they can be exercised in a browser side-by-side.
 | `Counter.efx` | Local `AtomRef` state, no Effect services. Reactive `.value` interpolation inside `{...}` expressions. |
 | `UserPage.efx` | Synchronous-style Effect.fn returning a view with `R = Http \| Theme` and `E = HttpError` channels in scope. |
 | `LiveUser.efx` | `AtomRef` + `AsyncResult` pattern matching for loading/success/failure shapes. |
-| `Todos.efx` | Keyed reactive list (`list(coll, ...)`). Per-row reactivity: toggling one row doesn't tear down others. |
+| `Todos.efx` | Keyed reactive list (`{coll.value.map(item => <Row item={item}/>)}` compiles to `list(coll, render)`). Per-row reactivity: toggling one row doesn't tear down others. |
 | `Lifecycle.efx` | `Effect.acquireRelease` inside a row — release fires when the row is removed (per-row Scope in mount). |
 | `main.efx` | Wires Layers (`EfxLive`, `HttpLive`, `ThemeLive`) + `Effect.scoped` + `Effect.never` (keep scope alive for page lifetime). |
 | `services.ts` | Mock Http + Theme services. `Data.TaggedError` for `HttpError`. |

--- a/apps/demo/src/Lifecycle.efx
+++ b/apps/demo/src/Lifecycle.efx
@@ -1,6 +1,5 @@
 import { Effect } from "effect"
 import { AtomRef } from "effect/unstable/reactivity"
-import { list } from "@efx/runtime"
 
 // Module-level event log, exposed on `window.__lifecycle` so the probe can
 // read it. Cleared on each fresh page load.
@@ -46,7 +45,7 @@ export const Lifecycle = Effect.fn("Lifecycle")(function* (_props: {} = {}) {
         <button onclick={removeLast}>− remove last</button>
       </div>
       <ul>
-        {list(items, (item) => <Row item={item} />)}
+        {items.value.map((item) => <Row item={item} />)}
       </ul>
       <p class="hint">
         Open devtools and inspect <code>__lifecycle</code> — expect a paired

--- a/apps/demo/src/Todos.efx
+++ b/apps/demo/src/Todos.efx
@@ -1,6 +1,5 @@
 import { Effect } from "effect"
 import { AtomRef } from "effect/unstable/reactivity"
-import { list, type View } from "@efx/runtime"
 
 interface Todo {
   readonly text: string
@@ -30,15 +29,14 @@ const TodoRow = Effect.fn("TodoRow")(function* (props: {
   const toggle = () => ref.update((t) => ({ ...t, done: !t.done }))
   const remove = () => todos.remove(ref)
 
-  // The compiler wraps every JSX expression in `h.track(() => …)`:
-  //  - `.value` reads become `h.read(…)` — tracks AtomRef value access
-  //  - bare identifiers in ternary/`&&`/`||`/`!` positions become
-  //    `h.peek(…)` — for AtomRefs, unwraps and tracks; for plain values,
-  //    identity. So `{done ? "✓" : "·"}` works with `done` as a ref.
+  // The compiler wraps every JSX expression in `h.track(() => …)` and
+  // rewrites `.value` reads inside to `h.read(…)`, tracking AtomRef
+  // dependencies. Always write `.value` explicitly — the types are exact
+  // (`done.value: boolean`), and the compiler handles the reactive plumbing.
   return yield* (
-    <li class={done ? "done" : ""}>
+    <li class={done.value ? "done" : ""}>
       <button class="toggle" onclick={toggle}>
-        {done ? "✓" : "·"}
+        {done.value ? "✓" : "·"}
       </button>
       <span class="text">{ref.value.text}</span>
       <button class="remove" onclick={remove}>×</button>
@@ -53,8 +51,9 @@ const remaining: AtomRef.ReadonlyRef<number> = todos.map((items) => {
 })
 
 /**
- * The list. `list(todos, ...)` returns a `View.List` IR node; `mount`
- * reconciles rows by ref identity on add/remove.
+ * The list. `todos.value.map(item => <TodoRow />)` in JSX position is
+ * compiled to a keyed `View.List` IR node; `mount` reconciles rows by ref
+ * identity on add/remove.
  */
 export const Todos = Effect.fn("Todos")(function* (_props: {} = {}) {
   return yield* (
@@ -66,7 +65,7 @@ export const Todos = Effect.fn("Todos")(function* (_props: {} = {}) {
         </span>
       </div>
       <ul>
-        {list(todos, (item) => <TodoRow item={item} />)}
+        {todos.value.map((item) => <TodoRow item={item} />)}
       </ul>
     </div>
   )

--- a/packages/compiler/AGENTS.md
+++ b/packages/compiler/AGENTS.md
@@ -43,16 +43,26 @@ local AST rewrite.
 
 Every JSX expression `{...}` triggers up to three local rewrites:
 
-1. **Wrap in `h.track(() => ...)`** — *only if something else got
-   rewritten*. See `wrapTracked` + `rewrote` flag in `transform.ts`.
+1. **Wrap in `h.track(() => ...)`** — *only if a `.value` read got
+   rewritten*. See `wrapTracked` + `rewroteRead` flag in `transform.ts`.
    This is load-bearing: `h.track`'s return is `unknown`, which would
    destroy the typing of static expressions like
    `<Row item={item} />` (where `item` is a generic `T`). Static
-   passes through with no wrap.
+   passes through with no wrap. The `.value.map → list(...)` rewrite
+   (#3) also does **not** trigger a wrap — `list()` subscribes inside
+   `mount`, so wrapping in `h.track` would be a redundant layer.
 
 2. **`x.value` → `h.read(x)`** inside the wrapped expression. Tracks
-   AtomRef reads. Skipped when `x.value` is on the LHS of an
-   assignment (`x.value = ...` stays bare).
+   AtomRef reads. Left bare on any write to `.value` — assignment LHS
+   (`x.value = …`, `x.value += …`) **and** update expressions
+   (`x.value++`, `--x.value`). The bare-write fallback exists so the
+   emitted JS stays well-formed (`h.read(x)++` would be a SyntaxError
+   in strict modules). The compiler intentionally does not raise its
+   own diagnostic for `.value++` on an AtomRef: TypeScript already
+   surfaces `ts(2540) Cannot assign to 'value' because it is a
+   read-only property` at the right column for `=`, `+=`, `++`, and
+   `--`, which is the familiar idiomatic error. The right idiom is
+   `ref.update(v => v + 1)`.
 
    **Destructuring blind spot.** The rewrite matches `MemberExpression`
    shapes only, so `const { value } = ref` inside a JSX expression is
@@ -63,35 +73,50 @@ Every JSX expression `{...}` triggers up to three local rewrites:
    reads as the idiom; don't extend the rewrite to destructuring
    without thinking through the alias-tracking ramifications.
 
-3. **Bare identifier in a test position → `h.peek(id)`**:
-   `cond ? A : B` (ConditionalExpression.test),
-   `a && b` / `a || b` (LogicalExpression operands),
-   `!x` (UnaryExpression argument with `!`).
-   `h.peek` is identity for non-AtomRef values; for AtomRefs it
-   unwraps + tracks. Lets `{loading ? <X /> : <Y />}` work with
-   `loading: AtomRef<boolean>`.
+3. **`<expr>.value.map(arrow → JSX)` → `list(<expr>, arrow)`** —
+   keyed reactive iteration. Caught before the bare `.value` rewrite
+   so the `.value` doesn't get turned into an `h.read` we'd then have
+   to undo. The arrow body must syntactically be a JSX node (direct
+   `item => <Row/>` or `item => <></>`) or a block whose only statement
+   is `return <JSX/>` — anything else (`.value.map(item => item.text)`,
+   `.value.map(Component)`) is left as a plain `.map` and the outer
+   `.value` is rewritten normally.
 
-**The test-position rewrite (#3) is leaf-local.** It only fires
-when the test is a bare identifier. Composite test expressions —
-`x.length > 0`, `items.find(...)`, `a.value === b.value` — are
-NOT auto-tracked. They won't react to AtomRef changes unless the
-user puts `.value` somewhere in the expression (the `.value`
-rewrite #2 fires through composites on the object side, so
-`arr[0].value` does work).
+   The rewrite is purely structural; it fires whenever the shape
+   matches, without consulting types. If `<expr>` isn't actually a
+   `Collection<T>`, the emitted `list(<expr>, arrow)` call fails to
+   type-check with a diagnostic like
+   `Argument of type 'X[]' is not assignable to parameter of type 'Collection<...>'`,
+   pointing at the source `<expr>.value.map(...)` site. That's the
+   intended user-facing signal — there's no way to do a type-aware
+   Babel pass.
 
-Whether the test-position rule should extend to simple shapes
-like `x.length` is an open question — predictability and easy
-debugging are the current rationale, not a closed decision. If
-you change it, update this section.
+   After the rewrite, `path.skip()` halts the inner traversal so it
+   doesn't descend into the new list's arrow body. `.value` reads
+   inside the arrow are part of inner JSX expressions and will get
+   their own `h.track` wrap when the outer `JSXElement` visitor in
+   `transformEfx` reaches them. Pre-emptively rewriting them here
+   would (a) wrap this `list(...)` in a redundant `h.track`, and (b)
+   strand the resulting `h.read` outside any active tracking scope.
+
+**No test-position magic.** Bare identifiers in `cond ? A : B`,
+`a && b`, `!x` positions are **not** rewritten. Users must write
+`.value` explicitly — that keeps the types honest
+(`ref.value: boolean`, not `AtomRef<boolean>`) and avoids surprising
+reads where none looked syntactically present. An earlier version of
+the compiler emitted `h.peek(...)` for bare test-position identifiers;
+that was removed because the implicit unwrap diverged from the type
+TS would assign at the source site.
 
 ## Auto-injected imports
 
 If any JSX rewrote to an `h()` call, the transform ensures
-`import { h } from "@efx/runtime"` exists. If `<>...</>` was used,
-`Fragment` is added too. `ensureRuntimeImports` finds an existing
-import from `@efx/runtime` and appends to it; otherwise it prepends
-a new declaration. Names already imported under their own identifier
-(no alias) are skipped to avoid duplicates.
+`import { h } from "@efx/runtime"` exists. `Fragment` is added when
+`<>...</>` is used. `list` is added when the `.value.map → list(...)`
+rewrite fires. `ensureRuntimeImports` finds an existing import from
+`@efx/runtime` and appends to it; otherwise it prepends a new
+declaration. Names already imported under their own identifier (no
+alias) are skipped to avoid duplicates.
 
 ## Tag dispatch
 
@@ -212,8 +237,8 @@ attributes, source maps. Run with `pnpm --filter @efx/compiler test`.
 ## What this package does NOT do
 
 - No type checking. That's tsc's job (post-transform).
-- No reactivity wiring. `h.track`/`read`/`peek` live in
-  `@efx/runtime`; the compiler only emits *calls* to them.
+- No reactivity wiring. `h.track`/`read` live in `@efx/runtime`;
+  the compiler only emits *calls* to them.
 - No `CodeInformation` profile assignment. The compiler classifies
   each span as `"user"` / `"h-call"` / `"punctuation"` (a
   Volar-free taxonomy); `@efx/language` translates kind → Volar
@@ -244,8 +269,8 @@ throw. The common case — typing a `.` in plain user code — works.
   "rewrite only bare identifiers / `.value` reads" rule is what
   keeps the system debuggable.
 - Don't emit `h.track(...)` unconditionally — generics die.
-- Don't auto-import anything except `h` and `Fragment`. Users
-  manage their own imports.
+- Don't auto-import anything except `h`, `Fragment`, and `list`.
+  Users manage their own imports.
 - Don't depend on `@babel/preset-*`. We use parser + traverse +
   generate directly to keep the bundle small (the ts-plugin ships
   this transform inside its dist).

--- a/packages/compiler/src/transform.test.ts
+++ b/packages/compiler/src/transform.test.ts
@@ -65,34 +65,37 @@ describe("JSX → h() rewrites", () => {
   })
 })
 
-describe("tracking-scope rewrites (h.track / h.read / h.peek)", () => {
+describe("tracking-scope rewrites (h.track / h.read)", () => {
   it("`.value` reads become h.read(...) and the expression is wrapped in h.track", () => {
     const out = compile(`const x = <div>{ref.value}</div>`)
     expect(out).toContain(`h.read(ref)`)
     expect(out).toContain(`h.track(() =>`)
   })
 
-  it("bare identifier in ternary test becomes h.peek(...) and wraps in h.track", () => {
+  it("bare identifier in ternary test is NOT rewritten — user must write .value", () => {
+    // Removed: bare identifiers in test positions used to be wrapped in
+    // `h.peek(...)`. Users must now write `.value` explicitly so the type
+    // checker sees a `boolean` (or whatever the ref unwraps to).
     const out = compile(`const x = <div>{loading ? <a /> : <b />}</div>`)
-    expect(out).toContain(`h.peek(loading)`)
-    expect(out).toContain(`h.track(() =>`)
+    expect(out).not.toContain(`h.peek`)
+    expect(out).not.toContain(`h.track`)
   })
 
-  it("bare identifier in `&&` becomes h.peek and wraps in h.track", () => {
+  it("bare identifier in `&&` is NOT rewritten", () => {
     const out = compile(`const x = <div>{show && <p />}</div>`)
-    expect(out).toContain(`h.peek(show)`)
-    expect(out).toContain(`h.track(() =>`)
+    expect(out).not.toContain(`h.peek`)
+    expect(out).not.toContain(`h.track`)
   })
 
-  it("bare identifier under `!` becomes h.peek", () => {
+  it("bare identifier under `!` is NOT rewritten", () => {
     const out = compile(`const x = <div>{!hidden ? <a /> : <b />}</div>`)
-    expect(out).toContain(`h.peek(hidden)`)
+    expect(out).not.toContain(`h.peek`)
   })
 
   it("static expressions DO NOT get wrapped in h.track", () => {
     // `<Row item={item} />` — `item` is a bare identifier in attribute
-    // position; there's no .value read and no test-position rewrite,
-    // so wrapping would only strip the static type to `unknown`.
+    // position; there's no .value read, so wrapping would only strip the
+    // static type to `unknown`.
     const out = compile(`const x = <Row item={item} />`)
     expect(out).toContain(`h(Row, { item: item })`)
     expect(out).not.toContain(`h.track`)
@@ -107,6 +110,137 @@ describe("tracking-scope rewrites (h.track / h.read / h.peek)", () => {
     // We only intercept reads — `obj.value = …` stays as a real assignment.
     expect(compile(`const x = <div>{(ref.value = 1, ref.value)}</div>`))
       .toMatch(/ref\.value = 1/)
+  })
+
+  it("`.value++` / `--.value` are left bare — `h.read(obj)++` would be invalid JS, and TS's own `ts(2540)` already flags the read-only write at the right column", () => {
+    const post = compile(`const v = <button onclick={() => count.value++}>+</button>`)
+    expect(post).toContain(`count.value++`)
+    expect(post).not.toMatch(/h\.read\(count\)\+\+/)
+
+    const pre = compile(`const v = <button onclick={() => --count.value}>-</button>`)
+    expect(pre).toContain(`--count.value`)
+    expect(pre).not.toMatch(/--h\.read\(count\)/)
+  })
+
+  it("`.value += X` (compound assignment) is NOT rewritten — caught by the LHS escape hatch", () => {
+    // AssignmentExpression with operator `+=` still has .left === the
+    // MemberExpression, so the existing skip predicate covers it.
+    const out = compile(`const v = <button onclick={() => { count.value += 1 }}>+</button>`)
+    expect(out).toContain(`count.value += 1`)
+    expect(out).not.toMatch(/h\.read\(count\) \+=/)
+  })
+})
+
+describe(".value.map(arrow → JSX) → list(...) rewrite", () => {
+  it("rewrites `<expr>.value.map(item => <JSX/>)` to a `list(<expr>, ...)` call", () => {
+    const out = compile(
+      `const x = <ul>{coll.value.map((item) => <Row item={item} />)}</ul>`,
+    )
+    expect(out).toContain(`list(coll, item =>`)
+    expect(out).toContain(`h(Row, { item: item })`)
+  })
+
+  it("does NOT wrap the rewritten call in h.track (no redundant reactivity)", () => {
+    const out = compile(
+      `const x = <ul>{coll.value.map((item) => <Row item={item} />)}</ul>`,
+    )
+    expect(out).not.toContain(`h.track`)
+    // And the `.value` is consumed by the rewrite — not turned into h.read.
+    expect(out).not.toContain(`h.read(coll)`)
+  })
+
+  it("auto-imports `list` from @efx/runtime", () => {
+    const out = compile(
+      `const x = <ul>{coll.value.map((item) => <Row item={item} />)}</ul>`,
+    )
+    expect(out).toMatch(/import \{[^}]*\blist\b[^}]*\} from "@efx\/runtime"/)
+  })
+
+  it("supports block-body arrow returning only a JSX node", () => {
+    const out = compile(
+      `const x = <ul>{coll.value.map((item) => { return <Row item={item} /> })}</ul>`,
+    )
+    expect(out).toContain(`list(coll,`)
+    expect(out).toContain(`h(Row, { item: item })`)
+  })
+
+  it("supports JSX fragment as arrow body (direct and via block)", () => {
+    // `isJsxArrowBody` accepts both JSXElement and JSXFragment — make sure
+    // both shapes flow through the rewrite. Otherwise users hitting the
+    // fragment idiom (`item => <>…</>` for multi-child rows without a wrapper
+    // element) would get a silent no-rewrite.
+    const direct = compile(
+      `const x = <ul>{coll.value.map((item) => <>{item}</>)}</ul>`,
+    )
+    expect(direct).toContain(`list(coll,`)
+    expect(direct).toContain(`h(Fragment,`)
+
+    const block = compile(
+      `const x = <ul>{coll.value.map((item) => { return <>{item}</> })}</ul>`,
+    )
+    expect(block).toContain(`list(coll,`)
+    expect(block).toContain(`h(Fragment,`)
+  })
+
+  it("does NOT rewrite when the arrow body is not JSX (preserves Array.map / Collection.map)", () => {
+    // Whole-collection derivation pattern (Collection.map((items) => derived))
+    // must NOT be touched.
+    const out = compile(
+      `const x = <span>{coll.value.map((items) => items.length)}</span>`,
+    )
+    expect(out).not.toContain(`list(`)
+    // The outer `.value` is a normal reactive read; should be rewritten to h.read.
+    expect(out).toContain(`h.read(coll)`)
+  })
+
+  it("does NOT rewrite plain `.map` (no `.value`) — leaves as-is", () => {
+    const out = compile(
+      `const x = <ul>{xs.map((x) => <li>{x}</li>)}</ul>`,
+    )
+    expect(out).not.toContain(`list(`)
+    expect(out).toContain(`h("li", {}, x)`)
+  })
+
+  it("does NOT rewrite when callee is not a function reference", () => {
+    // `.value.map(SomeFn)` — argument is an identifier, not an arrow.
+    // Conservative: the rewrite only fires when the body is unambiguously JSX.
+    // The outer `.value` still gets the normal `h.read` rewrite + h.track wrap.
+    const out = compile(`const x = <ul>{coll.value.map(SomeRow)}</ul>`)
+    expect(out).not.toContain(`list(`)
+    expect(out).toContain(`h.read(coll)`)
+    expect(out).toContain(`h.track(() =>`)
+  })
+
+  it("rewrites the innermost `.value.map → list` in nested map chains", () => {
+    // The outer arrow's body is a CallExpression, not JSX, so the outer
+    // `.value.map` stays as Array.prototype.map. The inner arrow's body IS
+    // JSX, so the inner `.value.map` becomes list(group.items, ...). The
+    // outer `.value` falls back to h.read; the whole expression wraps in
+    // h.track because that read happened.
+    const out = compile(
+      `const x = <ul>{outer.value.map((group) => group.items.value.map((item) => <li>{item}</li>))}</ul>`,
+    )
+    expect(out).toContain(`h.read(outer)`)
+    expect(out).toContain(`list(group.items,`)
+    expect(out).toContain(`h.track(() =>`)
+    // Inner `.value` was consumed by the rewrite — never turned into h.read.
+    expect(out).not.toContain(`h.read(group.items)`)
+  })
+
+  it("does NOT pre-emptively rewrite `.value` reads inside the list arrow body", () => {
+    // `ref.value` inside the arrow body is its own JSX expression
+    // (`<Row badge={ref.value}/>`). It gets its OWN h.track wrap when the
+    // outer JSX traversal reaches that inner `<Row>`. If the outer rewrite
+    // descended into the new list's children, it would (a) wrap the whole
+    // list(...) in a redundant h.track and (b) strand the inner h.read
+    // outside any active tracking scope.
+    const out = compile(
+      `const x = <ul>{coll.value.map((item) => <Row badge={ref.value} />)}</ul>`,
+    )
+    // The list(...) call is NOT wrapped in h.track.
+    expect(out).not.toMatch(/h\.track\(\(\)\s*=>\s*list\(/)
+    // The inner ref.value gets its own h.track wrap around the h.read.
+    expect(out).toMatch(/h\.track\(\(\)\s*=>\s*h\.read\(ref\)\)/)
   })
 })
 

--- a/packages/compiler/src/transform.ts
+++ b/packages/compiler/src/transform.ts
@@ -95,86 +95,135 @@ const attrName = (id: t.JSXIdentifier | t.JSXNamespacedName): t.Identifier | t.S
 }
 
 /**
- * Wrap a JSX-expression's value in a `h.track(() => expr)` call **only when
- * the rewriter found something to track** (a `.value` read or a bare
- * identifier in a test position). Static expressions like `{item}` or
- * `{"hello"}` pass through unchanged so their TypeScript type is preserved
- * — h.track's return is `unknown`, which would otherwise destroy the typing
- * of component props (`<Row item={item} />`, the prop's `item` type).
+ * Per-call mutable state, threaded through every helper that may emit a
+ * `list(...)` call. `transformEfx` creates a fresh instance and reads
+ * `wroteList` at the end to decide whether to auto-import `list`.
  */
-const wrapTracked = (expr: t.Expression): t.Expression => {
-  const { expr: rewritten, rewrote } = rewriteValueReads(expr)
-  if (!rewrote) return rewritten
+interface RewriteState {
+  wroteList: boolean
+}
+
+/**
+ * Wrap a JSX-expression's value in a `h.track(() => expr)` call **only when
+ * a `.value` read was found**. Static expressions like `{item}` or `{"hello"}`
+ * pass through unchanged so their TypeScript type is preserved — h.track's
+ * return is `unknown`, which would otherwise destroy the typing of component
+ * props (`<Row item={item} />`, the prop's `item` type).
+ *
+ * The `.value.map(arrow → JSX)` rewrite does **not** trigger a wrap: the
+ * resulting `list(...)` call subscribes inside `mount`, so wrapping in
+ * `h.track` would add a redundant reactive layer. It flips `state.wroteList`
+ * instead, which `transformEfx` reads to decide on the `list` auto-import.
+ */
+const wrapTracked = (expr: t.Expression, state: RewriteState): t.Expression => {
+  const { expr: rewritten, rewroteRead } = rewriteTrackedExpression(expr, state)
+  if (!rewroteRead) return rewritten
   return t.callExpression(
     t.memberExpression(t.identifier("h"), t.identifier("track")),
     [t.arrowFunctionExpression([], rewritten)],
   )
 }
 
-const hMember = (name: "read" | "peek") =>
-  t.memberExpression(t.identifier("h"), t.identifier(name))
+const hRead = (): t.MemberExpression =>
+  t.memberExpression(t.identifier("h"), t.identifier("read"))
 
-const wrapPeek = (id: t.Identifier): t.CallExpression =>
-  t.callExpression(hMember("peek"), [id])
+/**
+ * True when an arrow body is a JSX expression — either directly
+ * (`item => <Row/>`) or via a block whose only statement is `return <JSX/>`
+ * (`item => { return <Row/> }`).
+ */
+const isJsxArrowBody = (body: t.BlockStatement | t.Expression): boolean => {
+  if (t.isJSXElement(body) || t.isJSXFragment(body)) return true
+  if (t.isBlockStatement(body) && body.body.length === 1) {
+    const stmt = body.body[0]
+    if (t.isReturnStatement(stmt) && stmt.argument) {
+      return t.isJSXElement(stmt.argument) || t.isJSXFragment(stmt.argument)
+    }
+  }
+  return false
+}
+
+/**
+ * Match `<expr>.value.map(<arrow>)` exactly. The arrow's JSX-ness is checked
+ * separately by `isJsxArrowBody` — this just confirms the call shape.
+ */
+const matchValueMapCall = (
+  node: t.CallExpression,
+): { source: t.Expression; arrow: t.ArrowFunctionExpression } | null => {
+  if (!t.isMemberExpression(node.callee) || node.callee.computed) return null
+  if (!t.isIdentifier(node.callee.property, { name: "map" })) return null
+  const valueAccess = node.callee.object
+  if (!t.isMemberExpression(valueAccess) || valueAccess.computed) return null
+  if (!t.isIdentifier(valueAccess.property, { name: "value" })) return null
+  if (node.arguments.length !== 1) return null
+  const arg = node.arguments[0]
+  if (!t.isArrowFunctionExpression(arg)) return null
+  if (!isJsxArrowBody(arg.body)) return null
+  if (t.isSuper(valueAccess.object)) return null
+  return { source: valueAccess.object, arrow: arg }
+}
 
 /**
  * In-place AST rewrites inside a tracked JSX expression:
  *
+ *   - `<expr>.value.map(arrow → JSX)` → `list(<expr>, arrow)` — keyed
+ *     reactive iteration. Caught before the bare `.value` rewrite so the
+ *     `.value` doesn't get turned into an `h.read` we'd then have to undo.
+ *     Flips `state.wroteList` so `transformEfx` adds the import, then
+ *     `path.skip()`s the new list's children: any `.value` reads inside the
+ *     arrow body belong to inner JSX expressions and will get their own
+ *     `h.track` wrap when the outer JSX traversal reaches them. Descending
+ *     here would (a) wrap this `list(...)` in a redundant `h.track`, and
+ *     (b) strand the inner `h.read` calls outside any active tracking scope.
  *   - `x.value` (read) → `h.read(x)` — tracks AtomRef reads via `.value`.
- *   - bare `x` in a test position (`x ? … : …`, `x && …`, `!x`, etc.) →
- *     `h.peek(x)` — for non-AtomRef `x`, identity; for AtomRef, unwraps
- *     value and tracks. Lets `{loading ? <A/> : <B/>}` work without `.value`.
- *
- * Both rewrites are leaf-local; composite expressions like `x.length > 0`
- * are left alone (the user can add `.value` explicitly).
+ *     Sets local `rewroteRead`, which triggers the surrounding `h.track`
+ *     wrap in `wrapTracked`.
  */
-const rewriteValueReads = (expr: t.Expression): { expr: t.Expression; rewrote: boolean } => {
+const rewriteTrackedExpression = (
+  expr: t.Expression,
+  state: RewriteState,
+): { expr: t.Expression; rewroteRead: boolean } => {
   const file = t.file(t.program([t.expressionStatement(expr)]))
-  let rewrote = false
+  let rewroteRead = false
   traverse(file, {
+    CallExpression(path) {
+      const matched = matchValueMapCall(path.node)
+      if (!matched) return
+      const newCall = t.callExpression(t.identifier("list"), [matched.source, matched.arrow])
+      path.replaceWith(copyLoc(newCall, path.node))
+      state.wroteList = true
+      path.skip()
+    },
     MemberExpression(path) {
+      // Rewrite `obj.value` → `h.read(obj)` for *reads only*. Anything that
+      // writes to `.value` (assignment LHS `=`/`+=`/etc., `++`/`--`) is left
+      // bare so the emitted JS stays well-formed (`h.read(obj)++` would be
+      // a SyntaxError). For AtomRefs this is also exactly what the user
+      // wants surfaced — TypeScript's own `ts(2540) Cannot assign to
+      // 'value' because it is a read-only property` already fires at the
+      // right position. No custom diagnostic needed.
       const n = path.node
-      if (
-        !n.computed &&
-        t.isIdentifier(n.property) &&
-        n.property.name === "value" &&
-        !(t.isAssignmentExpression(path.parent) && path.parent.left === n)
-      ) {
-        path.replaceWith(t.callExpression(hMember("read"), [n.object as t.Expression]))
-        rewrote = true
-      }
-    },
-    ConditionalExpression(path) {
-      if (t.isIdentifier(path.node.test)) {
-        path.node.test = wrapPeek(path.node.test)
-        rewrote = true
-      }
-    },
-    LogicalExpression(path) {
-      if (t.isIdentifier(path.node.left)) {
-        path.node.left = wrapPeek(path.node.left)
-        rewrote = true
-      }
-      if (t.isIdentifier(path.node.right)) {
-        path.node.right = wrapPeek(path.node.right)
-        rewrote = true
-      }
-    },
-    UnaryExpression(path) {
-      if (path.node.operator === "!" && t.isIdentifier(path.node.argument)) {
-        path.node.argument = wrapPeek(path.node.argument)
-        rewrote = true
-      }
+      if (n.computed) return
+      if (!t.isIdentifier(n.property)) return
+      if (n.property.name !== "value") return
+      const parent = path.parent
+      if (t.isAssignmentExpression(parent) && parent.left === n) return
+      if (t.isUpdateExpression(parent) && parent.argument === n) return
+      path.replaceWith(t.callExpression(hRead(), [n.object as t.Expression]))
+      rewroteRead = true
     },
   })
   return {
     expr: (file.program.body[0] as t.ExpressionStatement).expression,
-    rewrote,
+    rewroteRead,
   }
 }
 
 /** Build the props object from JSX attributes. */
-const buildProps = (attrs: ReadonlyArray<t.JSXAttribute | t.JSXSpreadAttribute>): t.Expression => {
+const buildProps = (
+  attrs: ReadonlyArray<t.JSXAttribute | t.JSXSpreadAttribute>,
+  state: RewriteState,
+): t.Expression => {
   const properties: Array<t.ObjectProperty | t.SpreadElement> = []
   for (const attr of attrs) {
     if (t.isJSXSpreadAttribute(attr)) {
@@ -190,10 +239,10 @@ const buildProps = (attrs: ReadonlyArray<t.JSXAttribute | t.JSXSpreadAttribute>)
     } else if (t.isJSXExpressionContainer(attr.value)) {
       value = t.isJSXEmptyExpression(attr.value.expression)
         ? t.booleanLiteral(true)
-        : wrapTracked(attr.value.expression)
+        : wrapTracked(attr.value.expression, state)
     } else {
       // JSXElement/JSXFragment values are exotic — fall back to recursive transform
-      value = transformJsxNode(attr.value as t.JSXElement | t.JSXFragment)
+      value = transformJsxNode(attr.value as t.JSXElement | t.JSXFragment, state)
     }
     properties.push(
       t.objectProperty(
@@ -248,6 +297,7 @@ const jsxMemberToMember = (m: t.JSXMemberExpression): t.MemberExpression => {
 /** Transform a single JSX child node into an expression. */
 const transformChild = (
   child: t.JSXElement["children"][number],
+  state: RewriteState,
 ): t.Expression | null => {
   if (t.isJSXText(child)) {
     // Collapse JSX whitespace per JSX spec: trim trailing newlines, keep
@@ -260,21 +310,18 @@ const transformChild = (
   if (t.isJSXExpressionContainer(child)) {
     return t.isJSXEmptyExpression(child.expression)
       ? null
-      : wrapTracked(child.expression)
+      : wrapTracked(child.expression, state)
   }
   if (t.isJSXSpreadChild(child)) {
     // Rare; treat as a passthrough spread.
     return child.expression
   }
-  return transformJsxNode(child)
+  return transformJsxNode(child, state)
 }
 
 const RUNTIME_PKG = "@efx/runtime"
 
-const ensureRuntimeImports = (program: t.Program, wantFragment: boolean): void => {
-  const wanted = new Set(["h"])
-  if (wantFragment) wanted.add("Fragment")
-
+const ensureRuntimeImports = (program: t.Program, wanted: Set<string>): void => {
   // First pass: find an existing import from the runtime; drop names that
   // are already imported under their own identifier (no `as` alias).
   let existing: t.ImportDeclaration | undefined
@@ -356,18 +403,21 @@ const collectJsxRange = (node: t.JSXElement | t.JSXFragment): JsxRange => {
 }
 
 /** Transform a JSX element or fragment node into an h(...) call expression. */
-const transformJsxNode = (node: t.JSXElement | t.JSXFragment): t.CallExpression => {
+const transformJsxNode = (
+  node: t.JSXElement | t.JSXFragment,
+  state: RewriteState,
+): t.CallExpression => {
   const tag: t.Expression = t.isJSXFragment(node)
     ? copyLoc(t.identifier("Fragment"), node)
     : tagExpression(node.openingElement.name)
 
   const props: t.Expression = t.isJSXFragment(node)
     ? t.objectExpression([])
-    : buildProps(node.openingElement.attributes)
+    : buildProps(node.openingElement.attributes, state)
 
   const childArgs: t.Expression[] = []
   for (const child of node.children) {
-    const transformed = transformChild(child)
+    const transformed = transformChild(child, state)
     if (transformed) childArgs.push(transformed)
   }
 
@@ -405,18 +455,19 @@ export const transformEfx = (source: string, filename: string): TransformResult 
     },
   })
 
+  const state: RewriteState = { wroteList: false }
   let usedH = false
   let usedFragment = false
 
   traverse(ast, {
     JSXElement(path: NodePath<t.JSXElement>) {
       usedH = true
-      path.replaceWith(transformJsxNode(path.node))
+      path.replaceWith(transformJsxNode(path.node, state))
     },
     JSXFragment(path: NodePath<t.JSXFragment>) {
       usedH = true
       usedFragment = true
-      path.replaceWith(transformJsxNode(path.node))
+      path.replaceWith(transformJsxNode(path.node, state))
     },
   })
 
@@ -424,7 +475,12 @@ export const transformEfx = (source: string, filename: string): TransformResult 
   // Looks for an existing `import … from "@efx/runtime"` and adds the
   // missing names there; otherwise prepends a new import. Keeps the user's
   // imports untouched and avoids duplicate specifiers.
-  if (usedH) ensureRuntimeImports(ast.program, usedFragment)
+  if (usedH) {
+    const wanted = new Set(["h"])
+    if (usedFragment) wanted.add("Fragment")
+    if (state.wroteList) wanted.add("list")
+    ensureRuntimeImports(ast.program, wanted)
+  }
 
   const result = generate(
     ast,

--- a/packages/language/src/source-map.test.ts
+++ b/packages/language/src/source-map.test.ts
@@ -8,10 +8,11 @@ import { convertSourceMap } from "./source-map.ts"
  *
  * The point of these tests is to lock in the bidirectional position-mapping
  * contract: every Babel transform that shifts byte counts (paren strip on
- * single-arg arrows, `.value` → `h.read(x)`, bare-test → `h.peek(id)`, etc.)
- * produces mappings where source and generated lengths can differ. If we ever
- * lose track of that asymmetry, inlay-hint / hover / go-to-def positions
- * silently drift in the editor — PR #12 was one such regression.
+ * single-arg arrows, `.value` → `h.read(x)`, `.value.map(arrow → JSX)` →
+ * `list(...)`, etc.) produces mappings where source and generated lengths
+ * can differ. If we ever lose track of that asymmetry, inlay-hint / hover /
+ * go-to-def positions silently drift in the editor — PR #12 was one such
+ * regression.
  */
 
 const buildMappings = (src: string) => {
@@ -86,24 +87,65 @@ const view = <div>{x.value}</div>`
     expect(intersecting.length).toBeGreaterThan(0)
   })
 
-  it("bare-test rewrite: `{cond ? a : b}` → `h.peek(cond) ? a : b` adds 8 generated chars before `cond`", () => {
-    // The `cond` identifier in test position gets wrapped: `cond` → `h.peek(cond)`.
-    // The source `cond` (4 chars) keeps a mapping; the inserted prefix `h.peek(`
-    // and suffix `)` have no source counterpart, but together with the wrap
-    // they create a region where generated length > source length.
-    const src = `const cond = true
-const a = "a"
-const b = "b"
-const view = <div>{cond ? a : b}</div>`
+  it(".value.map → list rewrite: source `coll.value.map(...)` shrinks to `list(coll, ...)`", () => {
+    // The `<expr>.value.map(arrow → JSX)` pattern collapses into a `list()`
+    // call. Source `coll.value.map(` (15 chars) becomes generated `list(coll,`
+    // (10 chars) — a region where source length > generated length, mirror of
+    // the .value → h.read case where generated is wider.
+    const src = `import { AtomRef } from "effect/unstable/reactivity"
+const coll = AtomRef.collection<number>([])
+const view = <ul>{coll.value.map((item) => <li>{item}</li>)}</ul>`
     const { code, mappings } = buildMappings(src)
-    expect(code).toContain("h.peek(cond)")
-    // The mapping at source `cond` (inside the ternary test) should exist and
-    // have a sensible shape.
-    const condTestSrc = src.indexOf("{cond ?") + 1
-    const m = findBySourceOffset(mappings, condTestSrc)
-    expect(m, "expected a mapping at the test-position `cond`").toBeDefined()
-    expect(m!.lengths[0], "source length covers `cond`").toBeGreaterThanOrEqual(1)
-    expect(m!.generatedLengths![0]).toBeDefined()
+    expect(code).toContain("list(coll,")
+    // At least one mapping must bridge the source `coll.value.map(` region to
+    // the generated `list(coll,` region. Exact mapping shape depends on Babel
+    // codegen, but the contract is that we don't lose the span altogether.
+    const collValueMapSrc = src.indexOf("coll.value.map")
+    const generatedList = code.indexOf("list(coll,")
+    expect(collValueMapSrc).toBeGreaterThanOrEqual(0)
+    expect(generatedList).toBeGreaterThanOrEqual(0)
+    const intersecting = mappings.filter(
+      (m) =>
+        m.sourceOffsets[0]! >= collValueMapSrc &&
+        m.sourceOffsets[0]! <= collValueMapSrc + 15 &&
+        m.generatedOffsets[0]! >= generatedList &&
+        m.generatedOffsets[0]! <= generatedList + 10,
+    )
+    expect(
+      intersecting.length,
+      "expected a mapping bridging `coll.value.map(` to `list(coll,`",
+    ).toBeGreaterThan(0)
+    // Every mapping must still carry both lengths (no bare source-only or
+    // generated-only spans leaking through).
+    for (const m of mappings) {
+      expect(m.lengths).toHaveLength(1)
+      expect(m.generatedLengths).toHaveLength(1)
+    }
+  })
+
+  it("list arrow body: the inner `<Row>` tag-name position still maps for go-to-def", () => {
+    // The `.value.map → list(...)` rewrite uses `path.skip()` to halt the
+    // inner traversal, but the outer JSX traversal still rewrites the inner
+    // `<Row>` to `h(Row, ...)`. The Row tag's nameStart in source must keep
+    // a mapping that lands inside the generated `h(Row,` so editor
+    // go-to-definition on Row inside the list arrow still resolves.
+    const src = `const Row = (props: { item: number }) => null
+const coll = { value: [] as number[] }
+const view = <ul>{coll.value.map((item) => <Row item={item} />)}</ul>`
+    const { code, mappings } = buildMappings(src)
+    expect(code).toContain("list(coll,")
+    expect(code).toContain("h(Row,")
+    // Find the `R` of `<Row` in source (the tag name's start, +1 to skip `<`).
+    const rowTagSrc = src.indexOf("<Row") + 1
+    // ...and the `R` of `h(Row,` in generated.
+    const rowGenStart = code.indexOf("h(Row,") + "h(".length
+    const m = findBySourceOffset(mappings, rowTagSrc)
+    expect(m, "expected a mapping at source `Row` tag name").toBeDefined()
+    expect(
+      m!.generatedOffsets[0],
+      "source `Row` must map into generated `h(Row,` region",
+    ).toBeGreaterThanOrEqual(rowGenStart)
+    expect(m!.generatedOffsets[0]).toBeLessThanOrEqual(rowGenStart + "Row".length)
   })
 
   it("h.track wrap: source JSX expression becomes h.track(() => <expr>)", () => {

--- a/packages/runtime/AGENTS.md
+++ b/packages/runtime/AGENTS.md
@@ -4,7 +4,7 @@ What the user actually imports from when writing components.
 Public surface (from `src/index.ts`):
 
 - `h` — the view factory (the compile target for `<...>` source
-  syntax) + `h.track`/`h.read`/`h.peek` (compiler hooks)
+  syntax) + `h.track`/`h.read` (compiler hooks)
 - `mount` — DOM renderer (returns `Effect<void, E, R | AtomRegistry | Scope>`)
 - `list` — keyed reactive list helper (`View.List` IR node)
 - `Fragment` — `<>...</>` compile target
@@ -30,7 +30,7 @@ the editor margin. If you rename them, update the regex.
 
 | File | Purpose |
 |---|---|
-| `src/h.ts` | `h()` factory + `track`/`read`/`peek` reactivity-tracking machinery |
+| `src/h.ts` | `h()` factory + `track`/`read` reactivity-tracking machinery |
 | `src/coerce.ts` | `coerceAsync` (any child shape → `Effect<View>`) and `coerceSync` (render-time emission → `View`). Internal; not re-exported from `index.ts`. Owns `isAtomRef` (brand check against `AtomRef.TypeId` from `effect/unstable/reactivity`) |
 | `src/View.ts` | `View` IR (intermediate representation) — hand-written union of 6 named interfaces (`ViewText`, `ViewElement`, `ViewFragment`, `ViewReactive`, `ViewList`, `ViewEmpty`); constructors via `Data.taggedEnum<View>()`. The normalized DOM-materialization shape `mount` switches on. Plus `isView`, `VIEW_TAGS` |
 | `src/mount.ts` | DOM renderer. `buildDom(view, registry, scope) → Node`, `mount(app, el)`. Cleanup is delegated to `Scope` — every subscription/listener/release registers a finalizer on the scope it was created in, and parent-fork cascade tears them down on close |
@@ -54,21 +54,18 @@ ship our own atom/signal primitive.
 
 `mount` requires `AtomRegistry` in `R`. `EfxLive` provides it.
 
-## The track/read/peek dance
+## The track/read dance
 
 The compiler wraps `{expr}` JSX expressions in `h.track(() => expr)`
-**only when** it actually rewrote something inside (see
+**only when** it actually rewrote a `.value` read inside (see
 [compiler AGENTS.md](../compiler/AGENTS.md)). Inside that scope:
 
 - `h.read(ref)` — reads `.value`, registers `ref` as a tracked dep.
-- `h.peek(id)` — for AtomRef, unwraps + tracks; for non-AtomRef,
-  identity. Used for bare identifiers in test positions.
 
 `h.track` itself:
 
 1. Sets module-level `currentTracker` to a fresh dep set.
-2. Runs the thunk; `h.read`/`h.peek` add to the set when they see an
-   AtomRef.
+2. Runs the thunk; `h.read` adds to the set when it sees an AtomRef.
 3. **If the set is empty**, returns the thunk's result directly
    (no AtomRef wrap, no reactivity overhead — and the caller's
    static typing is preserved).
@@ -270,8 +267,14 @@ site preserves `T`, and accept a function child instead of a JSX
 list<T>(coll: AtomRef.Collection<T>, render: (item: AtomRef.AtomRef<T>, i: number) => …)
 ```
 
-Don't "fix" this by widening `h()`'s signature — see the root
-[AGENTS.md](../../AGENTS.md) anti-pattern about pluggable JSX
+Users normally never write `list()` by hand — the compiler rewrites
+`{coll.value.map(item => <Row item={item} />)}` in JSX expression
+position into this call. The function is exported and stable so the
+generated code has something to link to (and so escape hatches like
+"call `list` from non-JSX code" stay possible).
+
+Don't "fix" generic erasure by widening `h()`'s signature — see the
+root [AGENTS.md](../../AGENTS.md) anti-pattern about pluggable JSX
 backends. The narrow `h()` signature is what makes channel folding
 work; carrying a component's inner generic would require
 higher-rank polymorphism TS doesn't have.

--- a/packages/runtime/src/h.ts
+++ b/packages/runtime/src/h.ts
@@ -71,22 +71,6 @@ function readImpl(obj: unknown): unknown {
 }
 
 /**
- * "Use this value, track if it's an AtomRef, otherwise pass through."
- * Called by the compiler when it sees a bare identifier in a test
- * position (ternary test, `&&`/`||` operand, `!` argument) so that
- * `{loading ? <X /> : <Y />}` works without an explicit `.value`.
- */
-function peekImpl<T>(obj: AtomRef.ReadonlyRef<T>): T
-function peekImpl<T>(obj: T): T
-function peekImpl(obj: unknown): unknown {
-  if (isAtomRef(obj)) {
-    if (currentTracker) currentTracker.add(obj)
-    return obj.value
-  }
-  return obj
-}
-
-/**
  * The view factory.
  *
  * Takes a tag (intrinsic element name or a component function) and any
@@ -130,13 +114,14 @@ type HFn = <
  * - `h.read(obj)` — like `obj?.value` but, when called inside an
  *   `h.track` scope, registers `obj` as a dependency if it's an AtomRef.
  *
- * The compiler wraps every JSX expression in `h.track(() => …)` and
- * rewrites every `x.value` member access inside to `h.read(x)`, so users
- * can write `<div>{loading.value ? <X /> : <Y />}</div>` and have it be
- * reactive without any explicit subscribe code.
+ * Inside any JSX expression `{…}` that contains a `.value` read, the
+ * compiler rewrites each `x.value` to `h.read(x)` and wraps the whole
+ * expression in `h.track(() => …)` — so `<div>{loading.value ? <X /> : <Y />}</div>`
+ * becomes reactive without any explicit subscribe code. JSX expressions
+ * with no `.value` read pass through unwrapped so their static type is
+ * preserved.
  */
 export const h: HFn & {
   readonly track: typeof trackImpl
   readonly read: typeof readImpl
-  readonly peek: typeof peekImpl
-} = Object.assign(_h as HFn, { track: trackImpl, read: readImpl, peek: peekImpl })
+} = Object.assign(_h as HFn, { track: trackImpl, read: readImpl })


### PR DESCRIPTION
## Summary

- **Drop `h.peek`** (the bare-identifier-in-test-position implicit unwrap). Users write `.value` explicitly — types stay honest (`ref.value: boolean`, not `AtomRef<boolean>`) and reactivity reads are visible at the source.
- **Add `.value.map(arrow → JSX) → list(...)` compiler rewrite** for the one site where `.value` is purely a Collection unwrap. The result is a keyed `View.List` IR node; `mount` reconciles by ref identity. `list()` self-subscribes, so the call is *not* wrapped in `h.track` — the row's generic stays sharp instead of widening to `unknown`. Users no longer write `list(coll, …)` by hand; `Todos.efx` and `Lifecycle.efx` updated to the new pattern.
- **`.value++` / `--.value` no longer emit invalid `h.read(obj)++`.** Left bare; TS's own `ts(2540) Cannot assign to 'value' because it is a read-only property` already flags this at the right column for AtomRefs, so no custom diagnostic was added.
- **Per-call rewriter state** (`wroteList`) threaded through a `RewriteState` object instead of a module-level `let`.
- **Source-map regressions covered** for: the new `coll.value.map(` → `list(coll,` span, go-to-def landing on `<Row>` inside the list arrow body, and the existing `.value` → `h.read(x)` collapse.

## Test plan

- [x] `pnpm -r test` — 120 tests pass across `@efx/compiler` (57), `@efx/runtime` (38), `@efx/language` (17), `@efx/ts-plugin` (8), `@efx/check` integration
- [x] `pnpm -r typecheck` — 0 errors across all packages; `apps/demo` runs `@efx/check` and reports `Checked 8 files: 0 errors`
- [ ] Manual: `pnpm --filter @efx/demo dev` — confirm `Todos`, `Lifecycle`, `Counter`, `LiveUser`, `UserPage` still behave correctly after the demo rewrites