### PR TITLE
refactor(ts-plugin): extract refKey/dedupeRefs/sortClassifiedRefs

### DIFF
--- a/packages/ts-plugin/AGENTS.md
+++ b/packages/ts-plugin/AGENTS.md
@@ -21,10 +21,10 @@ for tsserver to `require()`.
 |---|---|
 | `src/index.ts` | Entry. Re-exports `pluginFactory` via `export =`. |
 | `src/jsx-tags.ts` | `findJsxTagPair` — takes a `JsxTagProvider` (the in-process seam) and uses its `jsxRanges` from the shared `EfxVirtualCode` to find tag-pair partners for document highlights. The service-proxy builds the provider by resolving the `EfxVirtualCode` from Volar's context. |
-| `src/classify-references.ts` | `classifyRefs` — decorates each ref with `{ isDef, isImport }` in one pass, with a per-call file-content cache so each source file is read at most once. `findReferences` then sorts on the precomputed booleans instead of doing disk I/O inside the comparator. |
+| `src/classify-references.ts` | `classifyRefs` — decorates each ref with `{ isDef, isImport }` in one pass, with a per-call file-content cache so each source file is read at most once. Plus `refKey` (the `${fileName}:${textSpan.start}` identity), `dedupeRefs` (drop same-key hits, first-seen order), and `sortClassifiedRefs` (def→usages→imports ordering on the precomputed booleans). The two reference handlers compose these instead of inlining the key/sort logic. |
 | `src/hint-text.ts` | `hintText(hint)` — reads an inlay hint's label across the shapes different TS versions use (`hint.text` string, `hint.text` parts, `hint.displayParts`), returning the first non-empty. Plus `SUPPRESS_RE`, the `_tag`/`_props`/`_children` regex. Pure + unit-tested so the filter doesn't need a tsserver. |
 | `src/service-proxy.ts` | `pluginFactory` — instantiates the shared LanguagePlugin via `createEfxLanguagePlugin<string>(identity)`, builds Volar's `createLanguageServicePlugin` (capturing the session `Language` through its `setup(language)` hook), then wraps the resulting `LanguageService` in a Proxy with a few method overrides (filter `@efx/runtime`'s `h.ts` from definition results, JSX tag-pair document highlights, `_tag`/`_props`/`_children` inlay-hint filter, reference dedup + sort). Resolves the per-`.efx` `EfxVirtualCode` from `language.scripts` when it needs `jsxRanges` or `source`. |
-| `src/classify-references.test.ts` | Unit tests for `classifyRefs` — injects a fake `readFile` to assert classification rules and per-call caching without touching disk. |
+| `src/classify-references.test.ts` | Unit tests for `classifyRefs` (injected fake `readFile`, no disk), plus `refKey`/`dedupeRefs`/`sortClassifiedRefs` — pins the dedup key, first-seen order, and the def→usages→imports ordering (incl. usage-tier stability) without a tsserver. |
 | `src/plugin.test.mjs` | Manual smoke test loading the built bundle (`dist/index.cjs`) and asserting plugin shape. Not run by `pnpm test` (vitest config only picks up `*.test.ts`); invoke directly with `node` after building. |
 | `vitest.config.ts` | Picks up `src/**/*.test.ts`. The package's `test` script runs vitest first, then builds and runs the integration harness. |
 | `test/integration.mjs` | tsserver-subprocess harness. The acceptance-level check that the plugin really works end-to-end. |
@@ -157,21 +157,25 @@ hand-rolled.
   next-line token. Same treatment for per-entry `replacementSpan`
   in case tsserver populates it.
 
-- **`getReferencesAtPosition` / `findReferences`** — dedupe + sort:
+- **`getReferencesAtPosition` / `findReferences`** — dedupe + sort.
+  Both compose the helpers in `classify-references.ts` rather than
+  inlining the logic; the two handlers iterate different shapes (a
+  flat `ReferenceEntry[]` vs the flattened nested `ReferencedSymbol[]`),
+  so they share the key formula, not the loop.
   - Filter out hits in `@efx/runtime`'s `h.ts` (same reason as the
     definition overrides).
