### PR TITLE
feat(compiler): track .value reads across the component body

### DIFF
--- a/packages/compiler/AGENTS.md
+++ b/packages/compiler/AGENTS.md
@@ -53,7 +53,11 @@ Every JSX expression `{...}` triggers up to three local rewrites:
    `mount`, so wrapping in `h.track` would be a redundant layer.
 
 2. **`x.value` → `h.read(x)`** inside the wrapped expression. Tracks
-   AtomRef reads. Left bare on any write to `.value` — assignment LHS
+   AtomRef reads. (The *same* read rewrite also runs over the whole
+   component body in a separate pass — see "Whole-body `.value` reads"
+   below — so reads in statements/extracted thunks track too. Both
+   share `rewriteValueRead` in `transform.ts`.) Left bare on any write
+   to `.value` — assignment LHS
    (`x.value = …`, `x.value += …`) **and** update expressions
    (`x.value++`, `--x.value`). The bare-write fallback exists so the
    emitted JS stays well-formed (`h.read(x)++` would be a SyntaxError
@@ -108,15 +112,58 @@ the compiler emitted `h.peek(...)` for bare test-position identifiers;
 that was removed because the implicit unwrap diverged from the type
 TS would assign at the source site.
 
+## Whole-body `.value` reads
+
+After the JSX pass, a third `traverse(ast, …)` over the **live** AST
+rewrites every *surviving* `obj.value` read — the ones in statements,
+helpers, and **extracted `Await` thunks** — to `h.read(obj)` (via the
+same `rewriteValueRead` helper, so the write-guards are identical). This
+closes the gap where a thunk lifted out of an `Await(...)` call site
+(`const get = () => http.getUser(userId.value)`) silently stopped
+tracking: it now tracks identically to the inline form.
+
+Why this is safe **without** any compile-time "is `obj` an AtomRef?"
+analysis — the key design decision:
+
+- `h.read` is a **faithful, transparent wrapper** for `.value`. For any
+  non-AtomRef it is byte-for-byte `obj.value` (it throws on null exactly
+  as `.value` would — there is no `?.` swallow; see `readImpl` in
+  `@efx/runtime`). For a branded AtomRef it *additionally* records a dep
+  iff a tracker is active. So emitting `h.read` for *every* `.value` read
+  is sound; the runtime `isAtomRef` brand check is the only gate, and
+  it's **exact** — it handles aliased imports, extracted refs,
+  service-returned refs, and dynamic indirection that no syntactic
+  binding analysis could. (This is the Vue model: the tracking lives in
+  the read primitive, not in a compile-time graph. efx routes `.value`
+  through `h.read` only because Effect's `AtomRef.value` getter is inert
+  and can't self-track.)
+- **Ordering matters.** The body pass runs *after* the JSX pass, so JSX
+  `.value` reads are already `h.read(...)` calls (callee property `read`,
+  not `value`) and cannot be double-rewritten. The body pass only ever
+  sees reads the JSX pass left behind.
+- **No `h.track` wrap in this pass.** Eager statement reads
+  (`const x = ref.value`) stay one-time reads — auto-deriving them would
+  be the implicit-infection model Vue retracted (Reactivity Transform)
+  and Svelte/Solid reject. Tracking activates only when the read
+  *executes* under a tracker: an `Await` thunk (run under `trackDeps`) or
+  a JSX `h.track` scope. A statement read outside any tracker is just
+  `.value`.
+
+Opt-out of tracking has no dedicated helper yet: read outside a tracking
+scope, or (future) a small `untrack`-style wrapper. Optional chaining
+(`obj?.value`, an `OptionalMemberExpression`) is never matched, so it is
+left as-is and does not track.
+
 ## Auto-injected imports
 
-If any JSX rewrote to an `h()` call, the transform ensures
-`import { h } from "@efx/runtime"` exists. `Fragment` is added when
-`<>...</>` is used. `list` is added when the `.value.map → list(...)`
-rewrite fires. `ensureRuntimeImports` finds an existing import from
-`@efx/runtime` and appends to it; otherwise it prepends a new
-declaration. Names already imported under their own identifier (no
-alias) are skipped to avoid duplicates.
+If any JSX rewrote to an `h()` call **or** the whole-body pass emitted any
+`h.read(...)`, the transform ensures `import { h } from "@efx/runtime"`
+exists (tracked via `usedH || usedHRead` in `transformEfx`). `Fragment`
+is added when `<>...</>` is used. `list` is added when the
+`.value.map → list(...)` rewrite fires. `ensureRuntimeImports` finds an
+existing import from `@efx/runtime` and appends to it; otherwise it
+prepends a new declaration. Names already imported under their own
+identifier (no alias) are skipped to avoid duplicates.
 
 ## Tag dispatch
 

--- a/packages/compiler/AGENTS.md
+++ b/packages/compiler/AGENTS.md
@@ -56,12 +56,19 @@ Every JSX expression `{...}` triggers up to three local rewrites:
    AtomRef reads. (The *same* read rewrite also runs over the whole
    component body in a separate pass — see "Whole-body `.value` reads"
    below — so reads in statements/extracted thunks track too. Both
-   share `rewriteValueRead` in `transform.ts`.) Left bare on any write
-   to `.value` — assignment LHS
-   (`x.value = …`, `x.value += …`) **and** update expressions
-   (`x.value++`, `--x.value`). The bare-write fallback exists so the
-   emitted JS stays well-formed (`h.read(x)++` would be a SyntaxError
-   in strict modules). The compiler intentionally does not raise its
+   share `rewriteValueRead` in `transform.ts`.) Left bare on any **write
+   or binding target** — see `isWriteTarget`, which covers the closed set
+   of LVal positions: assignment LHS (`x.value = …`, `x.value += …`),
+   update (`x.value++`, `--x.value`), `delete x.value`, destructuring
+   targets (`[x.value] = …`, `({k: x.value} = …)`, `[...x.value] = …`),
+   and `for (x.value of/in …)`. The bare fallback exists so the emitted
+   JS stays well-formed: `h.read(x)++` / `[h.read(x)] = …` would be
+   invalid, and `for (h.read(x) of …)` would even crash Babel's AST
+   validator (`ForOfStatement.left` rejects a `CallExpression`). Read
+   sub-positions that only *look* write-adjacent are still rewritten — an
+   assignment's RHS, an `AssignmentPattern` default (`[a = x.value]`), a
+   computed pattern key, and the iterable of a `for…of`
+   (`for (a of x.value)`). The compiler intentionally does not raise its
    own diagnostic for `.value++` on an AtomRef: TypeScript already
    surfaces `ts(2540) Cannot assign to 'value' because it is a
    read-only property` at the right column for `=`, `+=`, `++`, and

--- a/packages/compiler/src/transform.test.ts
+++ b/packages/compiler/src/transform.test.ts
@@ -260,6 +260,81 @@ describe("Await calls are not h.track-wrapped", () => {
   })
 })
 
