### PR TITLE
fix(runtime): drop Stream from channel-fold types (match coerceAsync)

### DIFF
--- a/apps/demo/src/channels.test-d.ts
+++ b/apps/demo/src/channels.test-d.ts
@@ -4,7 +4,7 @@
  * Each assertion either holds or produces a type error naming the
  * mismatched channel — this *is* the demonstration.
  */
-import type { Effect } from "effect"
+import type { Chunk, Effect, Option, Result } from "effect"
 import type { AtomRegistry } from "effect/unstable/reactivity"
 import { h, type View } from "@efx/runtime"
 import { Counter } from "./Counter.efx"
@@ -122,6 +122,25 @@ void WrongType
 // @ts-expect-error — extra prop not declared on component
 const Extra = h(UserPage, { userId: "42", nope: true })
 void Extra
+
+// ─── Container parity: ChildE/ChildR must peel exactly what coerceAsync
+//     peels at runtime (Fold.ts ↔ coerce.ts). A shape folded here but not
+//     peeled there makes the channel claim a *lie* (the type promises an E/R
+//     the runtime would `String(v)` away). These pin the inner Effect's E/R
+//     folding through each peelable container. `Stream` is in NEITHER — it is
+//     deliberately not peeled, so it contributes no channels.
+
+declare const optEff: Option.Option<Effect.Effect<View, HttpError, Http>>
+const WithOption = h("div", {}, optEff)
+assertEquals<typeof WithOption, Effect.Effect<View, HttpError, Http>>()
+
+declare const resEff: Result.Result<Effect.Effect<View, HttpError, Http>, unknown>
+const WithResult = h("div", {}, resEff)
+assertEquals<typeof WithResult, Effect.Effect<View, HttpError, Http>>()
+
+declare const chunkEff: Chunk.Chunk<Effect.Effect<View, HttpError, Http>>
+const WithChunk = h("div", {}, chunkEff)
+assertEquals<typeof WithChunk, Effect.Effect<View, HttpError, Http>>()
 
 // Note: the type assertions above are the **load-bearing proof** of the POC.
 // If they compile, channels are surviving the tree.

--- a/packages/runtime/src/types/Fold.ts
+++ b/packages/runtime/src/types/Fold.ts
@@ -1,4 +1,4 @@
-import type { Chunk, Effect, Option, Result, Stream } from "effect"
+import type { Chunk, Effect, Option, Result } from "effect"
 import type { Atom, AtomRef } from "effect/unstable/reactivity"
 import type { View } from "../View.ts"
 import type { IntrinsicProps } from "./Html.ts"
@@ -10,6 +10,12 @@ import type { IntrinsicProps } from "./Html.ts"
  *
  * Recursion is handled at the use site by `ChildE`/`ChildR` — they recurse
  * via `infer` inside conditional types, which TS does support.
+ *
+ * This set must stay in lockstep with the containers `coerceAsync` peels in
+ * `../coerce.ts` (Effect, Option, Result, Chunk, Atom, AtomRef, array). A
+ * shape listed here but not peeled there makes the channel fold *lie* — the
+ * type claims an E/R the runtime never produces (it would `String(v)` the
+ * value instead). `apps/demo/src/channels.test-d.ts` pins this parity.
  */
 export type Child =
   | Effect.Effect<View, any, any>
@@ -22,7 +28,6 @@ export type Child =
   | Option.Option<unknown>
   | Result.Result<unknown, any>
   | Chunk.Chunk<unknown>
-  | Stream.Stream<unknown, any, any>
   | Atom.Atom<unknown>
   | AtomRef.ReadonlyRef<unknown>
   | ReadonlyArray<unknown>
@@ -36,7 +41,6 @@ export type Child =
  */
 export type ChildE<C> =
   C extends Effect.Effect<any, infer E, any> ? E :
-  C extends Stream.Stream<infer T, infer E, any> ? E | ChildE<T> :
   C extends Option.Option<infer T> ? ChildE<T> :
   C extends Result.Result<infer A, any> ? ChildE<A> :
   C extends Chunk.Chunk<infer T> ? ChildE<T> :
@@ -54,7 +58,6 @@ export type ChildE<C> =
  */
 export type ChildR<C> =
   C extends Effect.Effect<any, any, infer R> ? R :
-  C extends Stream.Stream<infer T, any, infer R> ? R | ChildR<T> :
   C extends Option.Option<infer T> ? ChildR<T> :
   C extends Result.Result<infer A, any> ? ChildR<A> :
   C extends Chunk.Chunk<infer T> ? ChildR<T> :


### PR DESCRIPTION
Architecture-review candidate **A1** (a real correctness bug surfaced by the two-track review).

## The bug

`Fold.ts` listed `Stream.Stream` in `ChildE`/`ChildR` (and the `Child` doc union), but `coerceAsync` in `coerce.ts` has **no Stream branch** — a `Stream` value falls through to `String(v)`. So the type system *claimed* a Stream child's `E`/`R` fold while `mount` would stringify it. The channel claim was a **lie**, and `channels.test-d.ts` never asserted Fold↔coerce parity.

## Fix (conservative — make the types match the runtime)

- Remove `Stream` from `ChildE`, `ChildR`, the `Child` union, and the import. If Stream rendering is ever wanted, add it to `coerceAsync` **first**, then the type.
- Document the Fold↔coerce parity invariant on the `Child` union.
- Add per-container parity assertions (Option/Result/Chunk wrapping an Effect) to `channels.test-d.ts`, through the public `h()`, so a future divergence fails `typecheck`.

Not a registry/codegen — TS can't express "generate predicates and conditional types from one source", and that'd add a wrapper the minimal-API invariant discourages.

## Verification

Type-only + type-test change. `pnpm -r typecheck` (demo via `@efx/check`) and `pnpm -r test` stay green.