-  - Deduplicate by `${fileName}:${textSpan.start}`. `findReferences`
-    in particular dedupes **across symbols** (its result is an
-    array of symbols, each with references), because TS often
-    returns the same logical reference under both the renamed
-    component name and the `h(...)` call symbol.
-  - Sort: definition first, then non-imports (usages), then
-    imports. The "is this an import line?" decision needs to read
-    the source file — `classifyRefs` does that **once** per
-    distinct file before the sort runs, so the comparator only
-    looks at precomputed booleans. Previously the comparator
-    called `ts.sys.readFile` inline, paying O(N log N) reads of
-    the same handful of files.
+  - `dedupeRefs` deduplicates by `refKey` (`${fileName}:${textSpan.start}`).
+    `findReferences` flattens its nested result first and dedupes
+    **across symbols**, because TS often returns the same logical
+    reference under both the renamed component name and the `h(...)`
+    call symbol.
+  - `sortClassifiedRefs` orders definition first, then usages, then
+    imports. The "is this an import line?" decision needs to read the
+    source file — `classifyRefs` does that **once** per distinct file
+    before the sort, so the comparator only looks at precomputed
+    booleans. (Previously the comparator called `ts.sys.readFile`
+    inline, paying O(N log N) reads of the same handful of files; and
+    the policy itself was untestable inside the Proxy closure.)
 
 ## Cross-file resolution
 

--- a/packages/ts-plugin/src/classify-references.test.ts
+++ b/packages/ts-plugin/src/classify-references.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest"
 import type * as ts from "typescript"
-import { classifyRefs } from "./classify-references.ts"
+import {
+  classifyRefs,
+  dedupeRefs,
+  refKey,
+  sortClassifiedRefs,
+  type ClassifiedRef,
+} from "./classify-references.ts"
 
 const span = (start: number, length = 1): ts.TextSpan => ({ start, length })
 
@@ -102,5 +108,82 @@ describe("classifyRefs", () => {
     const refs = [{ fileName: "b.ts", textSpan: span(content.indexOf("X")) }]
     const out = classifyRefs(refs, def, () => content)
     expect(out[0]?.isImport).toBe(true)
+  })
+})
+
+describe("refKey", () => {
+  it("combines file path and start offset", () => {
+    expect(refKey({ fileName: "a.ts", textSpan: span(42) })).toBe("a.ts:42")
+  })
+
+  it("distinguishes same offset in different files and different offsets", () => {
+    expect(refKey({ fileName: "a.ts", textSpan: span(1) })).not.toBe(
+      refKey({ fileName: "b.ts", textSpan: span(1) }),
+    )
+    expect(refKey({ fileName: "a.ts", textSpan: span(1) })).not.toBe(
+      refKey({ fileName: "a.ts", textSpan: span(2) }),
+    )
+  })
+})
+
+describe("dedupeRefs", () => {
+  it("drops same-(file,start) duplicates, keeping first-seen order", () => {
+    const refs = [
+      { fileName: "a.ts", textSpan: span(10) },
+      { fileName: "a.ts", textSpan: span(20) },
+      { fileName: "a.ts", textSpan: span(10) }, // dup of #0
+      { fileName: "b.ts", textSpan: span(10) }, // same start, other file → kept
+    ]
+    const out = dedupeRefs(refs)
+    expect(out.map(refKey)).toEqual(["a.ts:10", "a.ts:20", "b.ts:10"])
+  })
+
+  it("dedupes by start only, ignoring length", () => {
+    const out = dedupeRefs([
+      { fileName: "a.ts", textSpan: span(5, 1) },
+      { fileName: "a.ts", textSpan: span(5, 99) },
+    ])
+    expect(out).toHaveLength(1)
+  })
+})
+
+describe("sortClassifiedRefs", () => {
+  const mk = (id: string, isDef: boolean, isImport: boolean): ClassifiedRef<string> => ({
+    ref: id,
+    isDef,
+    isImport,
+  })
+
+  it("orders definition first, then usages, then imports last", () => {
+    const sorted = sortClassifiedRefs([
+      mk("import1", false, true),
+      mk("usage1", false, false),
+      mk("def", true, false),
+      mk("import2", false, true),
+      mk("usage2", false, false),
+    ])
+    expect(sorted.map((c) => c.ref)).toEqual([
+      "def",
+      "usage1",
+      "usage2",
+      "import1",
+      "import2",
+    ])
+  })
+
+  it("is stable within the usage tier (preserves input order)", () => {
+    const sorted = sortClassifiedRefs([
+      mk("u1", false, false),
+      mk("u2", false, false),
+      mk("u3", false, false),
+    ])
+    expect(sorted.map((c) => c.ref)).toEqual(["u1", "u2", "u3"])
+  })
+
+  it("does not mutate the input array", () => {
+    const input = [mk("import1", false, true), mk("def", true, false)]
+    const snapshot = input.map((c) => c.ref)
+    sortClassifiedRefs(input)
+    expect(input.map((c) => c.ref)).toEqual(snapshot)
   })
 })

