### PR TITLE
feat(testing): in-process component test harness (@efx/testing)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,12 @@ compiler eats and converts into `h()` calls." Not the React thing.
   Oxc type-strip via `transformWithOxc`, returning `moduleType: "js"`),
   rewrites `.efx` URLs with `?import` so strict-MIME browsers accept the
   response.
+- **[`packages/testing/`](./packages/testing/AGENTS.md)** — in-process
+  component test harness. `render(app, layer?)` mounts a component into a
+  happy-dom DOM, drives it (click/fire/tick), and tears it down — the
+  deterministic middle layer between `channels.test-d.ts` (compile-time)
+  and the browser probes. The `layer` requirement is type-enforced so a
+  missing service is a compile error (channels not swallowed).
 - **[`apps/demo/`](./apps/demo/AGENTS.md)** — usage patterns by
   primitive (Counter, UserPage, LiveUser, Todos, Lifecycle).
   Also home to `channels.test-d.ts`, the compile-time proof.
@@ -152,7 +158,7 @@ compiler eats and converts into `h()` calls." Not the React thing.
 
 ## Tooling at a glance
 
-- pnpm workspace, 6 packages (4 publishable + demo + workspace root).
+- pnpm workspace, 7 packages (4 publishable + `@efx/testing` + demo + workspace root).
 - Effect v4 / `effect-smol` (currently `effect@4.0.0-beta.70`).
 - Vitest — compiler tests use plain `vitest`; runtime channel-fold
   type-tests via `expectTypeOf` at typecheck time.

--- a/packages/testing/AGENTS.md
+++ b/packages/testing/AGENTS.md
@@ -1,0 +1,87 @@
+# `@efx/testing` — in-process component test harness
+
+Mount an efx component into an in-process DOM, drive it, and tear it
+down — without a browser or the Vite dev server. Fills the gap between
+the type-level proof (`apps/demo/src/channels.test-d.ts`) and the
+browser probes (`scripts/probe-*.mjs`): a deterministic, fast middle
+layer for "does this component actually render and react?"
+
+Public surface: `render(app, layer?)` returning a `RenderResult`.
+
+## What it does
+
+```ts
+const ui = await render(UserPage({ userId: "42" }), Layer.mergeAll(HttpTest, ThemeTest))
+expect(ui.text(".user-card strong")).toBe("Ada Lovelace")
+ui.click(".refresh")
+await ui.tick()
+await ui.unmount()
+```
+
+- `render(app, layer?)` — `app` is a component result (`Component(props)`
+  or `h(Component, props)`), i.e. an `Effect<View, E, R>`. Creates a
+  container on `document.body`, makes a Closeable `Scope`, and runs
+  `mount(app, container)` with `EfxLive` (AtomRegistry) + that scope
+  provided. Returns once the DOM is attached.
+- `RenderResult` — `get`/`query`/`all`/`text` (DOM queries),
+  `click`/`fire` (dispatch bubbling events that hit the component's
+  handlers), `tick()` (flush a macrotask so async/atom updates settle),
+  `unmount()` (close the scope → fire every finalizer → detach).
+
+## The load-bearing invariant: do NOT swallow E/R
+
+The harness injects only `AtomRegistry` + `Scope`. Everything else the
+component requires is `R` the **caller** must satisfy with `layer`, and
+the type makes that mandatory:
+
+```ts
+type Required<R> = Exclude<R, AtomRegistry | Scope>
+render(app, ...rest: [Required<R>] extends [never]
+  ? [layer?: Layer<never>]            // no extra services → layer optional
+  : [layer: Layer<Required<R>>])      // missing a service → COMPILE ERROR
+```
+
+A component needing `Http` won't `render` without an `Http` layer — the
+same forgotten-`Layer`-is-a-compile-error guarantee efx gives at a real
+`mount`. **Never** loosen this to an untyped `layer?` default or a cast
+that lies about coverage (`Layer.empty as Layer<Required<R>>`): that
+would defeat the thesis exactly where it should be proven. The internal
+`Layer.empty` fallback is only reached when `Required<R>` is `never`.
+
+## Why a Closeable scope (not `Effect.scoped`)
+
+`mount` registers every subscription/listener/`acquireRelease` release
+as a finalizer on the ambient `Scope`. The harness makes that scope with
+`Scope.makeUnsafe()` and holds it open across interaction, then closes it
+in `unmount()` — so a test can assert that finalizers fire on teardown
+(the in-process equivalent of `scripts/probe-lifecycle.mjs`). Using
+`Effect.scoped` would close the scope as soon as `mount` returned, tearing
+the component down before you could drive it.
+
+## Setup
+
+- Tests run under `environment: "happy-dom"` (`vitest.config.ts`) so
+  `document`/`HTMLElement`/`MouseEvent` exist in-process. `happy-dom` is a
+  devDependency.
+- Build components in tests with raw `h()` calls — no `.efx` compiler is
+  needed; an `AtomRef` passed as a child coerces to a reactive node, so
+  reactivity is exercisable without the Babel transform.
+
+## Anti-patterns
+
+- Don't add a `waitFor(predicate)` polling helper until a test needs it;
+  `tick()` + synchronous `AtomRef` reactivity covers the current cases.
+- Don't provide the component's real production layers here by default —
+  tests pass their own (often test doubles). The harness only injects the
+  framework infra (`EfxLive` + scope).
+- Don't reach into `RenderResult.container` to mutate the DOM directly;
+  drive the component through `click`/`fire` so the reactive path runs.
+
+## Related context
+
+- [`@efx/runtime`](../runtime/AGENTS.md) — `mount`, `EfxLive`, the View IR
+  this harness drives.
+- [`apps/demo/channels.test-d.ts`](../../apps/demo/src/channels.test-d.ts)
+  — the type-level channel proof (compile-time peer to this runtime proof).
+- [`scripts/`](../../scripts/AGENTS.md) — the browser probes this
+  complements (use those for HMR / real-browser behaviors).

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@efx/testing",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@efx/runtime": "workspace:*",
+    "effect": "4.0.0-beta.71"
+  },
+  "devDependencies": {
+    "happy-dom": "^20.9.0",
+    "vitest": "^4.1.7"
+  }
+}