+describe("whole-body `.value` reads (tracking outside JSX)", () => {
+  // The JSX pass only rewrites `.value` inside JSX expressions. A third pass
+  // rewrites `.value` reads that survive in *statements* — extracted Await
+  // thunks, helpers, locals — so an AtomRef tracks anywhere in a component
+  // body. Detection is the runtime brand inside `h.read` (faithful for
+  // non-AtomRefs); there is no compile-time atom analysis and no `h.track`
+  // wrap in this pass (eager reads stay one-time).
+
+  it("rewrites a `.value` read in an extracted thunk (the motivating gap)", () => {
+    const out = compile(
+      `const get = () => client.getUser(userId.value)\n` +
+        `const x = <div>{Await(get, { onSuccess: (u) => <span>{u}</span> })}</div>`,
+    )
+    expect(out).toContain(`h.read(userId)`)
+    // No h.track wrap around the thunk read — Await runs it under its own tracker.
+    expect(out).not.toMatch(/h\.track\(\(\)\s*=>\s*client\.getUser/)
+  })
+
+  it("rewrites a plain statement-level `.value` read", () => {
+    const out = compile(`const n = count.value + 1`)
+    expect(out).toContain(`h.read(count)`)
+    expect(out).not.toContain(`h.track`)
+  })
+
+  it("rewrites `.value` inside a non-thunk function body", () => {
+    const out = compile(`function label() { return count.value }`)
+    expect(out).toContain(`h.read(count)`)
+  })
+
+  it("auto-imports `h` when the only rewrite is a body read (no JSX)", () => {
+    const out = compile(`const get = () => ref.value`)
+    expect(out).toContain(`h.read(ref)`)
+    expect(out).toMatch(/import \{[^}]*\bh\b[^}]*\} from "@efx\/runtime"/)
+  })
+
+  it("leaves a body `.value` *write* bare (assignment + update)", () => {
+    const assign = compile(`const f = () => { ref.value = 1 }`)
+    expect(assign).toContain(`ref.value = 1`)
+    expect(assign).not.toContain(`h.read(ref)`)
+
+    const update = compile(`const f = () => { count.value++ }`)
+    expect(update).toContain(`count.value++`)
+    expect(update).not.toMatch(/h\.read\(count\)\+\+/)
+  })
+
+  it("leaves optional-chained `obj?.value` alone (different node type)", () => {
+    const out = compile(`const v = maybe?.value`)
+    expect(out).toContain(`maybe?.value`)
+    expect(out).not.toContain(`h.read(maybe)`)
+  })
+
+  it("does NOT double-rewrite JSX `.value` reads (no h.read(h.read(...)))", () => {
+    const out = compile(`const x = <div>{ref.value}</div>`)
+    expect(out).toContain(`h.read(ref)`)
+    expect(out).not.toContain(`h.read(h.read`)
+  })
+
+  it("rewrites both a JSX read and a body read with a single `h` import", () => {
+    const out = compile(
+      `const dbl = () => count.value * 2\n` +
+        `const x = <div>{count.value}</div>`,
+    )
+    // body read + JSX read both go through h.read
+    expect(out.match(/h\.read\(count\)/g)?.length).toBe(2)
+    const importLines = out.split(";").filter((s) => s.includes(`from "@efx/runtime"`))
+    expect(importLines.length).toBe(1)
+  })
+
+  it("does NOT rewrite a non-`value` property read", () => {
+    const out = compile(`const u = props.userId`)
+    expect(out).not.toContain(`h.read`)
+    expect(out).not.toContain(`@efx/runtime`)
+  })
+})
+
 describe("runtime auto-imports", () => {
   it("adds `import { h } from \"@efx/runtime\"` when JSX is present", () => {
     const out = compile(`const x = <div />`)

--- a/packages/compiler/src/transform.test.ts
+++ b/packages/compiler/src/transform.test.ts
@@ -305,6 +305,55 @@ describe("whole-body `.value` reads (tracking outside JSX)", () => {
     expect(update).not.toMatch(/h\.read\(count\)\+\+/)
   })
 
+  it("leaves destructuring-assignment targets bare (array + object patterns)", () => {
+    const arr = compile(`const f = () => { [obj.value] = arr }`)
+    expect(arr).toContain(`[obj.value] = arr`)
+    expect(arr).not.toContain(`h.read(obj)`)
+
+    const objPat = compile(`const f = () => { ({ x: obj.value } = o) }`)
+    expect(objPat).toContain(`x: obj.value`)
+    expect(objPat).not.toContain(`h.read(obj)`)
+
+    const dflt = compile(`const f = () => { [obj.value = 1] = arr }`)
+    expect(dflt).toContain(`obj.value = 1`)
+    expect(dflt).not.toContain(`h.read(obj)`)
+
+    const rest = compile(`const f = () => { [...obj.value] = arr }`)
+    expect(rest).toContain(`...obj.value`)
+    expect(rest).not.toContain(`h.read(obj)`)
+  })
+
+  it("leaves a `for (obj.value of …)` target bare (and does not crash)", () => {
+    // The unguarded form crashed Babel: ForOfStatement.left rejects a
+    // CallExpression. Must stay bare.
+    const of = compile(`const f = () => { for (el.value of xs) {} }`)
+    expect(of).toContain(`for (el.value of xs)`)
+    expect(of).not.toContain(`h.read(el)`)
+
+    const inn = compile(`const f = () => { for (el.value in xs) {} }`)
+    expect(inn).toContain(`for (el.value in xs)`)
+    expect(inn).not.toContain(`h.read(el)`)
+  })
+
+  it("still rewrites a `.value` READ on the for-of iterable (right side)", () => {
+    const out = compile(`const f = () => { for (const x of coll.value) {} }`)
+    expect(out).toContain(`for (const x of h.read(coll))`)
+  })
+
+  it("leaves `delete obj.value` bare", () => {
+    const out = compile(`const f = () => delete obj.value`)
+    expect(out).toContain(`delete obj.value`)
+    expect(out).not.toContain(`h.read(obj)`)
+  })
+
+  it("rewrites reads that only LOOK write-adjacent (RHS, default value, unary)", () => {
+    // x = obj.value (RHS), [a = obj.value] (pattern default), !obj.value (unary)
+    // are all reads and must be rewritten.
+    expect(compile(`const f = () => { x = obj.value }`)).toContain(`h.read(obj)`)
+    expect(compile(`const f = () => { [a = obj.value] = arr }`)).toContain(`h.read(obj)`)
+    expect(compile(`const f = () => !obj.value`)).toContain(`!h.read(obj)`)
+  })
+
   it("leaves optional-chained `obj?.value` alone (different node type)", () => {
     const out = compile(`const v = maybe?.value`)
     expect(out).toContain(`maybe?.value`)

--- a/packages/compiler/src/transform.ts
+++ b/packages/compiler/src/transform.ts
@@ -154,6 +154,37 @@ const hRead = (): t.MemberExpression =>
   t.memberExpression(t.identifier("h"), t.identifier("read"))
 
 /**
+ * Rewrite a single `obj.value` member *read* to `h.read(obj)`, returning whether
+ * it rewrote. Shared by the JSX-expression rewrite (`rewriteTrackedExpression`)
+ * and the whole-body pass (`transformEfx` pass 3) so both apply identical rules:
+ *
+ *   - Only non-computed `.value` reads. `obj["value"]` and other properties pass.
+ *   - Writes are left bare: assignment LHS (`= / += / …`) and `++`/`--`. Emitting
+ *     `h.read(obj)++` would be a SyntaxError, and for an AtomRef the bare form
+ *     surfaces TypeScript's own `ts(2540) Cannot assign to 'value' … read-only`
+ *     at the right column — no custom diagnostic needed.
+ *   - Optional chaining (`obj?.value`) is a different node type
+ *     (`OptionalMemberExpression`), so it is never matched here — left as-is.
+ *
+ * Detection of *what actually tracks* is deferred to runtime: `h.read` is a
+ * faithful passthrough that records a dependency only for branded AtomRefs under
+ * an active tracker (see `readImpl` in `@efx/runtime`). So this rewrite needs no
+ * compile-time "is this an AtomRef?" analysis — it routes every `.value` read
+ * through the one exact gate.
+ */
+const rewriteValueRead = (path: NodePath<t.MemberExpression>): boolean => {
+  const n = path.node
+  if (n.computed) return false
+  if (!t.isIdentifier(n.property)) return false
+  if (n.property.name !== "value") return false
+  const parent = path.parent
+  if (t.isAssignmentExpression(parent) && parent.left === n) return false
+  if (t.isUpdateExpression(parent) && parent.argument === n) return false
+  path.replaceWith(t.callExpression(hRead(), [n.object as t.Expression]))
+  return true
+}
+
+/**
  * True when an arrow body is a JSX expression — either directly
  * (`item => <Row/>`) or via a block whose only statement is `return <JSX/>`
  * (`item => { return <Row/> }`).
@@ -221,22 +252,7 @@ const rewriteTrackedExpression = (
       path.skip()
     },
     MemberExpression(path) {
-      // Rewrite `obj.value` → `h.read(obj)` for *reads only*. Anything that
-      // writes to `.value` (assignment LHS `=`/`+=`/etc., `++`/`--`) is left
-      // bare so the emitted JS stays well-formed (`h.read(obj)++` would be
-      // a SyntaxError). For AtomRefs this is also exactly what the user
-      // wants surfaced — TypeScript's own `ts(2540) Cannot assign to
-      // 'value' because it is a read-only property` already fires at the
-      // right position. No custom diagnostic needed.
-      const n = path.node
-      if (n.computed) return
-      if (!t.isIdentifier(n.property)) return
-      if (n.property.name !== "value") return
-      const parent = path.parent
-      if (t.isAssignmentExpression(parent) && parent.left === n) return
-      if (t.isUpdateExpression(parent) && parent.argument === n) return
-      path.replaceWith(t.callExpression(hRead(), [n.object as t.Expression]))
-      rewroteRead = true
+      if (rewriteValueRead(path)) rewroteRead = true
     },
   })
   return {
@@ -511,11 +527,33 @@ export const transformEfx = (
     },
   })
 
+  // Pass 3 — whole-body `.value` reads. The JSX pass above only rewrites
+  // `.value` inside JSX expressions; a `.value` read in a *statement* (an
+  // extracted `Await` thunk, a helper, a local `const`) was left bare and so
+  // never tracked. Rewrite those surviving reads too, so an AtomRef tracks
+  // anywhere in a component body, not just in JSX.
+  //
+  // Runs on the LIVE AST *after* the JSX pass, so every JSX `.value` is already
+  // an `h.read(...)` call (property name "read", not "value") and can't be
+  // double-rewritten. There is NO compile-time atom detection: `h.read` is a
+  // faithful passthrough (identical to `.value` for non-AtomRefs), so emitting
+  // it for every `.value` read is safe; the runtime brand check is the exact
+  // gate. And NO `h.track` wrap here — eager statement reads stay one-time
+  // reads (Solid/Svelte/Vue semantics); tracking only activates when the read
+  // executes under a tracker (an `Await` thunk, or a JSX `h.track` scope).
+  let usedHRead = false
+  traverse(ast, {
+    MemberExpression(path: NodePath<t.MemberExpression>) {
+      if (rewriteValueRead(path)) usedHRead = true
+    },
+  })
+
   // Auto-inject the runtime imports the rewritten code now depends on.
   // Looks for an existing `import … from "@efx/runtime"` and adds the
   // missing names there; otherwise prepends a new import. Keeps the user's
-  // imports untouched and avoids duplicate specifiers.
-  if (usedH) {
+  // imports untouched and avoids duplicate specifiers. `h` is needed if the
+  // JSX pass emitted `h(...)` OR pass 3 emitted any `h.read(...)`.
+  if (usedH || usedHRead) {
     const wanted = new Set(["h"])
     if (usedFragment) wanted.add("Fragment")
     if (state.wroteList) wanted.add("list")

--- a/packages/compiler/src/transform.ts
+++ b/packages/compiler/src/transform.ts
@@ -154,15 +154,54 @@ const hRead = (): t.MemberExpression =>
   t.memberExpression(t.identifier("h"), t.identifier("read"))
 
 /**
+ * True when an `obj.value` member sits in a write / binding-target position, so
+ * it must be left bare. Rewriting a write target to `h.read(obj)` would emit
+ * invalid JS (`[h.read(obj)] = …` — assignment to a call) or, for
+ * `for (obj.value of …)`, crash Babel's AST validator (`ForOfStatement.left`
+ * rejects a `CallExpression`). Covers every LVal shape:
+ *
+ *   obj.value = …      obj.value++ / --obj.value     delete obj.value
+ *   [obj.value] = …    ({ k: obj.value } = …)        for (obj.value of/in …)
+ *   [obj.value = d] = …    [...obj.value] = …
+ *
+ * The set of LVal positions is closed, so this is exhaustive. It climbs through
+ * destructuring connectors (`RestElement`, `AssignmentPattern.left`,
+ * `ObjectProperty.value`), and reaching an `ArrayPattern`/`ObjectPattern` — node
+ * types that exist *only* in target positions — confirms a write. Read
+ * sub-positions are distinguished: a computed pattern key (`{[obj.value]: x}`),
+ * an `AssignmentPattern` default (`[a = obj.value]`), the `.right` of an
+ * assignment, and the iterable of a `for…of` (`for (x of obj.value)`) all read.
+ * Any ordinary expression parent means it's a read.
+ */
+const isWriteTarget = (path: NodePath<t.MemberExpression>): boolean => {
+  let cur: NodePath = path
+  let parent: NodePath | null = path.parentPath
+  while (parent) {
+    const pn = parent.node
+    const cn = cur.node
+    if (t.isAssignmentExpression(pn)) return pn.left === cn
+    if (t.isUpdateExpression(pn)) return pn.argument === cn
+    if (t.isUnaryExpression(pn) && pn.operator === "delete") return pn.argument === cn
+    if (t.isForOfStatement(pn) || t.isForInStatement(pn)) return pn.left === cn
+    if (t.isArrayPattern(pn) || t.isObjectPattern(pn)) return true
+    // Connectors — climb only via their target sub-position.
+    if (t.isRestElement(pn) && pn.argument === cn) { cur = parent; parent = parent.parentPath; continue }
+    if (t.isAssignmentPattern(pn) && pn.left === cn) { cur = parent; parent = parent.parentPath; continue }
+    if (t.isObjectProperty(pn) && pn.value === cn) { cur = parent; parent = parent.parentPath; continue }
+    return false
+  }
+  return false
+}
+
+/**
  * Rewrite a single `obj.value` member *read* to `h.read(obj)`, returning whether
  * it rewrote. Shared by the JSX-expression rewrite (`rewriteTrackedExpression`)
  * and the whole-body pass (`transformEfx` pass 3) so both apply identical rules:
  *
  *   - Only non-computed `.value` reads. `obj["value"]` and other properties pass.
- *   - Writes are left bare: assignment LHS (`= / += / …`) and `++`/`--`. Emitting
- *     `h.read(obj)++` would be a SyntaxError, and for an AtomRef the bare form
- *     surfaces TypeScript's own `ts(2540) Cannot assign to 'value' … read-only`
- *     at the right column — no custom diagnostic needed.
+ *   - Writes/binding targets are left bare (see `isWriteTarget`). For an AtomRef
+ *     the bare write also surfaces TypeScript's own `ts(2540) Cannot assign to
+ *     'value' … read-only` at the right column — no custom diagnostic needed.
  *   - Optional chaining (`obj?.value`) is a different node type
  *     (`OptionalMemberExpression`), so it is never matched here — left as-is.
  *
@@ -170,17 +209,17 @@ const hRead = (): t.MemberExpression =>
  * faithful passthrough that records a dependency only for branded AtomRefs under
  * an active tracker (see `readImpl` in `@efx/runtime`). So this rewrite needs no
  * compile-time "is this an AtomRef?" analysis — it routes every `.value` read
- * through the one exact gate.
+ * through the one exact gate. `copyLoc` keeps the emitted call mapped to the
+ * original `.value` span (matters for statement reads, which no `jsxRange`
+ * covers).
  */
 const rewriteValueRead = (path: NodePath<t.MemberExpression>): boolean => {
   const n = path.node
   if (n.computed) return false
   if (!t.isIdentifier(n.property)) return false
   if (n.property.name !== "value") return false
-  const parent = path.parent
-  if (t.isAssignmentExpression(parent) && parent.left === n) return false
-  if (t.isUpdateExpression(parent) && parent.argument === n) return false
-  path.replaceWith(t.callExpression(hRead(), [n.object as t.Expression]))
+  if (isWriteTarget(path)) return false
+  path.replaceWith(copyLoc(t.callExpression(hRead(), [n.object as t.Expression]), n))
   return true
 }
 

--- a/packages/runtime/AGENTS.md
+++ b/packages/runtime/AGENTS.md
@@ -61,7 +61,13 @@ The compiler wraps `{expr}` JSX expressions in `h.track(() => expr)`
 **only when** it actually rewrote a `.value` read inside (see
 [compiler AGENTS.md](../compiler/AGENTS.md)). Inside that scope:
 
-- `h.read(ref)` — reads `.value`, registers `ref` as a tracked dep.
+- `h.read(ref)` — a **faithful, transparent wrapper for `.value`**:
+  byte-for-byte `ref.value` for any non-AtomRef (throws on null exactly
+  as `.value` would — no `?.` swallow), and for a branded AtomRef it
+  *additionally* registers `ref` as a tracked dep when a tracker is
+  active. This faithfulness is what lets the compiler emit `h.read` for
+  *every* `.value` read in a component body (not just JSX) without any
+  compile-time atom analysis — the `isAtomRef` brand is the exact gate.
 
 `h.track` itself (via `trackDeps` in `coerce.ts`, shared with `Await`):
 
@@ -171,12 +177,15 @@ so an *async* arm effect can never resolve and renders `[effect failed: …]`;
 an arm effect needing an unprovided service also fails only at runtime (its
 `R` isn't folded). Keep arms pure markup.
 
-**Tracking is inline-only.** The `.value`→`h.read` rewrite the tracker relies
-on happens in JSX expression positions, so only `.value` reads written
-*inline in the thunk* track. An extracted thunk —
-`const get = () => http.getUser(userId.value)` then `Await(get, …)` — silently
-does NOT refetch (runs once, no error). Write the thunk inline at the call
-site. (Binding-aware rewriting to lift this is a planned follow-up.)
+**Inline or extracted — both track.** The compiler rewrites `.value`→`h.read`
+across the whole component body, not just in JSX expressions (see the compiler's
+"Whole-body `.value` reads"), so an extracted thunk —
+`const get = () => http.getUser(userId.value)` then `Await(get, …)` — refetches
+identically to the inline form. The read just has to happen *inside* the thunk
+(so it runs under `Await`'s tracker); a `.value` read into a local *before* the
+thunk (`const id = userId.value; Await(() => http.getUser(id), …)`) captures a
+snapshot and won't refetch — that's the ordinary eager-read semantics, not a
+special case.
 
 **Why a thunk, not the bare expression** (`Await(http.getUser(userId.value))`):
 the bare form evaluates the effect eagerly with nothing re-runnable, and the
@@ -359,14 +368,11 @@ higher-rank polymorphism TS doesn't have.
 
 ### `h.read` overload preserves arbitrary `.value` types
 
-`h.read` is intentionally overloaded three ways:
+`h.read` is intentionally overloaded two ways:
 
 ```ts
 function read<T>(obj: AtomRef.ReadonlyRef<T>): T
 function read<T extends HasValue>(obj: T): T["value"]
-function read<T extends HasValue | null | undefined>(
-  obj: T
-): T extends HasValue ? T["value"] : undefined
 ```
 
 (`HasValue = { readonly value: unknown }`.) The second signature
@@ -375,11 +381,14 @@ is **load-bearing**: it lets compiled code like `h.read(s).bio`
 `s.value.bio`) type-check against `Success`'s payload. Drop it
 and every pattern-match site against `AsyncResult` / `Option` /
 `Result` shapes that reads `.value` inside a JSX expression
-breaks. The third overload extends that to nullable receivers so
-`opt?.value` inside JSX still narrows correctly. The TS-side
-overloads are independent of the runtime behavior (for AtomRefs
-it tracks; for anything else it's identity to `.value`, with
-optional-chaining preserved).
+breaks. There is **no** nullable overload: reading `.value` on a
+possibly-null base is a type error in the source `.value` form
+too, and `h.read` now mirrors that — it is byte-for-byte
+`obj.value` at runtime (it throws on null; there is no `?.`
+swallow). The TS-side overloads are independent of the runtime
+behavior (for AtomRefs it tracks; for anything else it's identity
+to `.value`). Optional chaining (`obj?.value`) is left un-rewritten
+by the compiler, so it never reaches `h.read`.
 
 ## Channel-fold quick check
 

--- a/packages/runtime/src/h.test.ts
+++ b/packages/runtime/src/h.test.ts
@@ -1,0 +1,54 @@
+/**
+ * `h.read` is a faithful, transparent wrapper for `.value`: byte-for-byte
+ * `obj.value` for any non-AtomRef (including throwing on null, NO `?.` swallow),
+ * and for a branded AtomRef it additionally records a dependency iff a tracker
+ * is active. This faithfulness is what lets the compiler rewrite *every* `.value`
+ * read in a component body to `h.read` with no compile-time atom analysis.
+ */
+import { describe, expect, it } from "@effect/vitest"
+import { AtomRef } from "effect/unstable/reactivity"
+import { h } from "./h.ts"
+import { trackDeps } from "./coerce.ts"
+
+// Untyped escape hatch for the faithfulness edge cases (null / non-HasValue)
+// that the typed overloads correctly reject at compile time.
+const readUnsafe = h.read as (obj: unknown) => unknown
+
+describe("h.read — AtomRef branch", () => {
+  it("returns the ref's value", () => {
+    const ref = AtomRef.make(7)
+    expect(h.read(ref)).toBe(7)
+  })
+
+  it("records the ref as a dependency when read under a tracker", () => {
+    const ref = AtomRef.make("x")
+    const { result, deps } = trackDeps(() => h.read(ref))
+    expect(result).toBe("x")
+    expect(deps.has(ref)).toBe(true)
+  })
+
+  it("records NO dependency when read outside any tracker", () => {
+    const ref = AtomRef.make("x")
+    // No trackDeps scope active — must not throw, must return the value.
+    expect(h.read(ref)).toBe("x")
+  })
+})
+
+describe("h.read — non-AtomRef branch (faithful .value)", () => {
+  it("returns `.value` of a plain object, identical to direct access", () => {
+    const domLike = { value: "typed" }
+    expect(h.read(domLike)).toBe("typed")
+  })
+
+  it("records NO dependency for a non-AtomRef, even under a tracker", () => {
+    const domLike = { value: "typed" }
+    const { result, deps } = trackDeps(() => h.read(domLike))
+    expect(result).toBe("typed")
+    expect(deps.size).toBe(0)
+  })
+
+  it("throws on null exactly like `null.value` would (no `?.` swallow)", () => {
+    expect(() => readUnsafe(null)).toThrow()
+    expect(() => readUnsafe(undefined)).toThrow()
+  })
+})

--- a/packages/runtime/src/h.ts
+++ b/packages/runtime/src/h.ts
@@ -44,15 +44,21 @@ type HasValue = { readonly value: unknown }
 
 function readImpl<T>(obj: AtomRef.ReadonlyRef<T>): T
 function readImpl<T extends HasValue>(obj: T): T["value"]
-function readImpl<T extends HasValue | null | undefined>(obj: T): T extends HasValue ? T["value"] : undefined
 function readImpl(obj: unknown): unknown {
   if (isAtomRef(obj)) {
     recordDep(obj)
     return obj.value
   }
-  // Identical semantics to `.value` access — preserves the typing TS would
-  // have given the original `.value` expression.
-  return (obj as HasValue | null | undefined)?.value
+  // Faithful, transparent passthrough: `h.read(x)` is byte-for-byte `x.value`
+  // for any non-AtomRef — including throwing on `null`/`undefined` exactly as
+  // `.value` would (NO `?.` swallow). This is what lets the compiler rewrite
+  // *every* `.value` read in a component body to `h.read` without any
+  // compile-time "is this an AtomRef?" analysis: the brand check above is the
+  // only gate, and it's exact. A non-AtomRef read records no dependency and
+  // returns its `.value` unchanged; an AtomRef read records a dep iff a tracker
+  // is active. Reading `.value` on a possibly-null base is a type error in the
+  // source `.value` form too, so there is no nullable overload here.
+  return (obj as HasValue).value
 }
 
 /**
@@ -96,8 +102,9 @@ type HFn = <
  * - `h.track(thunk)` — runs `thunk` in a reactive tracking scope; returns
  *   the static value if no refs were read, or a derived `AtomRef` that
  *   re-runs the thunk when deps change.
- * - `h.read(obj)` — like `obj?.value` but, when called inside an
- *   `h.track` scope, registers `obj` as a dependency if it's an AtomRef.
+ * - `h.read(obj)` — a faithful, transparent wrapper for `obj.value` that, when
+ *   called inside an `h.track` (or `Await`) tracking scope, registers `obj` as a
+ *   dependency if it's an AtomRef. On any non-AtomRef it is exactly `obj.value`.
  *
  * Inside any JSX expression `{…}` that contains a `.value` read, the
  * compiler rewrites each `x.value` to `h.read(x)` and wraps the whole

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -73,12 +73,10 @@ interface AwaitArms<A, E> {
  * to `h.read`, which records the dep — so in `.efx` you just write
  * `userId.value` inside the thunk.)
  *
- * LIMITATION: only `.value` reads written **inline in the thunk** track. The
- * compiler rewrites `.value`→`h.read` in JSX expression positions only, so an
- * *extracted* thunk — `const get = () => http.getUser(userId.value)` then
- * `Await(get, …)` — silently does NOT refetch (it runs once, no error). Write
- * the thunk inline at the `Await(...)` call site. (Binding-aware rewriting that
- * lifts this restriction is a planned follow-up.)
+ * The thunk may be written inline OR extracted to a binding — the compiler
+ * rewrites `.value`→`h.read` across the whole component body, not just in JSX
+ * expressions, so `const get = () => http.getUser(userId.value)` then
+ * `Await(get, …)` tracks identically to the inline form.
  *
  * Channels: extract services with `yield* Service` *before* the thunk so the
  * effect the thunk builds carries no `R` (it's already discharged into the

--- a/packages/testing/src/await-autotrack.test.ts
+++ b/packages/testing/src/await-autotrack.test.ts
@@ -52,6 +52,33 @@ describe("auto-tracking Await", () => {
     await ui.unmount()
   })
 
+  it("refetches even when the thunk is extracted to a separate binding", async () => {
+    // The gap the whole-body `.value`→h.read rewrite closes: a thunk lifted out
+    // of the Await(...) call site. Post-compile it's `const get = () =>
+    // client.get(h.read(userId))`, so the read still happens inside the thunk
+    // Await runs under its tracker — and tracking works identically to inline.
+    const userId = AtomRef.make("42")
+    const ExtractedPage = Effect.fn(function* () {
+      const client = yield* Users
+      const get = () => client.get(read(userId)) // extracted thunk
+      return yield* h("div", { class: "page" },
+        h("button", { class: "grace", onclick: () => userId.set("7") }, "Grace"),
+        yield* Await(get, {
+          pending: h("span", { class: "loading" }, "…"),
+          onSuccess: (n) => h("span", { class: "ok" }, n),
+          onError: () => h("span", { class: "err" }, "not found"),
+        }),
+      )
+    })
+    const ui = await render(ExtractedPage(), UsersLive)
+    expect((await ui.waitFor(".ok")).textContent?.trim()).toBe("Ada")
+    ui.click(".grace")
+    const d = Date.now() + 1000
+    while (ui.query(".ok")?.textContent?.trim() !== "Grace" && Date.now() < d) await ui.tick()
+    expect(ui.query(".ok")?.textContent?.trim()).toBe("Grace")
+    await ui.unmount()
+  })
+
   it("auto-refetch shows the error arm on a bad key", async () => {
     const userId = AtomRef.make("42")
     const ui = await render(Page(userId), UsersLive)


### PR DESCRIPTION
## What

Rewrite `.value`→`h.read` **everywhere in a component body**, not just in JSX expressions, so an `AtomRef` read tracks in statements and **extracted `Await` thunks**. Closes the gap where lifting a thunk out of the `Await(...)` call site silently stopped refetching:

```ts
const get = () => http.getUser(userId.value)   // → http.getUser(h.read(userId)) — now tracks
Await(get, { … })
```

## Why this shape (not compile-time atom analysis)

An earlier plan tried to detect "is `x` an AtomRef?" at compile time (declaration shape + type annotations + alias resolution). After studying how Vue / Solid / Svelte / Marko handle reactivity, we rejected that: **detection belongs at runtime, where it's exact** — exactly what Vue (`.value` getter self-tracks) and Solid (read inside a tracking scope) do. Static analysis is fragile under aliasing, extraction, `yield* Service`, and dynamic indirection, and is unnecessary.

We also explored two ways to drop the compiler rewrite entirely — patching Effect's `AtomRef` to self-track (Vue-style), or a thin wrapper type. Both are dead ends here: Effect stores `value` as a **plain instance data field** on the core impl (no getter seam), Collection rows are constructed **internally**, and a wrapper only covers user-constructed refs (rows / derived / service refs would silently not track) — the compiler rewrite is *more* uniform because it keys on the syntactic read + runtime brand, regardless of where the ref came from.

## Changes

- **runtime (`h.ts`)** — `h.read` is now a faithful, transparent wrapper for `.value`: byte-for-byte `x.value` for any non-AtomRef (throws on null as `.value` would; no `?.` swallow), and records a dep only for branded AtomRefs under an active tracker. Nullable overload removed (reading `.value` on a nullable is a type error in source too). This is what makes emitting `h.read` for *every* `.value` read sound — the `isAtomRef` brand is the only, exact gate.
- **compiler (`transform.ts`)** — a third `traverse` over the live AST, *after* the JSX pass (so JSX `.value` is already `h.read` and can't be double-rewritten), rewrites surviving `obj.value`→`h.read(obj)` via a shared `rewriteValueRead` helper. **No `h.track` wrap** — eager statement reads stay one-time (Solid/Svelte/Vue semantics). `h` auto-imported when only body reads exist.
- **compiler — exhaustive LVal guard (`isWriteTarget`)** — leaves every write/binding target bare: assignment LHS, update, `delete`, array/object destructuring targets (incl. rest + assignment-pattern), and `for (x.value of/in …)`. The unguarded for-of form previously **crashed** Babel's AST validator on the per-keystroke editor path; destructuring targets emitted invalid JS. Read sub-positions that only look write-adjacent (assignment RHS, `for…of` iterable, pattern defaults, computed keys) are still rewritten. The emitted call is `copyLoc`'d so statement reads map back to their source span.

## Tests & docs

- compiler `transform.test.ts` **+14** (whole-body reads, all LVal cases, read-adjacent reads)
- new runtime `h.test.ts` (faithfulness + tracking)
- testing `await-autotrack.test.ts` **+1** (extracted-thunk refetch)
- `compiler/AGENTS.md`, `runtime/AGENTS.md`, `Await` docstring updated

## Verification

- `pnpm -r test` → **EXIT 0** (compiler 77, runtime 44, language 15, vite-plugin 5, testing 10, ts-plugin 31, check OK)
- `pnpm -r typecheck` → **EXIT 0**, incl. `apps/demo` `@efx/check` 0 errors / 9 `.efx` files

## Commits
1. `a84885e` feat(compiler): track .value reads across the component body
2. `f276931` fix(compiler): guard all LVal positions in .value rewrite