--- a/packages/ts-plugin/src/classify-references.ts
+++ b/packages/ts-plugin/src/classify-references.ts
@@ -17,6 +17,48 @@ export type ClassifiedRef<R> = {
   readonly isImport: boolean
 }
 
+/**
+ * Identity key for a reference: file path + start offset. The single
+ * definition of "these two reference hits are the same one" — both reference
+ * handlers in `service-proxy.ts` dedupe with this. They iterate different
+ * shapes (a flat `ReferenceEntry[]` vs the flattened nested
+ * `ReferencedSymbol[]`), so they share the key formula, not the loop.
+ */
+export const refKey = (ref: { fileName: string; textSpan: ts.TextSpan }): string =>
+  `${ref.fileName}:${ref.textSpan.start}`
+
+/** Drop duplicate reference hits (same `refKey`), preserving first-seen order. */
+export function dedupeRefs<R extends { fileName: string; textSpan: ts.TextSpan }>(
+  refs: ReadonlyArray<R>,
+): R[] {
+  const seen = new Set<string>()
+  const out: R[] = []
+  for (const ref of refs) {
+    const key = refKey(ref)
+    if (seen.has(key)) continue
+    seen.add(key)
+    out.push(ref)
+  }
+  return out
+}
+
+/**
+ * Ordering policy for find-references results: definition first, then usages,
+ * then imports last. Sorts on the precomputed `isDef`/`isImport` booleans
+ * (from `classifyRefs`) so no source re-reads happen in the comparator.
+ * Stable for the equal (usage) case — Node's sort preserves input order, so
+ * usages keep tsserver's original ordering.
+ */
+export function sortClassifiedRefs<R>(
+  classified: ReadonlyArray<ClassifiedRef<R>>,
+): ClassifiedRef<R>[] {
+  return [...classified].sort((a, b) => {
+    if (a.isDef !== b.isDef) return a.isDef ? -1 : 1
+    if (a.isImport !== b.isImport) return a.isImport ? 1 : -1
+    return 0
+  })
+}
+
 export function classifyRefs<R extends { fileName: string; textSpan: ts.TextSpan }>(
   refs: ReadonlyArray<R>,
   def: { fileName: string; textSpan: ts.TextSpan },

--- a/packages/ts-plugin/src/service-proxy.ts
+++ b/packages/ts-plugin/src/service-proxy.ts
@@ -3,7 +3,7 @@ import type { Language } from "@volar/language-core"
 import type * as ts from "typescript"
 import { createEfxLanguagePlugin, EfxVirtualCode } from "@efx/language"
 import { findJsxTagPair, type JsxTagProvider } from "./jsx-tags.ts"
-import { classifyRefs } from "./classify-references.ts"
+import { classifyRefs, dedupeRefs, sortClassifiedRefs } from "./classify-references.ts"
 import { hintText, SUPPRESS_RE } from "./hint-text.ts"
 
 // tsserver identifies scripts by file path strings — asFileName is identity.
@@ -205,45 +205,23 @@ export const pluginFactory: ts.server.PluginModuleFactory = (modules) => {
           if (prop === "getReferencesAtPosition") {
             return wrapMethod("getReferencesAtPosition", (result) => {
               if (!result) return result
-              const filtered = filterRuntimeHits(result)
-              const seen = new Set<string>()
-              return filtered.filter(r => {
-                const key = `${r.fileName}:${r.textSpan.start}`
-                if (seen.has(key)) return false
-                seen.add(key)
-                return true
-              })
+              return dedupeRefs(filterRuntimeHits(result))
             })
           }
 
           if (prop === "findReferences") {
             return wrapMethod("findReferences", (result) => {
               if (!result) return result
-              // Deduplicate across ALL symbols, not per-symbol
-              const allRefs: ts.ReferencedSymbolEntry[] = []
-              const seen = new Set<string>()
-              for (const symbol of result) {
-                for (const ref of symbol.references) {
-                  const filtered = filterRuntimeHit(ref)
-                  if (!filtered) continue
-                  const key = `${filtered.fileName}:${filtered.textSpan.start}`
-                  if (seen.has(key)) continue
-                  seen.add(key)
-                  allRefs.push(filtered)
-                }
-              }
               const firstSymbol = result[0]
               if (!firstSymbol) return result
               const def = firstSymbol.definition
-              // Classify once (one read per distinct file), then sort on the
-              // booleans. Otherwise the comparator would re-read source for
-              // each pair it compared.
-              const classified = classifyRefs(allRefs, def, ts.sys.readFile)
-              classified.sort((a, b) => {
-                if (a.isDef !== b.isDef) return a.isDef ? -1 : 1
-                if (a.isImport !== b.isImport) return a.isImport ? 1 : -1
-                return 0
-              })
+              // Flatten the nested ReferencedSymbol[] into one list, drop h.ts
+              // hits, then dedupe across ALL symbols (not per-symbol) with the
+              // shared refKey. Classify once (one read per distinct file), then
+              // apply the def→usages→imports ordering — both extracted next to
+              // classifyRefs so the policy is unit-tested without a tsserver.
+              const allRefs = dedupeRefs(filterRuntimeHits(result.flatMap((s) => s.references)))
+              const classified = sortClassifiedRefs(classifyRefs(allRefs, def, ts.sys.readFile))
               return [{
                 definition: def,
                 references: classified.map((c) => c.ref),


### PR DESCRIPTION
Architecture-review candidate #2 (the last remaining one).

## Problem

The reference handlers in `service-proxy.ts` inlined two things in their Proxy closures:
- The dedup key `${fileName}:${textSpan.start}` — written at **both** `getReferencesAtPosition` and `findReferences` (drift risk: add a column to one site, forget the other).
- The **sort comparator** (definition → usages → imports) — the ordering *contract*, buried in a closure with **no test surface** (only reachable through a full tsserver subprocess).

## Change

Extract three pure helpers beside `classifyRefs` in `classify-references.ts`:
- `refKey(ref)` — one definition of "these two hits are the same reference"
- `dedupeRefs(refs)` — drop same-key hits, first-seen order
- `sortClassifiedRefs(classified)` — def-first / usages / imports-last, sorting on the precomputed `isDef`/`isImport` booleans

Both handlers now compose them:
- `getReferencesAtPosition` → `dedupeRefs(filterRuntimeHits(result))`
- `findReferences` → flatten nested result → `dedupeRefs` (across symbols) → `classifyRefs` once → `sortClassifiedRefs`

The two handlers still iterate **different shapes** (flat `ReferenceEntry[]` vs flattened nested `ReferencedSymbol[]`) — they share the key formula, not the loop, exactly as the review prescribed. `readFile` stays injected; the once-per-file read optimization is preserved.

## Why

The ordering policy is now a pure input/output function with **7 new unit tests** (order, usage-tier stability, no-mutation, key formula, dedupe semantics) — testable without a tsserver. The interface becomes the test surface.

## Verification

- `pnpm --filter @efx/ts-plugin typecheck` — clean
- `classify-references.test.ts` — 15 tests pass (was 8)
- tsserver integration still **"3 references in .efx files - PASS"** (dedup + sort work end-to-end)

AGENTS.md updated (files table, proxy-wrapper section, test-loop list).