--- a/packages/testing/src/index.test.ts
+++ b/packages/testing/src/index.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest"
+import { Context, Effect, Layer } from "effect"
+import { AtomRef } from "effect/unstable/reactivity"
+import { h } from "@efx/runtime"
+import { render } from "./index.ts"
+
+// Components are built with raw `h()` calls (no `.efx` compiler needed in the
+// unit test) — an AtomRef passed as a child coerces to a reactive node.
+
+describe("render() harness", () => {
+  it("mounts a component and reflects a reactive update from a click", async () => {
+    const Counter = Effect.fn(function* () {
+      const count = AtomRef.make(0)
+      return yield* h(
+        "div",
+        { class: "counter" },
+        h("button", { class: "inc", onclick: () => count.update((n) => n + 1) }, "+"),
+        h("span", { class: "n" }, count),
+      )
+    })
+
+    const ui = await render(Counter())
+    expect(ui.text(".n")).toBe("0")
+
+    ui.click(".inc")
+    await ui.tick()
+    expect(ui.text(".n")).toBe("1")
+
+    ui.click(".inc")
+    await ui.tick()
+    expect(ui.text(".n")).toBe("2")
+
+    await ui.unmount()
+    expect(document.body.contains(ui.container)).toBe(false)
+  })
+
+  it("fires scope finalizers on unmount", async () => {
+    const log: string[] = []
+    const Resource = Effect.fn(function* () {
+      yield* Effect.acquireRelease(
+        Effect.sync(() => log.push("acquire")),
+        () => Effect.sync(() => log.push("release")),
+      )
+      return yield* h("div", { class: "res" }, "live")
+    })
+
+    const ui = await render(Resource())
+    expect(ui.text(".res")).toBe("live")
+    expect(log).toEqual(["acquire"])
+
+    await ui.unmount()
+    expect(log).toEqual(["acquire", "release"])
+  })
+
+  it("renders a component once its required service is provided via layer", async () => {
+    class Greeter extends Context.Service<Greeter, {
+      readonly hello: (name: string) => string
+    }>()("test/Greeter") {}
+
+    const GreeterTest: Layer.Layer<Greeter> = Layer.succeed(Greeter, {
+      hello: (name) => `hi ${name}`,
+    })
+
+    const Hello = Effect.fn(function* () {
+      const greeter = yield* Greeter
+      return yield* h("p", { class: "msg" }, greeter.hello("ada"))
+    })
+
+    // `render` requires a layer covering Greeter — omitting it is a compile
+    // error (the channel is not swallowed). Provide the test layer:
+    const ui = await render(Hello(), GreeterTest)
+    expect(ui.text(".msg")).toBe("hi ada")
+    await ui.unmount()
+  })
+})

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -1,0 +1,106 @@
+import { Effect, Exit, Layer, Scope } from "effect"
+import type { AtomRegistry } from "effect/unstable/reactivity"
+import { EfxLive, mount, type View } from "@efx/runtime"
+
+/**
+ * Services the harness provides for you: the `AtomRegistry` (via `EfxLive`)
+ * and the ambient `Scope` (held open across interaction, closed on `unmount`).
+ * Everything else a component requires is `R` you must satisfy with `layer` —
+ * if you forget one, `render` fails to type-check. That's deliberate: the
+ * harness must NOT swallow the `E`/`R` channels, or it would defeat the whole
+ * point of efx at the test site.
+ */
+type Injected = AtomRegistry.AtomRegistry | Scope.Scope
+
+/** The component requirements you must provide — everything except what the harness injects. */
+type Required<R> = Exclude<R, Injected>
+
+/** Handle to a mounted component: query the DOM, fire events, settle async, tear down. */
+export interface RenderResult {
+  /** The container the component was mounted into (attached to `document.body`). */
+  readonly container: HTMLElement
+  /** First match for `selector`, or throw if none (use when you expect it to exist). */
+  get(selector: string): HTMLElement
+  /** First match for `selector`, or `null`. */
+  query(selector: string): HTMLElement | null
+  /** All matches for `selector`. */
+  all(selector: string): HTMLElement[]
+  /** Trimmed `textContent` of the first match (or the container when `selector` is omitted). */
+  text(selector?: string): string
+  /** Dispatch a bubbling `click` at the first match — fires the component's `onclick`. */
+  click(selector: string): void
+  /** Dispatch a bubbling event of `type` at the first match (e.g. `"input"`, `"submit"`). */
+  fire(selector: string, type: string): void
+  /** Flush microtasks + one macrotask so async/atom-driven updates settle. */
+  tick(): Promise<void>
+  /** Close the scope (firing every finalizer) and detach the container. */
+  unmount(): Promise<void>
+}
+
+const el = (container: HTMLElement, selector: string): HTMLElement => {
+  const found = container.querySelector(selector)
+  if (!found) throw new Error(`render(): no element matches ${JSON.stringify(selector)}`)
+  return found as HTMLElement
+}
+
+/**
+ * Mount a component into an in-process DOM and return a handle to drive it.
+ *
+ * `app` is a component result — `Component(props)` or `h(Component, props)` —
+ * i.e. an `Effect<View, E, R>`. Provide a `layer` covering every service the
+ * component needs (the harness adds `AtomRegistry` + `Scope`); omit it only
+ * when the component requires nothing else. A missing service is a compile
+ * error, exactly as it would be at a real `mount`.
+ *
+ * ```ts
+ * const ui = await render(UserPage({ userId: "42" }), Layer.mergeAll(HttpTest, ThemeTest))
+ * expect(ui.text(".user-card strong")).toBe("Ada Lovelace")
+ * await ui.unmount()
+ * ```
+ */
+export const render = <E, R>(
+  app: Effect.Effect<View, E, R>,
+  ...rest: [Required<R>] extends [never]
+    ? [layer?: Layer.Layer<never>]
+    : [layer: Layer.Layer<Required<R>>]
+): Promise<RenderResult> => {
+  const layer = (rest[0] ?? Layer.empty) as Layer.Layer<never>
+  return renderImpl(app as Effect.Effect<View, unknown, never>, layer)
+}
+
+const renderImpl = async (
+  app: Effect.Effect<View, unknown, never>,
+  layer: Layer.Layer<never>,
+): Promise<RenderResult> => {
+  const container = document.createElement("div")
+  document.body.appendChild(container)
+
+  // A Closeable scope we own: mount registers every subscription/listener/
+  // release finalizer on it, and we keep it open until unmount().
+  const scope = Scope.makeUnsafe()
+  await Effect.runPromise(
+    Scope.provide(
+      mount(app, container).pipe(Effect.provide(layer), Effect.provide(EfxLive)),
+      scope,
+    ),
+  )
+
+  return {
+    container,
+    get: (s) => el(container, s),
+    query: (s) => container.querySelector(s) as HTMLElement | null,
+    all: (s) => Array.from(container.querySelectorAll(s)) as HTMLElement[],
+    text: (s) => (s ? el(container, s) : container).textContent?.trim() ?? "",
+    click: (s) => {
+      el(container, s).dispatchEvent(new MouseEvent("click", { bubbles: true }))
+    },
+    fire: (s, type) => {
+      el(container, s).dispatchEvent(new Event(type, { bubbles: true }))
+    },
+    tick: () => new Promise<void>((resolve) => setTimeout(resolve, 0)),
+    unmount: async () => {
+      await Effect.runPromise(Scope.close(scope, Exit.void))
+      container.remove()
+    },
+  }
+}

