### PR TITLE
fix(ts-plugin): extract inlay-hint text reader, fix displayParts overwrite

### DIFF
--- a/packages/ts-plugin/AGENTS.md
+++ b/packages/ts-plugin/AGENTS.md
@@ -22,6 +22,7 @@ for tsserver to `require()`.
 | `src/index.ts` | Entry. Re-exports `pluginFactory` via `export =`. |
 | `src/jsx-tags.ts` | `findJsxTagPair` — takes a `JsxTagProvider` (the in-process seam) and uses its `jsxRanges` from the shared `EfxVirtualCode` to find tag-pair partners for document highlights. The service-proxy builds the provider by resolving the `EfxVirtualCode` from Volar's context. |
 | `src/classify-references.ts` | `classifyRefs` — decorates each ref with `{ isDef, isImport }` in one pass, with a per-call file-content cache so each source file is read at most once. `findReferences` then sorts on the precomputed booleans instead of doing disk I/O inside the comparator. |
+| `src/hint-text.ts` | `hintText(hint)` — reads an inlay hint's label across the shapes different TS versions use (`hint.text` string, `hint.text` parts, `hint.displayParts`), returning the first non-empty. Plus `SUPPRESS_RE`, the `_tag`/`_props`/`_children` regex. Pure + unit-tested so the filter doesn't need a tsserver. |
 | `src/service-proxy.ts` | `pluginFactory` — instantiates the shared LanguagePlugin via `createEfxLanguagePlugin<string>(identity)`, builds Volar's `createLanguageServicePlugin` (capturing the session `Language` through its `setup(language)` hook), then wraps the resulting `LanguageService` in a Proxy with a few method overrides (filter `@efx/runtime`'s `h.ts` from definition results, JSX tag-pair document highlights, `_tag`/`_props`/`_children` inlay-hint filter, reference dedup + sort). Resolves the per-`.efx` `EfxVirtualCode` from `language.scripts` when it needs `jsxRanges` or `source`. |
 | `src/classify-references.test.ts` | Unit tests for `classifyRefs` — injects a fake `readFile` to assert classification rules and per-call caching without touching disk. |
 | `src/plugin.test.mjs` | Manual smoke test loading the built bundle (`dist/index.cjs`) and asserting plugin shape. Not run by `pnpm test` (vitest config only picks up `*.test.ts`); invoke directly with `node` after building. |
@@ -135,9 +136,12 @@ hand-rolled.
 
 - **`provideInlayHints`** — `.efx`-only filter. Volar gives us all
   hints including the h() parameter labels (`_tag`, `_props`,
-  `_children`). We drop any hint whose text matches
-  `/^_?(tag|props|children):?$/i`. Reads `hint.text` AND
-  `hint.displayParts` (newer TS uses the latter).
+  `_children`). We drop any hint whose label matches `SUPPRESS_RE`.
+  Label extraction (`hintText`) and the regex live in `hint-text.ts`
+  (pure + unit-tested); `hintText` reads the first non-empty of
+  `hint.text` (string), `hint.text` (parts), or `hint.displayParts`
+  (newer TS) — first-non-empty so an empty `displayParts` can't clobber
+  a found label.
 
 - **`getCompletionsAtPosition`** — `.efx`-only span clamp. When the
   user types `count.` mid-edit and triggers completions, Babel's
