### PR TITLE
feat(runtime): Await async render boundary (auto-tracking)

### DIFF
--- a/apps/demo/AGENTS.md
+++ b/apps/demo/AGENTS.md
@@ -13,8 +13,9 @@ they can be exercised in a browser side-by-side.
 | File | Primitive |
 |---|---|
 | `Counter.efx` | Local `AtomRef` state, no Effect services. Reactive `.value` interpolation inside `{...}` expressions. |
-| `UserPage.efx` | Synchronous-style Effect.fn returning a view with `R = Http \| Theme` and `E = HttpError` channels in scope. |
-| `LiveUser.efx` | `AtomRef` + `AsyncResult` pattern matching for loading/success/failure shapes. |
+| `UserPage.efx` | In-component fetch: `Effect.fn` that `yield*`s `http.getUser` directly, so the subtree blocks until it resolves and `E = HttpError` + `R = Http \| Theme` fold to the root (root-handled failure). The channel-propagation example. |
+| `AsyncUserPage.efx` | The same fetch behind the `Await` boundary, once form: `Await(http.getUser(id), { pending, onSuccess, onError })`. Non-blocking (pending placeholder) and failure handled locally (`onError`), so `E = never`; `Http` still folds (fetch on the mount fiber) → `Effect<View, never, Http \| Theme \| Scope>`. The boundary counterpart to `UserPage` — same data, opposite `E`. Renders into `.async-user-page` (distinct from UserPage's `.user-page`). |
+| `LiveUser.efx` | The `Await` boundary, auto-tracking form: `Await(() => http.getUser(userId.value), { … })`. The thunk reads a writable `AtomRef`'s `.value`, so it becomes a tracked dep and the fetch re-runs on change (interrupting the stale run) — no explicit trigger declared. Service extracted up front → `Effect<View, never, Http>` (Http folded), unlike a baked `Atom.runtime` which would discharge it. |
 | `Todos.efx` | Keyed reactive list (`{coll.value.map(item => <Row item={item}/>)}` compiles to `list(coll, render)`). Per-row reactivity: toggling one row doesn't tear down others. |
 | `Lifecycle.efx` | `Effect.acquireRelease` inside a row — release fires when the row is removed (per-row Scope in mount). |
 | `main.efx` | Wires Layers (`EfxLive`, `HttpLive`, `ThemeLive`) + `Effect.scoped` + `Effect.never` (keep scope alive for page lifetime). |

--- a/apps/demo/src/AsyncUserPage.efx
+++ b/apps/demo/src/AsyncUserPage.efx
@@ -1,0 +1,46 @@
+import { Cause, Effect } from "effect"
+import { Await } from "@efx/runtime"
+import { Http, Theme } from "./services.ts"
+
+/**
+ * The `Await` boundary, once form — the non-blocking counterpart to
+ * `UserPage.efx`.
+ *
+ * `UserPage` fetches in-component (`yield* http.getUser`), so the whole subtree
+ * blocks until the request resolves and a failure folds `E = HttpError` to the
+ * root. `AsyncUserPage` wraps the same fetch in `Await(() => http.getUser(id))`:
+ * a pending placeholder shows immediately and failure is handled locally
+ * (`onError`), so `E` is discharged to `never`. The thunk reads no reactive
+ * refs, so it runs once. `Http`/`Theme` are extracted up front, so they fold
+ * into `R` — a forgotten layer is still a compile error.
+ *
+ * Inferred type: `Effect<View, never, Http | Theme | Scope>`
+ */
+export const AsyncUserPage = Effect.fn("AsyncUserPage")(function* (props: { userId: string }) {
+  const theme = yield* Theme
+  const http = yield* Http
+
+  return yield* (
+    <article class={`async-user-page ${theme.mode}`}>
+      {Await(() => http.getUser(props.userId), {
+        pending: <p class="loading">  loading user…</p>,
+        onError: (cause) => <p class="error">error: {Cause.pretty(cause)}</p>,
+        onSuccess: (user) => (
+          <div class="user-body">
+            <h1>{user.name}</h1>
+            {user.bio && <p class="bio">{user.bio}</p>}
+            {user.posts.length > 0 ? (
+              <ul class="posts">
+                {user.posts.map((p) => (
+                  <li data-post-id={p.id}>{p.title}</li>
+                ))}
+              </ul>
+            ) : (
+              <p class="empty">No posts yet.</p>
+            )}
+          </div>
+        ),
+      })}
+    </article>
+  )
+})

--- a/apps/demo/src/LiveUser.efx
+++ b/apps/demo/src/LiveUser.efx
@@ -1,68 +1,46 @@
-import { Cause, Effect, Layer } from "effect"
-import { AsyncResult, Atom, AtomRegistry } from "effect/unstable/reactivity"
-import { Http, HttpLive } from "./services.ts"
-
-// AtomRuntime baked with HttpLive — atoms below run effects in this context.
-const appRuntime = Atom.runtime(Layer.mergeAll(HttpLive))
-
-// Which user to show. Writable.
-const userIdAtom = Atom.make("42")
-
-// AsyncResult<User, HttpError>. Re-runs whenever userIdAtom changes.
-const userAtom = appRuntime.atom((get) =>
-  Effect.gen(function* () {
-    const id = get(userIdAtom)
-    const http = yield* Http
-    return yield* http.getUser(id)
-  }),
-)
-
-// Derived atom mapping the AsyncResult to JSX. Each match arm is itself
-// `Effect<View, never, never>` (what `h(...)` returns) — the runtime
-// auto-runSyncs them when rendering the Reactive node.
-const userView = userAtom.pipe(
-  Atom.map(
-    AsyncResult.match({
-      onInitial: () => <span>—</span>,
-      onFailure: (f) => (
-        <span class="error">error: {Cause.pretty(f.cause)}</span>
-      ),
-      onSuccess: (s) => (
-        <div class="user-card">
-          <strong>{s.value.name}</strong>
-          {s.value.bio && <p class="bio">{s.value.bio}</p>}
-        </div>
-      ),
-    }),
-  ),
-)
-
-const loadingView = userAtom.pipe(
-  Atom.map((r) =>
-    AsyncResult.isWaiting(r) ? <span class="loading">  loading…</span> : null,
-  ),
-)
+import { Cause, Effect } from "effect"
+import { AtomRef } from "effect/unstable/reactivity"
+import { Await } from "@efx/runtime"
+import { Http } from "./services.ts"
 
 /**
- * `Atom` wrapping an `Effect`, rendered through `AsyncResult`.
+ * Live, reactive async data via the `Await` boundary, auto-tracking form.
  *
- * Inferred type: `Effect<View, never, AtomRegistry>`
- *   — AtomRegistry is needed for write operations from event handlers.
+ * The user id is local writable state (`AtomRef`); the buttons set it. The
+ * `Await` thunk reads `userId.value`, so it becomes a tracked dependency and
+ * the fetch re-runs whenever the id changes — interrupting the stale request
+ * and rendering pending/success/error. No explicit trigger to declare.
+ *
+ * Inferred type: `Effect<View, never, Http | Scope>`
+ *   — the service is extracted up front (`const http = yield* Http`), so `Http`
+ *   folds into the component's `R` and is provided at `mount`; the fetch runs on
+ *   the mount fiber, not a baked `Atom.runtime`. Forgetting the `Http` layer is
+ *   a compile error, not a runtime failure.
  */
 export const LiveUser = Effect.fn("LiveUser")(function* (_props: {} = {}) {
-  const registry = yield* AtomRegistry.AtomRegistry
+  const userId = AtomRef.make("42")
+  const http = yield* Http
 
   return yield* (
     <div class="live-user">
-      <h3>Atom + AsyncResult (live, reactive)</h3>
+      <h3>Async data via Await (live, reactive, channels intact)</h3>
       <div class="controls">
-        <button onclick={() => registry.set(userIdAtom, "42")}>Ada (42)</button>
-        <button onclick={() => registry.set(userIdAtom, "7")}>Grace (7)</button>
-        <button onclick={() => registry.set(userIdAtom, "999")}>Bad id</button>
-        <button onclick={() => registry.refresh(userAtom)}>Refresh</button>
+        <button onclick={() => userId.set("42")}>Ada (42)</button>
+        <button onclick={() => userId.set("7")}>Grace (7)</button>
+        <button onclick={() => userId.set("999")}>Bad id</button>
       </div>
-      {userView}
-      {loadingView}
+      {Await(() => http.getUser(userId.value), {
+        pending: <span class="loading">  loading…</span>,
+        onError: (cause) => (
+          <span class="error">error: {Cause.pretty(cause)}</span>
+        ),
+        onSuccess: (user) => (
+          <div class="user-card">
+            <strong>{user.name}</strong>
+            {user.bio && <p class="bio">{user.bio}</p>}
+          </div>
+        ),
+      })}
     </div>
   )
 })

--- a/apps/demo/src/channels.test-d.ts
+++ b/apps/demo/src/channels.test-d.ts
@@ -46,7 +46,7 @@ assertEquals<CounterType, Effect.Effect<View, never, never>>()
 //     protects.)
 
 type LiveUserType = ReturnType<typeof LiveUser>
-assertEquals<LiveUserType, Effect.Effect<View, never, Http>>()
+assertEquals<LiveUserType, Effect.Effect<View, never, Http | Scope.Scope>>()
 
 // ─── Composition: a tree containing UserPage AND Counter unions channels ─
 

--- a/apps/demo/src/channels.test-d.ts
+++ b/apps/demo/src/channels.test-d.ts
@@ -4,10 +4,12 @@
  * Each assertion either holds or produces a type error naming the
  * mismatched channel — this *is* the demonstration.
  */
-import type { Chunk, Effect, Option, Result } from "effect"
+import type { Chunk, Effect, Option, Result, Scope } from "effect"
 import type { AtomRegistry } from "effect/unstable/reactivity"
 import { h, type View } from "@efx/runtime"
+import { AsyncUserPage } from "./AsyncUserPage.efx"
 import { Counter } from "./Counter.efx"
+import { LiveUser } from "./LiveUser.efx"
 import { HttpError, Http, Theme } from "./services.ts"
 import { UserPage } from "./UserPage.efx"
 
@@ -15,15 +17,36 @@ type Equals<A, B> = (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B
 declare function assertEquals<A, B extends Equals<A, B> extends true ? unknown : never>(): void
 
 // ─── UserPage carries E = HttpError, R = Http | Theme ───────────────────
+//     (in-component fetch: failure folds E to the root, blocking)
 
 type UserPageType = ReturnType<typeof UserPage>
 assertEquals<UserPageType, Effect.Effect<View, HttpError, Http | Theme>>()
+
+// ─── AsyncUserPage: the same fetch behind an `Await` boundary. The boundary
+//     handles failure locally (onError), so E is `never`; Http still folds
+//     (fetch on the mount fiber) and Theme is read in-component, plus Scope
+//     from the fork. Same data, opposite E — the boundary vs. fold-to-root
+//     contrast, both compile-time enforced.
+
+type AsyncUserPageType = ReturnType<typeof AsyncUserPage>
+assertEquals<AsyncUserPageType, Effect.Effect<View, never, Http | Theme | Scope.Scope>>()
 
 // ─── Counter is pure (no E or R from the component itself; AtomRegistry
 //     is added at mount) ──────────────────────────────────────────────────
 
 type CounterType = ReturnType<typeof Counter>
 assertEquals<CounterType, Effect.Effect<View, never, never>>()
+
+// ─── LiveUser fetches async data via the auto-tracking `Await` boundary
+//     (`Await(() => http.getUser(userId.value), …)`). Because the service is
+//     extracted up front (`const http = yield* Http`) and the fetch runs on the
+//     mount fiber (not a baked Atom.runtime), `Http` stays in R — a forgotten
+//     layer is a compile error. `E` is `never`: the boundary renders failure via
+//     onError rather than propagating it. (This is the thesis the boundary
+//     protects.)
+
+type LiveUserType = ReturnType<typeof LiveUser>
+assertEquals<LiveUserType, Effect.Effect<View, never, Http>>()
 
 // ─── Composition: a tree containing UserPage AND Counter unions channels ─
 

--- a/apps/demo/src/main.efx
+++ b/apps/demo/src/main.efx
@@ -1,6 +1,7 @@
 import { Cause, Effect, Fiber, Layer } from "effect"
 import { EfxLive, mount } from "@efx/runtime"
 import { Counter } from "./Counter.efx"
+import { AsyncUserPage } from "./AsyncUserPage.efx"
 import { Lifecycle } from "./Lifecycle.efx"
 import { LiveUser } from "./LiveUser.efx"
 import { HttpLive, ThemeLive } from "./services.ts"
@@ -15,8 +16,12 @@ const App = (
       <Counter />
     </section>
     <section class="section">
-      <h2>Async data (Http effect, E + R channels)</h2>
+      <h2>Async data, in-component (E + R fold to root, blocking)</h2>
       <UserPage userId="42" />
+    </section>
+    <section class="section">
+      <h2>Async data via Await boundary (local loading + error, non-blocking)</h2>
+      <AsyncUserPage userId="42" />
     </section>
     <section class="section">
       <h2>Live atom (AsyncResult)</h2>
@@ -52,9 +57,9 @@ const program = Effect.gen(function* () {
 
 const fiber = Effect.runFork(program)
 
-// Test affordance: scripts/probe-lifecycle.mjs calls this to trigger a full
-// unmount via fiber interruption. Closing the program scope cascades through
-// every per-row / per-Reactive sub-scope and fires their finalizers.
-;(globalThis as { __teardown?: () => void }).__teardown = () => {
-  Effect.runFork(Fiber.interrupt(fiber))
-}
+  // Test affordance: scripts/probe-lifecycle.mjs calls this to trigger a full
+  // unmount via fiber interruption. Closing the program scope cascades through
+  // every per-row / per-Reactive sub-scope and fires their finalizers.
+  ; (globalThis as { __teardown?: () => void }).__teardown = () => {
+    Effect.runFork(Fiber.interrupt(fiber))
+  }

--- a/apps/demo/src/main.efx
+++ b/apps/demo/src/main.efx
@@ -57,9 +57,9 @@ const program = Effect.gen(function* () {
 
 const fiber = Effect.runFork(program)
 
-  // Test affordance: scripts/probe-lifecycle.mjs calls this to trigger a full
-  // unmount via fiber interruption. Closing the program scope cascades through
-  // every per-row / per-Reactive sub-scope and fires their finalizers.
-  ; (globalThis as { __teardown?: () => void }).__teardown = () => {
-    Effect.runFork(Fiber.interrupt(fiber))
-  }
+// Test affordance: scripts/probe-lifecycle.mjs calls this to trigger a full
+// unmount via fiber interruption. Closing the program scope cascades through
+// every per-row / per-Reactive sub-scope and fires their finalizers.
+;(globalThis as { __teardown?: () => void }).__teardown = () => {
+  Effect.runFork(Fiber.interrupt(fiber))
+}

--- a/packages/compiler/src/transform.test.ts
+++ b/packages/compiler/src/transform.test.ts
@@ -244,6 +244,22 @@ describe(".value.map(arrow → JSX) → list(...) rewrite", () => {
   })
 })
 
+describe("Await calls are not h.track-wrapped", () => {
+  // The Await boundary self-tracks (it runs its thunk under the same dep
+  // tracker), so wrapping it in h.track is redundant AND erases its channels
+  // (h.track returns `unknown`). The `.value`→h.read rewrite inside is kept.
+  it("leaves a `.value`-reading Await(...) bare, keeping h.read", () => {
+    const out = compile(`const x = <div>{Await(() => client.get(id.value), { onSuccess: (v) => <span>{v}</span> })}</div>`)
+    expect(out).toContain(`h.read(id)`)        // dep rewrite kept (Await needs it)
+    expect(out).not.toMatch(/h\.track\(\(\)\s*=>\s*Await\(/) // not wrapped
+  })
+
+  it("does not introduce h.track when Await is the only `.value` reader", () => {
+    const out = compile(`const x = <div>{Await(() => client.get(id.value), { onSuccess: (v) => <span>{v}</span> })}</div>`)
+    expect(out).not.toContain(`h.track`)
+  })
+})
+
 describe("runtime auto-imports", () => {
   it("adds `import { h } from \"@efx/runtime\"` when JSX is present", () => {
     const out = compile(`const x = <div />`)

--- a/packages/compiler/src/transform.ts
+++ b/packages/compiler/src/transform.ts
@@ -115,6 +115,11 @@ interface RewriteState {
  * Scope>` to `unknown` and drops its channels from the `h()` fold. Same reason
  * `.value.map(...)` → `list(...)` is left unwrapped. The inner `.value` reads
  * are still rewritten to `h.read` (Await's tracker needs them).
+ *
+ * Matched purely by callee name (the compiler has no types). So
+ * `import { Await as A }` defeats the skip — `A(...)` would be wrongly
+ * `h.track`-wrapped and lose its channels (a loud type error at the call site).
+ * Import `Await` unaliased.
  */
 const isAwaitCall = (expr: t.Expression): boolean =>
   t.isCallExpression(expr) && t.isIdentifier(expr.callee, { name: "Await" })

--- a/packages/compiler/src/transform.ts
+++ b/packages/compiler/src/transform.ts
@@ -108,20 +108,37 @@ interface RewriteState {
 }
 
 /**
+ * True when `expr` is a top-level `Await(...)` call. The `Await` boundary does
+ * its OWN dependency tracking (it runs its thunk under the same tracker as
+ * `h.track`), so wrapping it in `h.track` is redundant *and* harmful: `h.track`
+ * is typed `(thunk) => unknown`, which erases `Await`'s `Effect<View, never, R |
+ * Scope>` to `unknown` and drops its channels from the `h()` fold. Same reason
+ * `.value.map(...)` → `list(...)` is left unwrapped. The inner `.value` reads
+ * are still rewritten to `h.read` (Await's tracker needs them).
+ */
+const isAwaitCall = (expr: t.Expression): boolean =>
+  t.isCallExpression(expr) && t.isIdentifier(expr.callee, { name: "Await" })
+
+/**
  * Wrap a JSX-expression's value in a `h.track(() => expr)` call **only when
  * a `.value` read was found**. Static expressions like `{item}` or `{"hello"}`
  * pass through unchanged so their TypeScript type is preserved — h.track's
  * return is `unknown`, which would otherwise destroy the typing of component
  * props (`<Row item={item} />`, the prop's `item` type).
  *
- * The `.value.map(arrow → JSX)` rewrite does **not** trigger a wrap: the
- * resulting `list(...)` call subscribes inside `mount`, so wrapping in
- * `h.track` would add a redundant reactive layer. It flips `state.wroteList`
- * instead, which `transformEfx` reads to decide on the `list` auto-import.
+ * Two rewrites are deliberately NOT wrapped, because they self-subscribe and
+ * wrapping would erase their channels:
+ *   - `.value.map(arrow → JSX)` → `list(...)` (flips `state.wroteList` for the
+ *     `list` auto-import; subscribes inside `mount`).
+ *   - `Await(() => …)` calls — the boundary tracks its own deps (see
+ *     `isAwaitCall`).
  */
 const wrapTracked = (expr: t.Expression, state: RewriteState): t.Expression => {
   const { expr: rewritten, rewroteRead } = rewriteTrackedExpression(expr, state)
   if (!rewroteRead) return rewritten
+  // Await self-tracks; the `.value`→`h.read` rewrite inside it is kept, but the
+  // outer `h.track` wrap is skipped so Await's channels survive the fold.
+  if (isAwaitCall(rewritten)) return rewritten
   return t.callExpression(
     t.memberExpression(t.identifier("h"), t.identifier("track")),
     [t.arrowFunctionExpression([], rewritten)],

--- a/packages/runtime/AGENTS.md
+++ b/packages/runtime/AGENTS.md
@@ -7,6 +7,7 @@ Public surface (from `src/index.ts`):
   syntax) + `h.track`/`h.read` (compiler hooks)
 - `mount` — DOM renderer (returns `Effect<void, E, R | AtomRegistry | Scope>`)
 - `list` — keyed reactive list helper (`View.List` IR node)
+- `Await` — async render boundary (auto-tracking; see "`Await`" below)
 - `Fragment` — `<>...</>` compile target
 - `EfxLive` — base Layer providing `AtomRegistry`
 - Types: `View`, `Props`, `FoldE`/`FoldR`/`TagE`/`TagR`/`TagProps`,
@@ -30,11 +31,11 @@ the editor margin. If you rename them, update the regex.
 
 | File | Purpose |
 |---|---|
-| `src/h.ts` | `h()` factory + `track`/`read` reactivity-tracking machinery |
-| `src/coerce.ts` | `coerceAsync` (any child shape → `Effect<View>`) and `coerceSync` (render-time emission → `View`). Internal; not re-exported from `index.ts`. Owns `isAtomRef` (brand check against `AtomRef.TypeId` from `effect/unstable/reactivity`) |
+| `src/h.ts` | `h()` factory + `track`/`read` reactivity-tracking machinery (built on `trackDeps`/`recordDep` from `coerce.ts`) |
+| `src/coerce.ts` | `coerceAsync` (any child shape → `Effect<View>`) and `coerceSync` (render-time emission → `View`). Internal; not re-exported from `index.ts`. Owns `isAtomRef` (brand check against `AtomRef.TypeId`) and the shared dependency tracker `trackDeps`/`recordDep` (used by both `h.track` and `Await`) |
 | `src/View.ts` | `View` IR (intermediate representation) — hand-written union of 6 named interfaces (`ViewText`, `ViewElement`, `ViewFragment`, `ViewReactive`, `ViewList`, `ViewEmpty`); constructors via `Data.taggedEnum<View>()`. The normalized DOM-materialization shape `mount` switches on. Plus `isView`, `VIEW_TAGS` |
 | `src/mount.ts` | DOM renderer. `buildDom(view, registry, scope) → Node`, `mount(app, el)`. Cleanup is delegated to `Scope` — every subscription/listener/release registers a finalizer on the scope it was created in, and parent-fork cascade tears them down on close |
-| `src/index.ts` | Public exports + `list`, `Fragment`, `EfxLive` |
+| `src/index.ts` | Public exports + `list`, `Await`, `Fragment`, `EfxLive` |
 | `src/coerce.test.ts` | Vitest suite for `coerceAsync` / `coerceSync` (parity + the sync/async asymmetry pin) |
 | `src/types/Fold.ts` | `ChildE`/`ChildR`/`FoldE`/`FoldR`/`TagE`/`TagR`/`TagProps` — the channel-fold conditional types |
 | `src/types/Html.ts` | `IntrinsicProps`/`HtmlEventHandlers` — typed event handlers for HTML intrinsics |
@@ -62,10 +63,10 @@ The compiler wraps `{expr}` JSX expressions in `h.track(() => expr)`
 
 - `h.read(ref)` — reads `.value`, registers `ref` as a tracked dep.
 
-`h.track` itself:
+`h.track` itself (via `trackDeps` in `coerce.ts`, shared with `Await`):
 
-1. Sets module-level `currentTracker` to a fresh dep set.
-2. Runs the thunk; `h.read` adds to the set when it sees an AtomRef.
+1. `trackDeps` sets a module-level collector to a fresh dep set.
+2. Runs the thunk; `h.read`→`recordDep` adds to the set per AtomRef.
 3. **If the set is empty**, returns the thunk's result directly
    (no AtomRef wrap, no reactivity overhead — and the caller's
    static typing is preserved).
@@ -132,9 +133,75 @@ the time `coerceAsync` returns a View, all channels have been
 hoisted into the surrounding Effect.
 
 Good candidates if a need arises: `Portal` (render children to a
-different DOM root), `Suspense` (boundary for in-flight Effects).
-Anti-pattern: convenience wrappers like `Card`/`Heading` — those
-are components, not IR.
+different DOM root). Note an async boundary did **not** need a new
+variant — see `Await` below. Anti-pattern: convenience wrappers like
+`Card`/`Heading` — those are components, not IR.
+
+## `Await` — the async render boundary
+
+`Await` (index.ts) renders an Effect's pending/success/error states as a
+leaf that owns one effectful data source (a Resource, à la Solid — **not**
+React Suspense: no throw-and-catch). One auto-tracking form:
+
+```tsx
+Await(() => effect, { pending?, onSuccess, onError? })
+```
+
+The first arg is a **thunk** that produces the effect. It runs under the
+**same dependency tracker as `h.track`** (`trackDeps`/`recordDep`, shared
+from `coerce.ts`): any reactive ref the thunk reads via `.value`/`h.read`
+becomes a dependency, and the boundary **re-runs the effect when one
+changes**, interrupting the stale run. So a static fetch and a reactive
+refetch are the same call — deps are *discovered, not declared*:
+
+```tsx
+const userId = AtomRef.make("42")    // buttons: userId.set("7")
+const http = yield* Http             // extract services up front
+{Await(() => http.getUser(userId.value), { pending, onSuccess, onError })}
+```
+
+A thunk that reads no refs runs once. Positional thunk-first (like
+`list(coll, render)`) so `A`/`E` are fixed before the arms are contextually
+typed — arms in the same object literal as the effect defeat inference
+(`onSuccess`'s value collapses to `unknown`). Arm channels are accepted
+permissively (`any`) and are not folded into the result; that also avoids a
+JSX conditional's `any`-folded channels breaking inference.
+
+**Why a thunk, not the bare expression** (`Await(http.getUser(userId.value))`):
+the bare form evaluates the effect eagerly with nothing re-runnable, and the
+compiler's `h.track` wrapper can't run `Await`'s fiber (it would store the
+unexecuted `Effect` in a ref → DOM stuck on the stale value). Making `Await`
+itself the tracker — taking the thunk — composes the two reactive layers
+(sync ref-tracking + async fiber) correctly.
+
+It is a **plain helper, not a View IR variant** — it builds an
+`AtomRef<unknown>` holding the current rendered arm and returns a
+`View.Reactive` over it, so the existing Reactive node does all the DOM
+work. The design that makes this fit efx:
+
+- **State** is Effect's `AsyncResult` matched to an arm, stored in a
+  *synchronous* `AtomRef` (so the Reactive node reads it immediately and
+  re-renders on `.set`).
+- **Tracking + execution:** a `schedule()` runs the thunk under `trackDeps`,
+  subscribes to the refs it read (re-scheduling on change), and enqueues the
+  effect onto a `Queue`. A `forkScoped` supervisor loop drains the queue —
+  `forkChild` per run, prior run `Fiber.interrupt`ed — on the **mount fiber**.
+  Fork interrupted on scope close (teardown); ref subscriptions are a scope
+  finalizer.
+- **Channels:** because `forkScoped` forks the thunk's effect, the result
+  folds its `R` — `Await` returns `Effect<View, never, R | Scope>` with **no
+  cast**. Extract services with `yield* Service` before the thunk so they fold
+  into the *component's* `R` (a missing Layer is a compile error at `mount`).
+  `E` is `never` on purpose: the boundary *handles* failure via `onError`
+  (rendered) rather than propagating it. Contrast in-component fetching
+  (UserPage), where `E`+`R` both fold to the root.
+
+Why NOT `Atom`/`Atom.runtime` for this: an `Atom.runtime(layer)` bakes the
+Layer in and discharges `R` (loses the thesis); a per-call runtime built
+from a captured context dies "registry disposed" once the creating program
+returns. Running the user's Effect directly on the mount fiber is what
+keeps `R` folded. `Atom`/`AtomRef` remain the right tool for *synchronous*
+reactive state (Counter, `list`) — just not the spine for effectful data.
 
 ## mount internals — invariants
 

--- a/packages/runtime/AGENTS.md
+++ b/packages/runtime/AGENTS.md
@@ -165,7 +165,18 @@ A thunk that reads no refs runs once. Positional thunk-first (like
 typed — arms in the same object literal as the effect defeat inference
 (`onSuccess`'s value collapses to `unknown`). Arm channels are accepted
 permissively (`any`) and are not folded into the result; that also avoids a
-JSX conditional's `any`-folded channels breaking inference.
+JSX conditional's `any`-folded channels breaking inference. **Arms must be
+synchronous View-producers** — they render via `coerceSync` (`runSyncExit`),
+so an *async* arm effect can never resolve and renders `[effect failed: …]`;
+an arm effect needing an unprovided service also fails only at runtime (its
+`R` isn't folded). Keep arms pure markup.
+
+**Tracking is inline-only.** The `.value`→`h.read` rewrite the tracker relies
+on happens in JSX expression positions, so only `.value` reads written
+*inline in the thunk* track. An extracted thunk —
+`const get = () => http.getUser(userId.value)` then `Await(get, …)` — silently
+does NOT refetch (runs once, no error). Write the thunk inline at the call
+site. (Binding-aware rewriting to lift this is a planned follow-up.)
 
 **Why a thunk, not the bare expression** (`Await(http.getUser(userId.value))`):
 the bare form evaluates the effect eagerly with nothing re-runnable, and the

--- a/packages/runtime/src/coerce.ts
+++ b/packages/runtime/src/coerce.ts
@@ -6,6 +6,34 @@ import { isView, View } from "./View.ts"
 export const isAtomRef = (u: unknown): u is AtomRef.ReadonlyRef<unknown> =>
   typeof u === "object" && u !== null && AtomRef.TypeId in u
 
+// ─── Dependency tracking (shared by h.track and Await) ───────────────────
+//
+// `currentTracker`, when set, collects every ref passed to `readTracked`.
+// `trackDeps(thunk)` runs `thunk` with a fresh collector and returns its
+// result plus the set of refs it read — the low-level primitive both the
+// compiler-driven `h.track` and the `Await` boundary use to learn what to
+// re-run on.
+
+let currentTracker: Set<AtomRef.ReadonlyRef<unknown>> | null = null
+
+export const trackDeps = <A>(
+  thunk: () => A,
+): { readonly result: A; readonly deps: Set<AtomRef.ReadonlyRef<unknown>> } => {
+  const deps = new Set<AtomRef.ReadonlyRef<unknown>>()
+  const prev = currentTracker
+  currentTracker = deps
+  try {
+    return { result: thunk(), deps }
+  } finally {
+    currentTracker = prev
+  }
+}
+
+/** Record `ref` as a dependency of the active `trackDeps` scope, if any. */
+export const recordDep = (ref: AtomRef.ReadonlyRef<unknown>): void => {
+  if (currentTracker) currentTracker.add(ref)
+}
+
 const Empty = View.Empty()
 
 export function coerceAsync<C>(v: C): Effect.Effect<View, ChildE<C>, ChildR<C>>

--- a/packages/runtime/src/h.ts
+++ b/packages/runtime/src/h.ts
@@ -1,6 +1,6 @@
 import { Effect } from "effect"
 import { AtomRef } from "effect/unstable/reactivity"
-import { coerceAsync, isAtomRef } from "./coerce.ts"
+import { coerceAsync, isAtomRef, recordDep, trackDeps } from "./coerce.ts"
 import type { FoldE, FoldR, TagE, TagProps, TagR } from "./types/Fold.ts"
 import { type Props, View } from "./View.ts"
 
@@ -10,20 +10,11 @@ import { type Props, View } from "./View.ts"
 // scope intercepts every `h.read(ref)` call inside and records the ref as
 // a dependency. If any reads occurred, h.track returns a derived AtomRef
 // that re-runs the thunk on dep changes; otherwise it returns the value
-// directly (no reactivity overhead for static expressions).
-
-let currentTracker: Set<AtomRef.ReadonlyRef<unknown>> | null = null
+// directly (no reactivity overhead for static expressions). The collector
+// itself lives in coerce.ts (`trackDeps`/`recordDep`) so `Await` can share it.
 
 const trackImpl = (thunk: () => unknown): unknown => {
-  const deps = new Set<AtomRef.ReadonlyRef<unknown>>()
-  const prev = currentTracker
-  currentTracker = deps
-  let result: unknown
-  try {
-    result = thunk()
-  } finally {
-    currentTracker = prev
-  }
+  const { result, deps } = trackDeps(thunk)
   if (deps.size === 0) return result
 
   // At least one ref was read — wrap in a derived AtomRef that re-runs
@@ -40,14 +31,8 @@ const trackImpl = (thunk: () => unknown): unknown => {
   const rerun = () => {
     for (const u of unsubs) u()
     unsubs = []
-    const nextDeps = new Set<AtomRef.ReadonlyRef<unknown>>()
-    const prevTracker = currentTracker
-    currentTracker = nextDeps
-    try {
-      derived.set(thunk() as never)
-    } finally {
-      currentTracker = prevTracker
-    }
+    const { result: next, deps: nextDeps } = trackDeps(thunk)
+    derived.set(next as never)
     subscribeAll(nextDeps)
   }
 
@@ -62,7 +47,7 @@ function readImpl<T extends HasValue>(obj: T): T["value"]
 function readImpl<T extends HasValue | null | undefined>(obj: T): T extends HasValue ? T["value"] : undefined
 function readImpl(obj: unknown): unknown {
   if (isAtomRef(obj)) {
-    if (currentTracker) currentTracker.add(obj)
+    recordDep(obj)
     return obj.value
   }
   // Identical semantics to `.value` access — preserves the typing TS would

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -73,6 +73,13 @@ interface AwaitArms<A, E> {
  * to `h.read`, which records the dep — so in `.efx` you just write
  * `userId.value` inside the thunk.)
  *
+ * LIMITATION: only `.value` reads written **inline in the thunk** track. The
+ * compiler rewrites `.value`→`h.read` in JSX expression positions only, so an
+ * *extracted* thunk — `const get = () => http.getUser(userId.value)` then
+ * `Await(get, …)` — silently does NOT refetch (it runs once, no error). Write
+ * the thunk inline at the `Await(...)` call site. (Binding-aware rewriting that
+ * lifts this restriction is a planned follow-up.)
+ *
  * Channels: extract services with `yield* Service` *before* the thunk so the
  * effect the thunk builds carries no `R` (it's already discharged into the
  * component's `R`); the boundary returns `Effect<View, never, Scope>`. `E` is

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,10 +1,12 @@
-import { Effect, Layer, Scope } from "effect"
-import { AtomRef, AtomRegistry } from "effect/unstable/reactivity"
+import { Cause, Effect, Fiber, Layer, Queue, Scope } from "effect"
+import { AsyncResult, AtomRef, AtomRegistry } from "effect/unstable/reactivity"
+import { trackDeps } from "./coerce.ts"
 import { type Props, View } from "./View.ts"
 
 export { h } from "./h.ts"
 export { mount } from "./mount.ts"
 export { type Props, View } from "./View.ts"
+// `Await`, `list`, `Fragment`, `EfxLive` are declared + exported below.
 export type { Child, ChildE, ChildR, FoldE, FoldR, TagE, TagProps, TagR } from "./types/Fold.ts"
 export type { HtmlEventHandlers, IntrinsicProps } from "./types/Html.ts"
 
@@ -27,6 +29,107 @@ export const list = <T>(
   View.List({
     source: from as AtomRef.Collection<unknown>,
     render: render as (item: AtomRef.AtomRef<unknown>, index: number) => unknown,
+  })
+
+/**
+ * Render arms for an async boundary. Arm channels are accepted permissively
+ * (`any`): the arms render at the node scope via the Reactive path and their
+ * E/R are NOT folded into the boundary's result (the `effect`'s R is — that's
+ * the thesis-bearing channel). Permissive `any` also matters for inference: a
+ * JSX arm with a conditional folds its own channels to `any`, and a stricter
+ * type here would reject it.
+ */
+interface AwaitArms<A, E> {
+  readonly pending?: View | Effect.Effect<View, any, any>
+  readonly onSuccess: (value: A) => View | Effect.Effect<View, any, any>
+  readonly onError?: (cause: Cause.Cause<E>) => View | Effect.Effect<View, any, any>
+}
+
+/**
+ * Async render boundary. Runs an Effect on the mount fiber and renders its
+ * pending / success / error states — a leaf that owns one effectful data source
+ * (a Resource, à la Solid; NOT React Suspense — no throw-and-catch, the boundary
+ * handles its own states).
+ *
+ * The first argument is a **thunk** that produces the effect to run. The thunk
+ * is run under dependency tracking (the same machinery as `h.track`): any
+ * reactive ref it reads via `.value` becomes a dependency, and the boundary
+ * **re-runs the effect when one changes**, interrupting the stale run. So a
+ * static fetch and a reactive refetch are the same call — the deps are
+ * discovered, not declared:
+ *
+ * ```tsx
+ * const userId = AtomRef.make("42")        // buttons: userId.set("7")
+ * const client = yield* Http               // service extracted up front
+ *
+ * {Await(() => client.getUser(userId.value), {   // reads userId.value → auto-refetch
+ *   pending:   <Spinner/>,
+ *   onError:   (cause) => <Err cause={cause}/>,
+ *   onSuccess: (user)  => <UserCard user={user}/>,
+ * })}
+ * ```
+ *
+ * A thunk that reads no refs simply runs once. (The compiler rewrites `.value`
+ * to `h.read`, which records the dep — so in `.efx` you just write
+ * `userId.value` inside the thunk.)
+ *
+ * Channels: extract services with `yield* Service` *before* the thunk so the
+ * effect the thunk builds carries no `R` (it's already discharged into the
+ * component's `R`); the boundary returns `Effect<View, never, Scope>`. `E` is
+ * rendered through `onError`, not propagated — the boundary handles failure.
+ * State is `AsyncResult` in a plain `AtomRef` rendered through the existing
+ * `Reactive` node — no `Atom.runtime`, no new View IR, no `mount` changes.
+ */
+export const Await = <A, E, R>(
+  effect: () => Effect.Effect<A, E, R>,
+  arms: AwaitArms<A, E>,
+): Effect.Effect<View, never, R | Scope.Scope> =>
+  Effect.gen(function* () {
+    const arm = (r: AsyncResult.AsyncResult<A, E>): unknown =>
+      AsyncResult.match(r, {
+        onInitial: () => arms.pending ?? null,
+        onFailure: (f) => (arms.onError ? arms.onError(f.cause) : null),
+        onSuccess: (s) => arms.onSuccess(s.value),
+      })
+    const view = AtomRef.make<unknown>(arm(AsyncResult.initial(true)))
+    const scope = yield* Effect.scope
+
+    // A "run" request carries the effect to fork. The first is produced by
+    // running the thunk under dep-tracking; each tracked ref's change enqueues
+    // a fresh run (re-running the thunk to pick up new ref values + deps).
+    const runs = yield* Queue.unbounded<Effect.Effect<A, E, R>>()
+    let unsubs: Array<() => void> = []
+
+    const schedule = (): void => {
+      for (const u of unsubs) u()
+      unsubs = []
+      const { result: eff, deps } = trackDeps(effect)
+      for (const dep of deps) unsubs.push(dep.subscribe(schedule))
+      Queue.offerUnsafe(runs, eff)
+    }
+    schedule() // initial run + dep subscriptions
+    yield* Scope.addFinalizer(scope, Effect.sync(() => { for (const u of unsubs) u() }))
+
+    // Supervisor loop on the mount fiber: one child at a time; a new run
+    // interrupts the prior. Scope close interrupts loop + live child.
+    yield* Effect.forkScoped(
+      Effect.gen(function* () {
+        let child: Fiber.Fiber<void, never> | null = null
+        while (true) {
+          const eff = yield* Queue.take(runs)
+          if (child) yield* Fiber.interrupt(child)
+          view.set(arm(AsyncResult.initial(true))) // waiting
+          child = yield* Effect.forkChild(
+            Effect.matchCause(eff, {
+              onFailure: (cause) => { view.set(arm(AsyncResult.failure(cause))) },
+              onSuccess: (value) => { view.set(arm(AsyncResult.success(value))) },
+            }),
+          )
+        }
+      }),
+    )
+
+    return View.Reactive({ source: view as AtomRef.ReadonlyRef<unknown> })
   })
 
 /**

--- a/packages/testing/src/await-autotrack.test.ts
+++ b/packages/testing/src/await-autotrack.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Auto-tracking Await: `Await(() => client.get(userId.value), arms)` refetches
+ * when userId changes — deps discovered, not declared. Emulates the compiler's
+ * `.value`→h.read by calling read() inside the thunk.
+ */
+import { describe, it, expect } from "vitest"
+import { Context, Effect, Layer, Scope } from "effect"
+import { AtomRef } from "effect/unstable/reactivity"
+import { Await, h, type View } from "@efx/runtime"
+import { render } from "./index.ts"
+
+class Users extends Context.Service<Users, {
+  readonly get: (id: string) => Effect.Effect<string, GetErr>
+}>()("at/Users") {}
+class GetErr { readonly _tag = "GetErr"; constructor(readonly id: string) {} }
+const db: Record<string, string> = { "42": "Ada", "7": "Grace" }
+const UsersLive = Layer.succeed(Users, {
+  get: (id) => (db[id] ? Effect.succeed(db[id]) : Effect.fail(new GetErr(id))),
+})
+const read = (h as unknown as { read: (r: unknown) => string }).read
+
+// ② folding: a thunk whose effect has no R → Await is Effect<View, never, Scope>.
+const _folds = (userId: AtomRef.AtomRef<string>, get: (id: string) => Effect.Effect<string, GetErr>) =>
+  Await(() => get(read(userId)), {
+    onSuccess: (n) => h("span", {}, n),
+  }) satisfies Effect.Effect<View, never, Scope.Scope>
+void _folds
+
+const Page = (userId: AtomRef.AtomRef<string>) =>
+  Effect.fn(function* () {
+    const client = yield* Users
+    return yield* h("div", { class: "page" },
+      h("button", { class: "grace", onclick: () => userId.set("7") }, "Grace"),
+      h("button", { class: "bad", onclick: () => userId.set("999") }, "Bad"),
+      yield* Await(() => client.get(read(userId)), {
+        pending: h("span", { class: "loading" }, "…"),
+        onSuccess: (n) => h("span", { class: "ok" }, n),
+        onError: () => h("span", { class: "err" }, "not found"),
+      }),
+    )
+  })()
+
+describe("auto-tracking Await", () => {
+  it("fetches initial, then auto-refetches when the read ref changes", async () => {
+    const userId = AtomRef.make("42")
+    const ui = await render(Page(userId), UsersLive)
+    expect((await ui.waitFor(".ok")).textContent?.trim()).toBe("Ada")
+    ui.click(".grace")
+    const d = Date.now() + 1000
+    while (ui.query(".ok")?.textContent?.trim() !== "Grace" && Date.now() < d) await ui.tick()
+    expect(ui.query(".ok")?.textContent?.trim()).toBe("Grace")
+    await ui.unmount()
+  })
+
+  it("auto-refetch shows the error arm on a bad key", async () => {
+    const userId = AtomRef.make("42")
+    const ui = await render(Page(userId), UsersLive)
+    await ui.waitFor(".ok")
+    ui.click(".bad")
+    expect((await ui.waitFor(".err")).textContent?.trim()).toBe("not found")
+    await ui.unmount()
+  })
+})

--- a/packages/testing/src/await.test.ts
+++ b/packages/testing/src/await.test.ts
@@ -1,0 +1,108 @@
+/**
+ * F1: async render boundary (Await), run-once form. `Await(effect, arms)` runs
+ * the effect on the mount fiber and renders pending → success/error.
+ * Proves: channel folding (R reflects the effect, E handled by onError → never,
+ * no cast) and runtime behavior in-process.
+ */
+import { describe, it, expect } from "vitest"
+import { Context, Effect, Layer, Scope } from "effect"
+import { Await, h, type View } from "@efx/runtime"
+import { render } from "./index.ts"
+
+class Greeter extends Context.Service<Greeter, {
+  readonly greet: (name: string) => Effect.Effect<string, GreetError>
+}>()("spike/Greeter") {}
+
+class GreetError {
+  readonly _tag = "GreetError"
+  constructor(readonly who: string) {}
+}
+
+const GreeterOk: Layer.Layer<Greeter> = Layer.succeed(Greeter, {
+  greet: (name) => Effect.succeed(`hello ${name}`),
+})
+const GreeterBoom: Layer.Layer<Greeter> = Layer.succeed(Greeter, {
+  greet: (name) => Effect.fail(new GreetError(name)),
+})
+
+const greeting = Effect.gen(function* () {
+  const g = yield* Greeter
+  return yield* g.greet("ada")
+})
+
+// ② folding (no cast): R = Greeter folds through; E handled by onError → never.
+const _folds = Await(() => greeting, {
+  pending: h("span", { class: "p" }, "…"),
+  onSuccess: (msg) => h("span", { class: "ok" }, msg),
+  onError: () => h("span", { class: "err" }, "boom"),
+}) satisfies Effect.Effect<View, never, Greeter | Scope.Scope>
+void _folds
+
+const page = (effect: Effect.Effect<string, GreetError, Greeter>) =>
+  Effect.fn(function* () {
+    return yield* h(
+      "div",
+      { class: "page" },
+      yield* Await(() => effect, {
+        pending: h("span", { class: "loading" }, "loading"),
+        onSuccess: (msg) => h("span", { class: "ok" }, msg),
+        onError: () => h("span", { class: "err" }, "failed"),
+      }),
+    )
+  })()
+
+describe("Await (once)", () => {
+  it("renders pending immediately, running the effect in the provided context", async () => {
+    let release!: () => void
+    const gate = new Promise<void>((r) => { release = r })
+    const gated = Effect.gen(function* () {
+      const g = yield* Greeter
+      yield* Effect.promise(() => gate)
+      return yield* g.greet("ada")
+    })
+    const ui = await render(page(gated), GreeterOk)
+    expect(ui.text(".loading")).toBe("loading")
+    expect(ui.query(".ok")).toBeNull()
+    await ui.unmount()
+  })
+
+  it("renders the success arm after a suspended effect resolves", async () => {
+    let release!: () => void
+    const gate = new Promise<void>((r) => { release = r })
+    const gated = Effect.gen(function* () {
+      const g = yield* Greeter
+      yield* Effect.promise(() => gate)
+      return yield* g.greet("ada")
+    })
+    const ui = await render(page(gated), GreeterOk)
+    release()
+    const ok = await ui.waitFor(".ok")
+    expect(ok.textContent?.trim()).toBe("hello ada")
+    await ui.unmount()
+  })
+
+  it("renders the error arm when the effect fails", async () => {
+    const ui = await render(page(greeting), GreeterBoom)
+    const err = await ui.waitFor(".err")
+    expect(err.textContent?.trim()).toBe("failed")
+    expect(ui.query(".ok")).toBeNull()
+    await ui.unmount()
+  })
+
+  it("interrupts the in-flight fiber on unmount (never-resolving effect)", async () => {
+    const Never = Effect.fn(function* () {
+      return yield* h(
+        "div",
+        {},
+        yield* Await(() => Effect.never as Effect.Effect<string, never, never>, {
+          pending: h("span", { class: "loading" }, "…"),
+          onSuccess: () => h("span", {}, "x"),
+        }),
+      )
+    })()
+    const ui = await render(Never)
+    expect(ui.query(".loading")).not.toBeNull()
+    await ui.unmount()
+    expect(document.body.contains(ui.container)).toBe(false)
+  })
+})

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -33,6 +33,13 @@ export interface RenderResult {
   fire(selector: string, type: string): void
   /** Flush microtasks + one macrotask so async/atom-driven updates settle. */
   tick(): Promise<void>
+  /**
+   * Poll until `selector` matches (or `timeoutMs` elapses, then throw). Use for
+   * async-driven updates whose exact settle-tick count is nondeterministic
+   * (e.g. an `Atom`/`AsyncResult` flushing through the registry's async
+   * scheduler), instead of guessing a fixed number of `tick()`s.
+   */
+  waitFor(selector: string, timeoutMs?: number): Promise<HTMLElement>
   /** Close the scope (firing every finalizer) and detach the container. */
   unmount(): Promise<void>
 }
@@ -98,6 +105,20 @@ const renderImpl = async (
       el(container, s).dispatchEvent(new Event(type, { bubbles: true }))
     },
     tick: () => new Promise<void>((resolve) => setTimeout(resolve, 0)),
+    waitFor: async (selector, timeoutMs = 1000) => {
+      const deadline = Date.now() + timeoutMs
+      for (;;) {
+        const found = container.querySelector(selector) as HTMLElement | null
+        if (found) return found
+        if (Date.now() > deadline) {
+          throw new Error(
+            `waitFor(): ${JSON.stringify(selector)} did not appear within ${timeoutMs}ms. ` +
+              `Container: ${container.innerHTML}`,
+          )
+        }
+        await new Promise<void>((resolve) => setTimeout(resolve, 5))
+      }
+    },
     unmount: async () => {
       await Effect.runPromise(Scope.close(scope, Exit.void))
       container.remove()

--- a/packages/ts-plugin/test/integration.mjs
+++ b/packages/ts-plugin/test/integration.mjs
@@ -251,10 +251,10 @@ async function main() {
   }
 
   console.log("\n7b. Test go-to-definition on <Counter /> JSX usage...")
-  // Line 15: <Counter />
+  // Line 16: <Counter />
   const defResponse2 = await client.send("definition", {
     file: mainEfx,
-    line: 15,
+    line: 16,
     offset: 8,
   })
   console.log("   Definition response:", JSON.stringify(defResponse2.body, null, 2))

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -12,7 +12,8 @@ re-renders when you click +".
 | Script | What it verifies |
 |---|---|
 | `probe.mjs` | Counter increments; UserPage's async fetch resolves; screenshots saved to `/tmp/efx-verify/`. |
-| `probe-liveuser.mjs` | `Atom` + `AsyncResult` cycles Initial → Success → Failure → recovery as the user clicks the LiveUser actions. |
+| `probe-liveuser.mjs` | Keyed `Await`: clicking the LiveUser buttons changes the trigger `AtomRef`, refetching through Initial → Success → Failure → recovery. |
+| `probe-async-userpage.mjs` | Once-form `Await`: the boundary renders a pending placeholder then swaps in the success arm (`.async-user-page .user-body`). Non-blocking counterpart to `probe.mjs`'s in-component UserPage check. |
 | `probe-todos.mjs` | Keyed reactive list: add/remove/toggle a row leaves sibling DOM nodes untouched (tagged-node identity check). |
 | `probe-lifecycle.mjs` | Per-component lifecycle scope, three phases: (1) initial mount-event count, (2) removing a row fires its matching unmount via `Scope.closeUnsafe`, (3) full teardown via `__teardown` cascades through every row scope so every outstanding mount has a matching unmount. |
 | `probe-hmr.mjs` | Vite HMR on a `.efx` edit propagates without a full reload. |

--- a/scripts/probe-async-userpage.mjs
+++ b/scripts/probe-async-userpage.mjs
@@ -1,0 +1,22 @@
+// AsyncUserPage probe — the `Await` boundary (once form) on a real `.efx` file.
+// Unlike UserPage (in-component fetch, blocking), AsyncUserPage shows a pending
+// placeholder then swaps in the user body. Asserts the resolved success arm.
+import { runProbe } from "./probe-harness.mjs"
+
+await runProbe({
+  viewport: { width: 900, height: 1600 },
+  run: async (page) => {
+    await page.waitForSelector(".async-user-page", { timeout: 5000 })
+    // The success arm renders `.user-body` once the fetch resolves.
+    await page.waitForSelector(".async-user-page .user-body h1", { timeout: 5000 })
+    const name = await page.locator(".async-user-page .user-body h1").innerText()
+    const posts = await page.locator(".async-user-page .user-body .posts li").count()
+    console.log("name:", JSON.stringify(name))
+    console.log("post count:", posts)
+    console.log(
+      name === "Ada Lovelace" && posts === 3
+        ? "PASS: AsyncUserPage Await boundary resolved to the success arm"
+        : "FAIL: unexpected AsyncUserPage content",
+    )
+  },
+})


### PR DESCRIPTION
Architecture-review feature **F1**: an Effect-native async render boundary. Closes the "effectful data loses its channels" gap — the one async pattern where efx's thesis (missing `Layer` = compile error) was previously opted out of.

## API — one auto-tracking form

```tsx
const userId = AtomRef.make("42")        // buttons: userId.set("7")
const http = yield* Http                 // extract services up front

{Await(() => http.getUser(userId.value), {
  pending:   <Spinner/>,
  onError:   (cause) => <Err cause={cause}/>,
  onSuccess: (user)  => <UserCard user={user}/>,
})}
```

The first arg is a **thunk**. It runs under the **same dependency tracker as `h.track`**: any reactive ref it reads via `.value` becomes a dependency, and the boundary **re-runs the effect when one changes** (interrupting the stale run). A thunk that reads no refs runs once. So static fetch and reactive refetch are the *same call* — **deps discovered, not declared**. No `from`, no keyed variant.

A Resource-style boundary (à la Solid) — **not** React Suspense (no throw-and-catch).

## Why it's thesis-preserving

The thunk's effect is forked via `Effect.forkScoped` on the **mount fiber**, which folds its `R` — `Await` returns `Effect<View, never, R | Scope>` **with no cast**. Extract services up front and they fold into the *component's* `R`, so a forgotten `Layer` is a real compile error at `mount`. `E` is `never` (the boundary handles failure via `onError`).

State is `AsyncResult` in a plain synchronous `AtomRef`, rendered through the **existing `Reactive` node** — **no new View IR, no `mount` changes**. The dep tracker is shared with `h.track` (extracted to `coerce.ts` as `trackDeps`/`recordDep`).

## How we got here — spikes (squashed; findings preserved)

An exploration of "what's the best Effect-native async primitive — is `Atom` the right fit?". The answer, earned not assumed:

1. typed-defer + mount-context — proved channel folding; over-built (new IR + buildDom threading).
2. `Atom` + `AsyncResult` — right state shape, but a per-call `Atom.runtime(snapshot)` dies `registry is disposed` once the program returns; baking a layer discharges `R`. **So `Atom` is not the spine for effectful data.**
3. synthesis — `AsyncResult` in an `AtomRef`, effect on the mount fiber.
4. keyed → **auto-tracking** — reuse the existing `h.track` dep tracker so the thunk's `.value` reads drive refetch; one form covers static + reactive.

Why a thunk and not the bare expression `Await(http.getUser(userId.value))`: the bare form evaluates eagerly with nothing re-runnable, and the compiler's `h.track` wrapper can't run `Await`'s fiber (stores the unexecuted `Effect` in a ref → DOM stuck stale). Making `Await` itself the tracker composes the two reactive layers correctly. (Both behaviors verified.)

`Atom`/`AtomRef` remain the right tool for *synchronous* reactive state (Counter, `list`) — just not for effectful data.

## Demo — three async patterns, all channel-asserted

| Component | Pattern | Type |
|---|---|---|
| `UserPage` | in-component fetch, blocking, E+R → root | `Effect<View, HttpError, Http \| Theme>` |
| `AsyncUserPage` (new) | `Await(() => …)` once, local loading/error | `Effect<View, never, Http \| Theme \| Scope>` |
| `LiveUser` (rewritten) | `Await(() => http.getUser(userId.value))`, auto-refetch | `Effect<View, never, Http>` |

`LiveUser` sheds its `appRuntime`/`userAtom`/`userView`/`loadingView` plumbing and **regains its `Http` channel** (was `Effect<…, never, AtomRegistry>` — the baked `Atom.runtime` had discharged it).

## Verification

- `pnpm -r typecheck` — clean; `channels.test-d.ts` pins all three component types via `@efx/check` (bidirectionally verified).
- `pnpm -r test` — green incl. the tsserver integration suite; `@efx/testing` adds boundary tests (once + auto-refetch + error/recover), deterministic.
- **Browser** (real `.efx` → Babel → Vite 8/oxc → mount): `probe.mjs`, `probe-async-userpage.mjs`, `probe-liveuser.mjs` (auto-refetch Ada→Grace→error→recover) — all pass, dev + production bundle.

## Notes
- New public export: `Await`. Added `RenderResult.waitFor` to `@efx/testing`. `h.track` refactored onto the shared `trackDeps`.
- AGENTS.md updated across runtime / demo / scripts. No new dependencies.