--- a/packages/testing/tsconfig.json
+++ b/packages/testing/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*.ts"]
+}

--- a/packages/testing/vitest.config.ts
+++ b/packages/testing/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    // In-process DOM so component mounts/interactions run without a browser.
+    environment: "happy-dom",
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@types/node@25.9.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(yaml@2.9.0))
+        version: 4.1.7(@types/node@25.9.1)(happy-dom@20.9.0)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(yaml@2.9.0))
 
   apps/demo:
     dependencies:
@@ -85,7 +85,7 @@ importers:
     devDependencies:
       '@effect/vitest':
         specifier: 4.0.0-beta.71
-        version: 4.0.0-beta.71(effect@4.0.0-beta.71)(vitest@4.1.7(@types/node@25.9.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.71(effect@4.0.0-beta.71)(vitest@4.1.7(@types/node@25.9.1)(happy-dom@20.9.0)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(yaml@2.9.0)))
       '@types/babel__generator':
         specifier: ^7
         version: 7.27.0
@@ -110,7 +110,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@types/node@25.9.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(yaml@2.9.0))
+        version: 4.1.7(@types/node@25.9.1)(happy-dom@20.9.0)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(yaml@2.9.0))
 
   packages/runtime:
     dependencies:
@@ -120,7 +120,23 @@ importers:
     devDependencies:
       '@effect/vitest':
         specifier: 4.0.0-beta.71