@@ -249,7 +253,8 @@ pnpm --filter @efx/ts-plugin test
 ```
 
 Three phases: vitest runs the `*.test.ts` unit suites
-(currently `src/classify-references.test.ts`), the package builds
+(`classify-references.test.ts`, `jsx-tags.test.ts`,
+`hint-text.test.ts`), the package builds
 its CJS bundle, and `node test/integration.mjs` spawns a real
 tsserver subprocess and exercises the LSP protocol against it.
 The integration harness is the acceptance-level definition of "the

--- a/packages/ts-plugin/src/hint-text.test.ts
+++ b/packages/ts-plugin/src/hint-text.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest"
+import { hintText, SUPPRESS_RE } from "./hint-text.ts"
+
+describe("hintText", () => {
+  it("reads a plain string label", () => {
+    expect(hintText({ text: "_tag:" })).toBe("_tag:")
+  })
+
+  it("joins display-part array `text`", () => {
+    expect(hintText({ text: [{ text: "_props" }, { text: ":" }] })).toBe("_props:")
+  })
+
+  it("reads newer-TS `displayParts`", () => {
+    expect(hintText({ displayParts: [{ text: "_children" }, { text: ":" }] })).toBe(
+      "_children:",
+    )
+  })
+
+  // The bug this extraction fixes: an empty `displayParts` must not clobber a
+  // label already found in `text`. The old inline version overwrote it.
+  it("keeps `text` when `displayParts` is present but empty", () => {
+    expect(hintText({ text: "_tag:", displayParts: [] })).toBe("_tag:")
+  })
+
+  it("keeps `text` array when `displayParts` is empty", () => {
+    expect(hintText({ text: [{ text: "_tag" }, { text: ":" }], displayParts: [] })).toBe(
+      "_tag:",
+    )
+  })
+
+  it("returns empty string when nothing is populated", () => {
+    expect(hintText({})).toBe("")
+    expect(hintText({ text: "" })).toBe("")
+  })
+})
+
+describe("SUPPRESS_RE", () => {
+  it("matches the h() parameter labels (prefixed and not, with/without colon)", () => {
+    for (const s of ["_tag", "_tag:", "tag:", "_props:", "_children:", "Props"]) {
+      expect(SUPPRESS_RE.test(s)).toBe(true)
+    }
+  })
+
+  it("does not match unrelated labels", () => {
+    for (const s of ["count:", "name:", "tagName:", "children2:"]) {
+      expect(SUPPRESS_RE.test(s)).toBe(false)
+    }
+  })
+})

--- a/packages/ts-plugin/src/hint-text.ts
+++ b/packages/ts-plugin/src/hint-text.ts
@@ -1,0 +1,41 @@
+/**
+ * Matches the labels TypeScript emits for `h()`'s parameters — `_tag`,
+ * `_props`, `_children` (and the un-prefixed `tag:`/`props:`/`children:`
+ * forms). The TS plugin filters these inlay hints out of `.efx` files; see
+ * `service-proxy.ts`. Coupled by name to `@efx/runtime`'s `h` parameter
+ * names — documented in both packages' AGENTS.md.
+ */
+export const SUPPRESS_RE = /^_?(tag|props|children):?$/i
+
+/** The subset of an inlay hint we read a label string from. */
+export interface HintTextShape {
+  readonly text?: string | ReadonlyArray<{ readonly text: string }>
+  readonly displayParts?: ReadonlyArray<{ readonly text: string }>
+}
+
+/**
+ * Read an inlay hint's label text across the shapes different TypeScript
+ * versions use, returning the **first non-empty** one:
+ *   1. `hint.text` as a plain string (older TS)
+ *   2. `hint.text` as display parts (array of `{ text }`)
+ *   3. `hint.displayParts` (newer TS — more relevant since TS 6.0)
+ *
+ * First-non-empty fixes a latent bug in the previous inline version: it
+ * assigned the `displayParts` join *unconditionally* when `displayParts`
+ * existed, silently discarding an already-found `text` string/array when
+ * `displayParts` was present but empty.
+ */
+export function hintText(hint: HintTextShape): string {
+  if (typeof hint.text === "string" && hint.text.length > 0) {
+    return hint.text
+  }
+  if (Array.isArray(hint.text)) {
+    const joined = hint.text.map((p) => p.text).join("")
+    if (joined.length > 0) return joined
+  }
+  if (Array.isArray(hint.displayParts)) {
+    const joined = hint.displayParts.map((p) => p.text).join("")
+    if (joined.length > 0) return joined
+  }
+  return ""
+}

--- a/packages/ts-plugin/src/service-proxy.ts
+++ b/packages/ts-plugin/src/service-proxy.ts
@@ -4,6 +4,7 @@ import type * as ts from "typescript"
 import { createEfxLanguagePlugin, EfxVirtualCode } from "@efx/language"
 import { findJsxTagPair, type JsxTagProvider } from "./jsx-tags.ts"
 import { classifyRefs } from "./classify-references.ts"
+import { hintText, SUPPRESS_RE } from "./hint-text.ts"
 
 // tsserver identifies scripts by file path strings — asFileName is identity.
 const efxLanguagePlugin = createEfxLanguagePlugin<string>((scriptId) => scriptId)
@@ -194,21 +195,10 @@ export const pluginFactory: ts.server.PluginModuleFactory = (modules) => {
           if (prop === "provideInlayHints") {
             return wrapMethod("provideInlayHints", (hints, fileName) => {
               if (!fileName.endsWith(".efx")) return hints
-              return hints.filter((hint: ts.InlayHint) => {
-                // Extract text from various possible structures
-                let text = ""
-                if (typeof hint.text === "string") {
-                  text = hint.text
-                } else if (Array.isArray(hint.text)) {
-                  text = (hint.text as Array<{ text: string }>).map((p) => p.text).join("")
-                }
-                // Also check displayParts which is used in newer TS versions
-                const hintAny = hint as { displayParts?: Array<{ text: string }> }
-                if (hintAny.displayParts && Array.isArray(hintAny.displayParts)) {
-                  text = hintAny.displayParts.map((p) => p.text).join("")
-                }
-                return !/^_?(tag|props|children):?$/i.test(text)
-              })
+              // Drop the h() parameter labels (_tag/_props/_children). Text
+              // extraction + the suppression regex live in hint-text.ts so
+              // they're unit-testable without a tsserver.
+              return hints.filter((hint: ts.InlayHint) => !SUPPRESS_RE.test(hintText(hint)))
             })
           }
 


### PR DESCRIPTION
Architecture-review candidate #3.

## The bug

The inlay-hint suppression filter (`service-proxy.ts`, `provideInlayHints`) inlined a three-shape label extraction in the Proxy closure:

```ts
let text = ""
if (typeof hint.text === "string") text = hint.text
else if (Array.isArray(hint.text)) text = hint.text.map(p => p.text).join("")
const hintAny = hint as { displayParts?: ... }
if (hintAny.displayParts && Array.isArray(hintAny.displayParts))
  text = hintAny.displayParts.map(p => p.text).join("")   // <- overwrites unconditionally
```

The `displayParts` branch overwrote `text` whenever `displayParts` *existed*, silently discarding an already-found `hint.text` string/array when `displayParts` was present but empty. More likely to surface now that TS 6.0 leans on `displayParts`.

## The fix

Extract `hintText(hint)` + `SUPPRESS_RE` into `hint-text.ts` — pure and **unit-tested without a tsserver** — and read the **first non-empty** shape so an empty `displayParts` can't clobber a found label. The Proxy callback collapses to:

```ts
return hints.filter((hint) => !SUPPRESS_RE.test(hintText(hint)))
```

## Why

The label extraction + regex previously had no test surface (only reachable through a full tsserver subprocess). Now the contract is a pure input/output function with 8 cases pinning the precedence and the empty-`displayParts` regression. Serves the project's testability/AI-navigability goal — same shape as the existing `jsx-tags.ts` / `classify-references.ts` helpers.

## Verification

- `pnpm --filter @efx/ts-plugin test` — 3 unit suites pass (incl. new `hint-text.test.ts`) + tsserver integration still shows **"No h() parameter hints - PASS"** (filter works end-to-end through the helper).
- `pnpm -r typecheck` clean.

AGENTS.md updated (files table, `provideInlayHints` description, test-loop list).