-        version: 4.0.0-beta.71(effect@4.0.0-beta.71)(vitest@4.1.7(@types/node@25.9.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.71(effect@4.0.0-beta.71)(vitest@4.1.7(@types/node@25.9.1)(happy-dom@20.9.0)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(yaml@2.9.0)))
+
+  packages/testing:
+    dependencies:
+      '@efx/runtime':
+        specifier: workspace:*
+        version: link:../runtime
+      effect:
+        specifier: 4.0.0-beta.71
+        version: 4.0.0-beta.71
+    devDependencies:
+      happy-dom:
+        specifier: ^20.9.0
+        version: 20.9.0
+      vitest:
+        specifier: ^4.1.7
+        version: 4.1.7(@types/node@25.9.1)(happy-dom@20.9.0)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(yaml@2.9.0))
 
   packages/ts-plugin:
     dependencies:
@@ -136,7 +152,7 @@ importers:
     devDependencies:
       '@effect/vitest':
         specifier: 4.0.0-beta.71
-        version: 4.0.0-beta.71(effect@4.0.0-beta.71)(vitest@4.1.7(@types/node@25.9.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.71(effect@4.0.0-beta.71)(vitest@4.1.7(@types/node@25.9.1)(happy-dom@20.9.0)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(yaml@2.9.0)))
       esbuild:
         specifier: ^0.28.0
         version: 0.28.0
@@ -155,7 +171,7 @@ importers:
         version: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@types/node@25.9.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(yaml@2.9.0))
+        version: 4.1.7(@types/node@25.9.1)(happy-dom@20.9.0)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(yaml@2.9.0))
 
 packages:
 
@@ -541,6 +557,12 @@ packages:
   '@types/node@25.9.1':
     resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
 
+  '@types/whatwg-mimetype@3.0.2':
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
   '@vitest/expect@4.1.7':
     resolution: {integrity: sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==}
 
@@ -614,6 +636,10 @@ packages:
   effect@4.0.0-beta.71:
     resolution: {integrity: sha512-DKnsUK3/DnCU4GfiOnw7DVXkKeg+UTh2J92rgVLpLZYUrfvQd5h7FasFm125/613Cbn/P0iPXkMnmFCd0fxV4g==}
 
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
@@ -649,6 +675,10 @@ packages:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  happy-dom@20.9.0:
+    resolution: {integrity: sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==}
+    engines: {node: '>=20.0.0'}
 
   ini@7.0.0:
     resolution: {integrity: sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w==}
@@ -966,10 +996,26 @@ packages:
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
@@ -1025,10 +1071,10 @@ snapshots:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
-  '@effect/vitest@4.0.0-beta.71(effect@4.0.0-beta.71)(vitest@4.1.7(@types/node@25.9.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(yaml@2.9.0)))':
+  '@effect/vitest@4.0.0-beta.71(effect@4.0.0-beta.71)(vitest@4.1.7(@types/node@25.9.1)(happy-dom@20.9.0)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(yaml@2.9.0)))':
     dependencies:
       effect: 4.0.0-beta.71
-      vitest: 4.1.7(@types/node@25.9.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(yaml@2.9.0))
+      vitest: 4.1.7(@types/node@25.9.1)(happy-dom@20.9.0)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(yaml@2.9.0))
 
   '@emnapi/core@1.10.0':
     dependencies:
@@ -1244,6 +1290,12 @@ snapshots:
     dependencies:
       undici-types: 7.24.6
 
+  '@types/whatwg-mimetype@3.0.2': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 25.9.1
+
   '@vitest/expect@4.1.7':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -1338,6 +1390,8 @@ snapshots:
       uuid: 14.0.0
       yaml: 2.9.0
 
+  entities@7.0.1: {}
+
   es-module-lexer@2.1.0: {}
 
   esbuild@0.28.0:
@@ -1387,6 +1441,18 @@ snapshots:
 
   fsevents@2.3.3:
     optional: true
+
+  happy-dom@20.9.0:
+    dependencies:
+      '@types/node': 25.9.1
+      '@types/whatwg-mimetype': 3.0.2
+      '@types/ws': 8.18.1
+      entities: 7.0.1
+      whatwg-mimetype: 3.0.0
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   ini@7.0.0: {}
 
@@ -1568,7 +1634,7 @@ snapshots:
       fsevents: 2.3.3
       yaml: 2.9.0
 
-  vitest@4.1.7(@types/node@25.9.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(yaml@2.9.0)):
+  vitest@4.1.7(@types/node@25.9.1)(happy-dom@20.9.0)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.7
       '@vitest/mocker': 4.1.7(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(yaml@2.9.0))
@@ -1592,6 +1658,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.9.1
+      happy-dom: 20.9.0
     transitivePeerDependencies:
       - msw
 
@@ -1621,9 +1688,13 @@ snapshots:
 
   vscode-uri@3.1.0: {}
 
+  whatwg-mimetype@3.0.0: {}
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  ws@8.21.0: {}
 
   yaml@2.9.0: {}


### PR DESCRIPTION
Architecture-review feature **F2** — the enabling investment ahead of F1 (Await). Gives components a deterministic, in-process test layer between `channels.test-d.ts` (compile-time proof) and the Playwright probes (real browser).

## API

```ts
const ui = await render(UserPage({ userId: "42" }), Layer.mergeAll(HttpTest, ThemeTest))
expect(ui.text(".user-card strong")).toBe("Ada Lovelace")
ui.click(".refresh"); await ui.tick()
await ui.unmount()
```

`render(app, layer?)` mounts a component result (`Component(props)` / `h(Component, props)`) into a happy-dom DOM and returns `RenderResult`: `get`/`query`/`all`/`text`, `click`/`fire`, `tick()`, `unmount()`.

## Thesis preserved at the test site (the key design point)

The harness injects **only** `AtomRegistry` (`EfxLive`) + a Closeable `Scope`. Everything else is a **type-enforced** `layer` argument:

```ts
type Required<R> = Exclude<R, AtomRegistry | Scope>
render(app, ...rest: [Required<R>] extends [never]
  ? [layer?: Layer<never>]          // nothing else needed → optional
  : [layer: Layer<Required<R>>])    // missing a service → COMPILE ERROR
```

A component needing `Http` won't `render` without an `Http` layer — the same forgotten-`Layer`-is-a-compile-error guarantee efx gives at a real `mount`. The review's top risk for F2 was a facade that swallows `E`/`R`; this avoids it by construction.

## Closeable scope

Uses `Scope.makeUnsafe()` held open across interaction and closed in `unmount()`, so tests can assert **finalizers fire on teardown** (the in-process equivalent of `probe-lifecycle.mjs`). `Effect.scoped` would tear the component down before you could drive it.

## Self-tests (3, all pass)

- reactive update via `click` (AtomRef child → reactive node)
- `acquireRelease` finalizer fires on `unmount`
- component renders once its service is provided via `layer`

## Verification

- `pnpm -r typecheck` clean (8 packages + demo)
- `pnpm -r test` green; new `packages/testing` suite runs under `happy-dom`
- happy-dom 20.9.0 (Apr 13) clears the `minimumReleaseAge` cooldown

AGENTS.md added for the package; root subsystems + package count (6→7) updated.