### PR TITLE
test: multi-line template literals for source fixtures

### DIFF
--- a/packages/compiler/src/source-map.test.ts
+++ b/packages/compiler/src/source-map.test.ts
@@ -20,7 +20,9 @@ const findBySourceOffset = (
 
 describe("transformEfx — mappings shape", () => {
   it("every mapping carries source and generated lengths plus a kind", () => {
-    const result = compile(`const x = <div class="page">hi</div>`)
+    const result = compile(`
+      const x = <div class="page">hi</div>
+    `)
     expect(result.mappings.length).toBeGreaterThan(0)
     for (const m of result.mappings) {
       expect(typeof m.source.offset).toBe("number")
@@ -37,7 +39,9 @@ describe("transformEfx — mappings shape", () => {
     // function-call paren + arrow paren) has source length 2 but generated
     // length 1. Without this, downstream consumers over-claim generated
     // territory and inlay-hint positions drift.
-    const src = `const f = () => count.update((n) => n + 1)`
+    const src = `
+      const f = () => count.update((n) => n + 1)
+    `
     const result = compile(src)
     expect(result.code).toContain("count.update(n => n + 1)")
 
@@ -49,7 +53,9 @@ describe("transformEfx — mappings shape", () => {
   })
 
   it("source positions are not duplicated (dedup by source offset)", () => {
-    const src = `const view = <div><span>x</span></div>`
+    const src = `
+      const view = <div><span>x</span></div>
+    `
     const result = compile(src)
     const seen = new Set<number>()
     for (const m of result.mappings) {
@@ -59,7 +65,9 @@ describe("transformEfx — mappings shape", () => {
   })
 
   it("user source positions are covered by at most one mapping (no overlap)", () => {
-    const src = `const view = <div>hi</div>`
+    const src = `
+      const view = <div>hi</div>
+    `
     const result = compile(src)
     for (let i = 0; i < src.length; i++) {
       const containing = result.mappings.filter(
@@ -70,7 +78,9 @@ describe("transformEfx — mappings shape", () => {
   })
 
   it("mappings are sorted by source offset", () => {
-    const src = `const view = <div><span>x</span></div>`
+    const src = `
+      const view = <div><span>x</span></div>
+    `
     const result = compile(src)
     for (let i = 1; i < result.mappings.length; i++) {
       expect(result.mappings[i]!.source.offset).toBeGreaterThan(result.mappings[i - 1]!.source.offset)
@@ -80,7 +90,9 @@ describe("transformEfx — mappings shape", () => {
 
 describe("transformEfx — mapping kinds", () => {
   it("JSX angle brackets `<` `>` `/` are classified as punctuation", () => {
-    const src = `const x = <div>hi</div>`
+    const src = `
+      const x = <div>hi</div>
+    `
     const result = compile(src)
     const ltSrc = src.indexOf("<div")
     const ltMapping = findBySourceOffset(result.mappings, ltSrc)
@@ -88,7 +100,9 @@ describe("transformEfx — mapping kinds", () => {
   })
 
   it("positions inside an h() call (JSX-derived) are classified as h-call", () => {
-    const src = `const x = <div class="page">hi</div>`
+    const src = `
+      const x = <div class="page">hi</div>
+    `
     const result = compile(src)
     // Find a mapping whose source span sits inside the JSX opening tag.
     // Babel's source map doesn't emit a mapping at every character, so we
@@ -102,8 +116,10 @@ describe("transformEfx — mapping kinds", () => {
   })
 
   it("normal user code outside JSX is classified as user", () => {
-    const src = `const x = 1
-const view = <div>hi</div>`
+    const src = `
+      const x = 1
+      const view = <div>hi</div>
+    `
     const result = compile(src)
     const constSrc = src.indexOf("const x")
     const m = findBySourceOffset(result.mappings, constSrc)
@@ -113,8 +129,10 @@ const view = <div>hi</div>`
   it("operator `>` inside a JSX expression is NOT punctuation", () => {
     // `{a > b}` inside JSX: the `>` is a JS operator, not JSX angle bracket.
     // The classifier checks for the tag-span containment to disambiguate.
-    const src = `const a = 1, b = 2
-const view = <div>{a > b ? "yes" : "no"}</div>`
+    const src = `
+      const a = 1, b = 2
+      const view = <div>{a > b ? "yes" : "no"}</div>
+    `
     const result = compile(src)
     const gtSrc = src.indexOf("a > b") + 2
     const m = findBySourceOffset(result.mappings, gtSrc)
@@ -128,7 +146,9 @@ const view = <div>{a > b ? "yes" : "no"}</div>`
 
 describe("transformEfx — no-source-map cases", () => {
   it("file without JSX produces a single passthrough-ish mapping", () => {
-    const src = `export const x = 42`
+    const src = `
+      export const x = 42
+    `
     const result = compile(src)
     expect(result.mappings.length).toBeGreaterThan(0)
     // All mappings should be classified as user code (no JSX in source).

--- a/packages/compiler/src/transform.test.ts
+++ b/packages/compiler/src/transform.test.ts
@@ -269,10 +269,10 @@ describe("whole-body `.value` reads (tracking outside JSX)", () => {
   // wrap in this pass (eager reads stay one-time).
 
   it("rewrites a `.value` read in an extracted thunk (the motivating gap)", () => {
-    const out = compile(
-      `const get = () => client.getUser(userId.value)\n` +
-        `const x = <div>{Await(get, { onSuccess: (u) => <span>{u}</span> })}</div>`,
-    )
+    const out = compile(`
+      const get = () => client.getUser(userId.value)
+      const x = <div>{Await(get, { onSuccess: (u) => <span>{u}</span> })}</div>
+    `)
     expect(out).toContain(`h.read(userId)`)
     // No h.track wrap around the thunk read — Await runs it under its own tracker.
     expect(out).not.toMatch(/h\.track\(\(\)\s*=>\s*client\.getUser/)
@@ -367,10 +367,10 @@ describe("whole-body `.value` reads (tracking outside JSX)", () => {
   })
 
   it("rewrites both a JSX read and a body read with a single `h` import", () => {
-    const out = compile(
-      `const dbl = () => count.value * 2\n` +
-        `const x = <div>{count.value}</div>`,
-    )
+    const out = compile(`
+      const dbl = () => count.value * 2
+      const x = <div>{count.value}</div>
+    `)
     // body read + JSX read both go through h.read
     expect(out.match(/h\.read\(count\)/g)?.length).toBe(2)
     const importLines = out.split(";").filter((s) => s.includes(`from "@efx/runtime"`))

--- a/packages/compiler/src/transform.test.ts
+++ b/packages/compiler/src/transform.test.ts
@@ -8,66 +8,90 @@ const compile = (src: string): string =>
 
 describe("JSX → h() rewrites", () => {
   it("intrinsic element with text child", () => {
-    expect(compile(`const x = <div>hi</div>`))
+    expect(compile(`
+      const x = <div>hi</div>
+    `))
       .toContain(`h("div", {}, "hi")`)
   })
 
   it("intrinsic element with string attr", () => {
-    expect(compile(`const x = <div class="page">hi</div>`))
+    expect(compile(`
+      const x = <div class="page">hi</div>
+    `))
       .toContain(`h("div", { class: "page" }, "hi")`)
   })
 
   it("intrinsic element with boolean (no-value) attr", () => {
-    expect(compile(`const x = <input disabled />`))
+    expect(compile(`
+      const x = <input disabled />
+    `))
       .toContain(`h("input", { disabled: true })`)
   })
 
   it("intrinsic element with hyphenated attr name", () => {
-    expect(compile(`const x = <div data-id="42" />`))
+    expect(compile(`
+      const x = <div data-id="42" />
+    `))
       .toContain(`h("div", { ["data-id"]: "42" })`)
   })
 
   it("intrinsic element with spread attribute", () => {
-    expect(compile(`const x = <div {...props} />`))
+    expect(compile(`
+      const x = <div {...props} />
+    `))
       .toMatch(/h\("div",\s*\{\s*\.\.\.props\s*\}\s*\)/)
   })
 
   it("capitalized tag becomes identifier (component)", () => {
-    expect(compile(`const x = <Foo bar={1} />`))
+    expect(compile(`
+      const x = <Foo bar={1} />
+    `))
       .toContain(`h(Foo, { bar: 1 })`)
   })
 
   it("fragment <>...</> uses Fragment identifier", () => {
-    expect(compile(`const x = <><span /><span /></>`))
+    expect(compile(`
+      const x = <><span /><span /></>
+    `))
       .toContain(`h(Fragment, {}, h("span", {}), h("span", {}))`)
   })
 
   it("nested JSX is recursively rewritten", () => {
-    const out = compile(`const x = <div><span>a</span></div>`)
+    const out = compile(`
+      const x = <div><span>a</span></div>
+    `)
     expect(out).toContain(`h("span", {}, "a")`)
     expect(out).toContain(`h("div", {}, h("span"`)
   })
 
   it("JSX inside `&&` is rewritten", () => {
-    expect(compile(`const x = <div>{cond && <p>y</p>}</div>`))
+    expect(compile(`
+      const x = <div>{cond && <p>y</p>}</div>
+    `))
       .toContain(`h("p", {}, "y")`)
   })
 
   it("JSX inside ternary branches is rewritten", () => {
-    const out = compile(`const x = <div>{cond ? <a /> : <b />}</div>`)
+    const out = compile(`
+      const x = <div>{cond ? <a /> : <b />}</div>
+    `)
     expect(out).toContain(`h("a", {})`)
     expect(out).toContain(`h("b", {})`)
   })
 
   it("JSX inside .map(...) is rewritten", () => {
-    expect(compile(`const x = <ul>{xs.map((x) => <li>{x}</li>)}</ul>`))
+    expect(compile(`
+      const x = <ul>{xs.map((x) => <li>{x}</li>)}</ul>
+    `))
       .toContain(`h("li", {},`)
   })
 })
 
 describe("tracking-scope rewrites (h.track / h.read)", () => {
   it("`.value` reads become h.read(...) and the expression is wrapped in h.track", () => {
-    const out = compile(`const x = <div>{ref.value}</div>`)
+    const out = compile(`
+      const x = <div>{ref.value}</div>
+    `)
     expect(out).toContain(`h.read(ref)`)
     expect(out).toContain(`h.track(() =>`)
   })
@@ -76,19 +100,25 @@ describe("tracking-scope rewrites (h.track / h.read)", () => {
     // Removed: bare identifiers in test positions used to be wrapped in
     // `h.peek(...)`. Users must now write `.value` explicitly so the type
     // checker sees a `boolean` (or whatever the ref unwraps to).
-    const out = compile(`const x = <div>{loading ? <a /> : <b />}</div>`)
+    const out = compile(`
+      const x = <div>{loading ? <a /> : <b />}</div>
+    `)
     expect(out).not.toContain(`h.peek`)
     expect(out).not.toContain(`h.track`)
   })
 
   it("bare identifier in `&&` is NOT rewritten", () => {
-    const out = compile(`const x = <div>{show && <p />}</div>`)
+    const out = compile(`
+      const x = <div>{show && <p />}</div>
+    `)
     expect(out).not.toContain(`h.peek`)
     expect(out).not.toContain(`h.track`)
   })
 
   it("bare identifier under `!` is NOT rewritten", () => {
-    const out = compile(`const x = <div>{!hidden ? <a /> : <b />}</div>`)
+    const out = compile(`
+      const x = <div>{!hidden ? <a /> : <b />}</div>
+    `)
     expect(out).not.toContain(`h.peek`)
   })
 
@@ -96,28 +126,38 @@ describe("tracking-scope rewrites (h.track / h.read)", () => {
     // `<Row item={item} />` — `item` is a bare identifier in attribute
     // position; there's no .value read, so wrapping would only strip the
     // static type to `unknown`.
-    const out = compile(`const x = <Row item={item} />`)
+    const out = compile(`
+      const x = <Row item={item} />
+    `)
     expect(out).toContain(`h(Row, { item: item })`)
     expect(out).not.toContain(`h.track`)
   })
 
   it("static literal attribute values are not wrapped", () => {
-    expect(compile(`const x = <Foo n={42} s={"hi"} />`))
+    expect(compile(`
+      const x = <Foo n={42} s={"hi"} />
+    `))
       .not.toContain(`h.track`)
   })
 
   it("`.value` assignment (LHS) is NOT rewritten as a read", () => {
     // We only intercept reads — `obj.value = …` stays as a real assignment.
-    expect(compile(`const x = <div>{(ref.value = 1, ref.value)}</div>`))
+    expect(compile(`
+      const x = <div>{(ref.value = 1, ref.value)}</div>
+    `))
       .toMatch(/ref\.value = 1/)
   })
 
   it("`.value++` / `--.value` are left bare — `h.read(obj)++` would be invalid JS, and TS's own `ts(2540)` already flags the read-only write at the right column", () => {
-    const post = compile(`const v = <button onclick={() => count.value++}>+</button>`)
+    const post = compile(`
+      const v = <button onclick={() => count.value++}>+</button>
+    `)
     expect(post).toContain(`count.value++`)
     expect(post).not.toMatch(/h\.read\(count\)\+\+/)
 
-    const pre = compile(`const v = <button onclick={() => --count.value}>-</button>`)
+    const pre = compile(`
+      const v = <button onclick={() => --count.value}>-</button>
+    `)
     expect(pre).toContain(`--count.value`)
     expect(pre).not.toMatch(/--h\.read\(count\)/)
   })
@@ -125,7 +165,9 @@ describe("tracking-scope rewrites (h.track / h.read)", () => {
   it("`.value += X` (compound assignment) is NOT rewritten — caught by the LHS escape hatch", () => {
     // AssignmentExpression with operator `+=` still has .left === the
     // MemberExpression, so the existing skip predicate covers it.
-    const out = compile(`const v = <button onclick={() => { count.value += 1 }}>+</button>`)
+    const out = compile(`
+      const v = <button onclick={() => { count.value += 1 }}>+</button>
+    `)
     expect(out).toContain(`count.value += 1`)
     expect(out).not.toMatch(/h\.read\(count\) \+=/)
   })
@@ -134,7 +176,9 @@ describe("tracking-scope rewrites (h.track / h.read)", () => {
 describe(".value.map(arrow → JSX) → list(...) rewrite", () => {
   it("rewrites `<expr>.value.map(item => <JSX/>)` to a `list(<expr>, ...)` call", () => {
     const out = compile(
-      `const x = <ul>{coll.value.map((item) => <Row item={item} />)}</ul>`,
+      `
+      const x = <ul>{coll.value.map((item) => <Row item={item} />)}</ul>
+    `,
     )
     expect(out).toContain(`list(coll, item =>`)
     expect(out).toContain(`h(Row, { item: item })`)
@@ -142,7 +186,9 @@ describe(".value.map(arrow → JSX) → list(...) rewrite", () => {
 
   it("does NOT wrap the rewritten call in h.track (no redundant reactivity)", () => {
     const out = compile(
-      `const x = <ul>{coll.value.map((item) => <Row item={item} />)}</ul>`,
+      `
+      const x = <ul>{coll.value.map((item) => <Row item={item} />)}</ul>
+    `,
     )
     expect(out).not.toContain(`h.track`)
     // And the `.value` is consumed by the rewrite — not turned into h.read.
@@ -151,14 +197,18 @@ describe(".value.map(arrow → JSX) → list(...) rewrite", () => {
 
   it("auto-imports `list` from @efx/runtime", () => {
     const out = compile(
-      `const x = <ul>{coll.value.map((item) => <Row item={item} />)}</ul>`,
+      `
+      const x = <ul>{coll.value.map((item) => <Row item={item} />)}</ul>
+    `,
     )
     expect(out).toMatch(/import \{[^}]*\blist\b[^}]*\} from "@efx\/runtime"/)
   })
 
   it("supports block-body arrow returning only a JSX node", () => {
     const out = compile(
-      `const x = <ul>{coll.value.map((item) => { return <Row item={item} /> })}</ul>`,
+      `
+      const x = <ul>{coll.value.map((item) => { return <Row item={item} /> })}</ul>
+    `,
     )
     expect(out).toContain(`list(coll,`)
     expect(out).toContain(`h(Row, { item: item })`)
@@ -170,13 +220,17 @@ describe(".value.map(arrow → JSX) → list(...) rewrite", () => {
     // fragment idiom (`item => <>…</>` for multi-child rows without a wrapper
     // element) would get a silent no-rewrite.
     const direct = compile(
-      `const x = <ul>{coll.value.map((item) => <>{item}</>)}</ul>`,
+      `
+      const x = <ul>{coll.value.map((item) => <>{item}</>)}</ul>
+    `,
     )
     expect(direct).toContain(`list(coll,`)
     expect(direct).toContain(`h(Fragment,`)
 
     const block = compile(
-      `const x = <ul>{coll.value.map((item) => { return <>{item}</> })}</ul>`,
+      `
+      const x = <ul>{coll.value.map((item) => { return <>{item}</> })}</ul>
+    `,
     )
     expect(block).toContain(`list(coll,`)
     expect(block).toContain(`h(Fragment,`)
@@ -186,7 +240,9 @@ describe(".value.map(arrow → JSX) → list(...) rewrite", () => {
     // Whole-collection derivation pattern (Collection.map((items) => derived))
     // must NOT be touched.
     const out = compile(
-      `const x = <span>{coll.value.map((items) => items.length)}</span>`,
+      `
+      const x = <span>{coll.value.map((items) => items.length)}</span>
+    `,
     )
     expect(out).not.toContain(`list(`)
     // The outer `.value` is a normal reactive read; should be rewritten to h.read.
@@ -195,7 +251,9 @@ describe(".value.map(arrow → JSX) → list(...) rewrite", () => {
 
   it("does NOT rewrite plain `.map` (no `.value`) — leaves as-is", () => {
     const out = compile(
-      `const x = <ul>{xs.map((x) => <li>{x}</li>)}</ul>`,
+      `
+      const x = <ul>{xs.map((x) => <li>{x}</li>)}</ul>
+    `,
     )
     expect(out).not.toContain(`list(`)
     expect(out).toContain(`h("li", {}, x)`)
@@ -205,7 +263,9 @@ describe(".value.map(arrow → JSX) → list(...) rewrite", () => {
     // `.value.map(SomeFn)` — argument is an identifier, not an arrow.
     // Conservative: the rewrite only fires when the body is unambiguously JSX.
     // The outer `.value` still gets the normal `h.read` rewrite + h.track wrap.
-    const out = compile(`const x = <ul>{coll.value.map(SomeRow)}</ul>`)
+    const out = compile(`
+      const x = <ul>{coll.value.map(SomeRow)}</ul>
+    `)
     expect(out).not.toContain(`list(`)
     expect(out).toContain(`h.read(coll)`)
     expect(out).toContain(`h.track(() =>`)
@@ -218,7 +278,9 @@ describe(".value.map(arrow → JSX) → list(...) rewrite", () => {
     // outer `.value` falls back to h.read; the whole expression wraps in
     // h.track because that read happened.
     const out = compile(
-      `const x = <ul>{outer.value.map((group) => group.items.value.map((item) => <li>{item}</li>))}</ul>`,
+      `
+      const x = <ul>{outer.value.map((group) => group.items.value.map((item) => <li>{item}</li>))}</ul>
+    `,
     )
     expect(out).toContain(`h.read(outer)`)
     expect(out).toContain(`list(group.items,`)
@@ -235,7 +297,9 @@ describe(".value.map(arrow → JSX) → list(...) rewrite", () => {
     // list(...) in a redundant h.track and (b) strand the inner h.read
     // outside any active tracking scope.
     const out = compile(
-      `const x = <ul>{coll.value.map((item) => <Row badge={ref.value} />)}</ul>`,
+      `
+      const x = <ul>{coll.value.map((item) => <Row badge={ref.value} />)}</ul>
+    `,
     )
     // The list(...) call is NOT wrapped in h.track.
     expect(out).not.toMatch(/h\.track\(\(\)\s*=>\s*list\(/)
@@ -249,13 +313,17 @@ describe("Await calls are not h.track-wrapped", () => {
   // tracker), so wrapping it in h.track is redundant AND erases its channels
   // (h.track returns `unknown`). The `.value`→h.read rewrite inside is kept.
   it("leaves a `.value`-reading Await(...) bare, keeping h.read", () => {
-    const out = compile(`const x = <div>{Await(() => client.get(id.value), { onSuccess: (v) => <span>{v}</span> })}</div>`)
+    const out = compile(`
+      const x = <div>{Await(() => client.get(id.value), { onSuccess: (v) => <span>{v}</span> })}</div>
+    `)
     expect(out).toContain(`h.read(id)`)        // dep rewrite kept (Await needs it)
     expect(out).not.toMatch(/h\.track\(\(\)\s*=>\s*Await\(/) // not wrapped
   })
 
   it("does not introduce h.track when Await is the only `.value` reader", () => {
-    const out = compile(`const x = <div>{Await(() => client.get(id.value), { onSuccess: (v) => <span>{v}</span> })}</div>`)
+    const out = compile(`
+      const x = <div>{Await(() => client.get(id.value), { onSuccess: (v) => <span>{v}</span> })}</div>
+    `)
     expect(out).not.toContain(`h.track`)
   })
 })
@@ -279,46 +347,64 @@ describe("whole-body `.value` reads (tracking outside JSX)", () => {
   })
 
   it("rewrites a plain statement-level `.value` read", () => {
-    const out = compile(`const n = count.value + 1`)
+    const out = compile(`
+      const n = count.value + 1
+    `)
     expect(out).toContain(`h.read(count)`)
     expect(out).not.toContain(`h.track`)
   })
 
   it("rewrites `.value` inside a non-thunk function body", () => {
-    const out = compile(`function label() { return count.value }`)
+    const out = compile(`
+      function label() { return count.value }
+    `)
     expect(out).toContain(`h.read(count)`)
   })
 
   it("auto-imports `h` when the only rewrite is a body read (no JSX)", () => {
-    const out = compile(`const get = () => ref.value`)
+    const out = compile(`
+      const get = () => ref.value
+    `)
     expect(out).toContain(`h.read(ref)`)
     expect(out).toMatch(/import \{[^}]*\bh\b[^}]*\} from "@efx\/runtime"/)
   })
 
   it("leaves a body `.value` *write* bare (assignment + update)", () => {
-    const assign = compile(`const f = () => { ref.value = 1 }`)
+    const assign = compile(`
+      const f = () => { ref.value = 1 }
+    `)
     expect(assign).toContain(`ref.value = 1`)
     expect(assign).not.toContain(`h.read(ref)`)
 
-    const update = compile(`const f = () => { count.value++ }`)
+    const update = compile(`
+      const f = () => { count.value++ }
+    `)
     expect(update).toContain(`count.value++`)
     expect(update).not.toMatch(/h\.read\(count\)\+\+/)
   })
 
   it("leaves destructuring-assignment targets bare (array + object patterns)", () => {
-    const arr = compile(`const f = () => { [obj.value] = arr }`)
+    const arr = compile(`
+      const f = () => { [obj.value] = arr }
+    `)
     expect(arr).toContain(`[obj.value] = arr`)
     expect(arr).not.toContain(`h.read(obj)`)
 
-    const objPat = compile(`const f = () => { ({ x: obj.value } = o) }`)
+    const objPat = compile(`
+      const f = () => { ({ x: obj.value } = o) }
+    `)
     expect(objPat).toContain(`x: obj.value`)
     expect(objPat).not.toContain(`h.read(obj)`)
 
-    const dflt = compile(`const f = () => { [obj.value = 1] = arr }`)
+    const dflt = compile(`
+      const f = () => { [obj.value = 1] = arr }
+    `)
     expect(dflt).toContain(`obj.value = 1`)
     expect(dflt).not.toContain(`h.read(obj)`)
 
-    const rest = compile(`const f = () => { [...obj.value] = arr }`)
+    const rest = compile(`
+      const f = () => { [...obj.value] = arr }
+    `)
     expect(rest).toContain(`...obj.value`)
     expect(rest).not.toContain(`h.read(obj)`)
   })
@@ -326,22 +412,30 @@ describe("whole-body `.value` reads (tracking outside JSX)", () => {
   it("leaves a `for (obj.value of …)` target bare (and does not crash)", () => {
     // The unguarded form crashed Babel: ForOfStatement.left rejects a
     // CallExpression. Must stay bare.
-    const of = compile(`const f = () => { for (el.value of xs) {} }`)
+    const of = compile(`
+      const f = () => { for (el.value of xs) {} }
+    `)
     expect(of).toContain(`for (el.value of xs)`)
     expect(of).not.toContain(`h.read(el)`)
 
-    const inn = compile(`const f = () => { for (el.value in xs) {} }`)
+    const inn = compile(`
+      const f = () => { for (el.value in xs) {} }
+    `)
     expect(inn).toContain(`for (el.value in xs)`)
     expect(inn).not.toContain(`h.read(el)`)
   })
 
   it("still rewrites a `.value` READ on the for-of iterable (right side)", () => {
-    const out = compile(`const f = () => { for (const x of coll.value) {} }`)
+    const out = compile(`
+      const f = () => { for (const x of coll.value) {} }
+    `)
     expect(out).toContain(`for (const x of h.read(coll))`)
   })
 
   it("leaves `delete obj.value` bare", () => {
-    const out = compile(`const f = () => delete obj.value`)
+    const out = compile(`
+      const f = () => delete obj.value
+    `)
     expect(out).toContain(`delete obj.value`)
     expect(out).not.toContain(`h.read(obj)`)
   })
@@ -349,19 +443,29 @@ describe("whole-body `.value` reads (tracking outside JSX)", () => {
   it("rewrites reads that only LOOK write-adjacent (RHS, default value, unary)", () => {
     // x = obj.value (RHS), [a = obj.value] (pattern default), !obj.value (unary)
     // are all reads and must be rewritten.
-    expect(compile(`const f = () => { x = obj.value }`)).toContain(`h.read(obj)`)
-    expect(compile(`const f = () => { [a = obj.value] = arr }`)).toContain(`h.read(obj)`)
-    expect(compile(`const f = () => !obj.value`)).toContain(`!h.read(obj)`)
+    expect(compile(`
+      const f = () => { x = obj.value }
+    `)).toContain(`h.read(obj)`)
+    expect(compile(`
+      const f = () => { [a = obj.value] = arr }
+    `)).toContain(`h.read(obj)`)
+    expect(compile(`
+      const f = () => !obj.value
+    `)).toContain(`!h.read(obj)`)
   })
 
   it("leaves optional-chained `obj?.value` alone (different node type)", () => {
-    const out = compile(`const v = maybe?.value`)
+    const out = compile(`
+      const v = maybe?.value
+    `)
     expect(out).toContain(`maybe?.value`)
     expect(out).not.toContain(`h.read(maybe)`)
   })
 
   it("does NOT double-rewrite JSX `.value` reads (no h.read(h.read(...)))", () => {
-    const out = compile(`const x = <div>{ref.value}</div>`)
+    const out = compile(`
+      const x = <div>{ref.value}</div>
+    `)
     expect(out).toContain(`h.read(ref)`)
     expect(out).not.toContain(`h.read(h.read`)
   })
@@ -378,7 +482,9 @@ describe("whole-body `.value` reads (tracking outside JSX)", () => {
   })
 
   it("does NOT rewrite a non-`value` property read", () => {
-    const out = compile(`const u = props.userId`)
+    const out = compile(`
+      const u = props.userId
+    `)
     expect(out).not.toContain(`h.read`)
     expect(out).not.toContain(`@efx/runtime`)
   })
@@ -386,12 +492,16 @@ describe("whole-body `.value` reads (tracking outside JSX)", () => {
 
 describe("runtime auto-imports", () => {
   it("adds `import { h } from \"@efx/runtime\"` when JSX is present", () => {
-    const out = compile(`const x = <div />`)
+    const out = compile(`
+      const x = <div />
+    `)
     expect(out).toContain(`import { h } from "@efx/runtime"`)
   })
 
   it("adds `Fragment` too when <>...</> is used", () => {
-    const out = compile(`const x = <><span /></>`)
+    const out = compile(`
+      const x = <><span /></>
+    `)
     expect(out).toMatch(/import \{[^}]*Fragment[^}]*\} from "@efx\/runtime"/)
     expect(out).toMatch(/import \{[^}]*h[^}]*\} from "@efx\/runtime"/)
   })
@@ -417,7 +527,9 @@ describe("runtime auto-imports", () => {
   })
 
   it("does NOT add runtime import when there's no JSX", () => {
-    const out = compile(`const x = 1; const y = 2;`)
+    const out = compile(`
+      const x = 1; const y = 2;
+    `)
     expect(out).not.toContain(`@efx/runtime`)
   })
 
@@ -441,7 +553,9 @@ describe("jsxRanges output", () => {
   }
 
   it("single element records its full span and tag name positions", () => {
-    const src = `const x = <div>hi</div>`
+    const src = `
+      const x = <div>hi</div>
+    `
     const r = firstElement(src)
     expect(src.slice(r.start, r.end)).toBe(`<div>hi</div>`)
     expect(src.slice(r.openingTag.start, r.openingTag.end)).toBe(`<div>`)
@@ -454,7 +568,9 @@ describe("jsxRanges output", () => {
   })
 
   it("self-closing element has no closingTag and isSelfClosing=true", () => {
-    const src = `const x = <Foo bar={1} />`
+    const src = `
+      const x = <Foo bar={1} />
+    `
     const r = firstElement(src)
     expect(r.isSelfClosing).toBe(true)
     expect(r.closingTag).toBeUndefined()
@@ -462,7 +578,9 @@ describe("jsxRanges output", () => {
   })
 
   it("fragment records both <> and </> tag positions, no names", () => {
-    const src = `const x = <><span /></>`
+    const src = `
+      const x = <><span /></>
+    `
     const frag = ranges(src).find((r) => r.kind === "fragment")
     if (!frag || frag.kind !== "fragment") throw new Error("expected fragment")
     expect(src.slice(frag.openingTag.start, frag.openingTag.end)).toBe(`<>`)
@@ -470,7 +588,9 @@ describe("jsxRanges output", () => {
   })
 
   it("nested elements emit parent before children in source order", () => {
-    const src = `const x = <div><span>a</span></div>`
+    const src = `
+      const x = <div><span>a</span></div>
+    `
     const rs = ranges(src)
     expect(rs.length).toBe(2)
     const [outer, inner] = rs
@@ -482,17 +602,23 @@ describe("jsxRanges output", () => {
   })
 
   it("dotted member tag name covers the full Foo.Bar span", () => {
-    const src = `const x = <Foo.Bar />`
+    const src = `
+      const x = <Foo.Bar />
+    `
     const r = firstElement(src)
     expect(src.slice(r.openingTag.nameStart, r.openingTag.nameEnd)).toBe(`Foo.Bar`)
   })
 
   it("ranges are empty when there's no JSX", () => {
-    expect(ranges(`const x = 1`)).toEqual([])
+    expect(ranges(`
+      const x = 1
+    `)).toEqual([])
   })
 
   it("ternary branches both produce ranges", () => {
-    const src = `const x = <div>{cond ? <a /> : <b />}</div>`
+    const src = `
+      const x = <div>{cond ? <a /> : <b />}</div>
+    `
     const tags = ranges(src)
       .filter((r) => r.kind === "element")
       .map((r) => src.slice(r.openingTag.nameStart, r.openingTag.nameEnd))
@@ -504,22 +630,30 @@ describe("jsxRanges output", () => {
 
 describe("TypeScript syntax survives", () => {
   it("type annotations are preserved", () => {
-    expect(compile(`const greet = (name: string) => <p>hi {name}</p>`))
+    expect(compile(`
+      const greet = (name: string) => <p>hi {name}</p>
+    `))
       .toContain(`name: string`)
   })
 
   it("generator functions are preserved", () => {
-    expect(compile(`const f = function* () { return <div /> }`))
+    expect(compile(`
+      const f = function* () { return <div /> }
+    `))
       .toContain(`function* ()`)
   })
 
   it("`yield*` survives the rewrite", () => {
-    expect(compile(`const f = function* () { yield* effect; return <div /> }`))
+    expect(compile(`
+      const f = function* () { yield* effect; return <div /> }
+    `))
       .toContain(`yield* effect`)
   })
 
   it("type parameters on functions survive", () => {
-    expect(compile(`const id = <T,>(x: T): T => { return (<p>{x}</p> as any) as T }`))
+    expect(compile(`
+      const id = <T,>(x: T): T => { return (<p>{x}</p> as any) as T }
+    `))
       .toMatch(/<T(,)?>/)
   })
 })

--- a/packages/compiler/src/transform.test.ts
+++ b/packages/compiler/src/transform.test.ts
@@ -397,13 +397,19 @@ describe("runtime auto-imports", () => {
   })
 
   it("does NOT inject if `h` is already imported under its own name", () => {
-    const src = `import { h } from "@efx/runtime"\nconst x = <div />`
+    const src = `
+      import { h } from "@efx/runtime"
+      const x = <div />
+    `
     const matches = compile(src).match(/import \{[^}]*\bh\b[^}]*\} from "@efx\/runtime"/g)
     expect(matches?.length).toBe(1)
   })
 
   it("extends an existing @efx/runtime import instead of adding a new one", () => {
-    const src = `import { mount } from "@efx/runtime"\nconst x = <div />`
+    const src = `
+      import { mount } from "@efx/runtime"
+      const x = <div />
+    `
     const out = compile(src)
     expect(out).toMatch(/import \{[^}]*mount[^}]*h[^}]*\} from "@efx\/runtime"/)
     const importLines = out.split(";").filter((s) => s.includes(`from "@efx/runtime"`))
@@ -416,7 +422,10 @@ describe("runtime auto-imports", () => {
   })
 
   it("preserves unrelated imports verbatim", () => {
-    const out = compile(`import { Effect } from "effect"\nconst x = <div />`)
+    const out = compile(`
+      import { Effect } from "effect"
+      const x = <div />
+    `)
     expect(out).toContain(`import { Effect } from "effect"`)
   })
 })

--- a/packages/language/src/source-map.test.ts
+++ b/packages/language/src/source-map.test.ts
@@ -28,7 +28,9 @@ const findBySourceOffset = (
 
 describe("convertSourceMap — span lengths", () => {
   it("every mapping carries both source and generated lengths", () => {
-    const src = `const x = <div class="page">hi</div>`
+    const src = `
+      const x = <div class="page">hi</div>
+    `
     const { mappings } = buildMappings(src)
     expect(mappings.length).toBeGreaterThan(0)
     for (const m of mappings) {
@@ -44,7 +46,9 @@ describe("convertSourceMap — span lengths", () => {
     // (function-call paren + arrow paren) has 2 source chars but only 1
     // generated char. Without distinct generatedLengths, Volar over-claims
     // generated territory and inlay-hint positions drift one column left.
-    const src = `const f = () => count.update((n) => n + 1)`
+    const src = `
+      const f = () => count.update((n) => n + 1)
+    `
     const { code, mappings } = buildMappings(src)
     // Sanity: Babel actually does strip the paren
     expect(code).toContain("count.update(n => n + 1)")
@@ -65,9 +69,11 @@ describe("convertSourceMap — span lengths", () => {
     // copies the source loc of the original MemberExpression onto the emitted
     // CallExpression — so the mapping at the start of `x` covers source span
     // for the original read, generated span for the `h.read(...)` call.
-    const src = `import { AtomRef } from "effect/unstable/reactivity"
-const x = AtomRef.make(0)
-const view = <div>{x.value}</div>`
+    const src = `
+      import { AtomRef } from "effect/unstable/reactivity"
+      const x = AtomRef.make(0)
+      const view = <div>{x.value}</div>
+    `
     const { code, mappings } = buildMappings(src)
     expect(code).toContain("h.read(x)")
     // The source `x.value` is at known position; assert SOMETHING maps to the
@@ -92,9 +98,11 @@ const view = <div>{x.value}</div>`
     // call. Source `coll.value.map(` (15 chars) becomes generated `list(coll,`
     // (10 chars) — a region where source length > generated length, mirror of
     // the .value → h.read case where generated is wider.
-    const src = `import { AtomRef } from "effect/unstable/reactivity"
-const coll = AtomRef.collection<number>([])
-const view = <ul>{coll.value.map((item) => <li>{item}</li>)}</ul>`
+    const src = `
+      import { AtomRef } from "effect/unstable/reactivity"
+      const coll = AtomRef.collection<number>([])
+      const view = <ul>{coll.value.map((item) => <li>{item}</li>)}</ul>
+    `
     const { code, mappings } = buildMappings(src)
     expect(code).toContain("list(coll,")
     // At least one mapping must bridge the source `coll.value.map(` region to
@@ -129,9 +137,11 @@ const view = <ul>{coll.value.map((item) => <li>{item}</li>)}</ul>`
     // `<Row>` to `h(Row, ...)`. The Row tag's nameStart in source must keep
     // a mapping that lands inside the generated `h(Row,` so editor
     // go-to-definition on Row inside the list arrow still resolves.
-    const src = `const Row = (props: { item: number }) => null
-const coll = { value: [] as number[] }
-const view = <ul>{coll.value.map((item) => <Row item={item} />)}</ul>`
+    const src = `
+      const Row = (props: { item: number }) => null
+      const coll = { value: [] as number[] }
+      const view = <ul>{coll.value.map((item) => <Row item={item} />)}</ul>
+    `
     const { code, mappings } = buildMappings(src)
     expect(code).toContain("list(coll,")
     expect(code).toContain("h(Row,")
@@ -152,9 +162,11 @@ const view = <ul>{coll.value.map((item) => <Row item={item} />)}</ul>`
     // When something inside a JSX expression got rewritten, the whole expression
     // wraps in `h.track(() => ...)`. The source expression range and the
     // generated wrapped range have different lengths.
-    const src = `import { AtomRef } from "effect/unstable/reactivity"
-const x = AtomRef.make(0)
-const view = <div>{x.value + 1}</div>`
+    const src = `
+      import { AtomRef } from "effect/unstable/reactivity"
+      const x = AtomRef.make(0)
+      const view = <div>{x.value + 1}</div>
+    `
     const { code, mappings } = buildMappings(src)
     expect(code).toContain("h.track(")
     // The wrap region exists; we just verify the mapping array is well-formed
@@ -171,7 +183,9 @@ const view = <div>{x.value + 1}</div>`
   })
 
   it("intrinsic tag span: source `<div>` (5 chars) ≠ generated `h(\"div\",` (8 chars)", () => {
-    const src = `const x = <div>hi</div>`
+    const src = `
+      const x = <div>hi</div>
+    `
     const { code, mappings } = buildMappings(src)
     expect(code).toContain('h("div"')
     // Some mapping in the tag region should reflect the asymmetry. Find a
@@ -192,7 +206,9 @@ const view = <div>{x.value + 1}</div>`
 
 describe("convertSourceMap — structural cases", () => {
   it("spread attribute: source `{...props}` maps into the h() call", () => {
-    const src = `const x = <div {...props}>hi</div>`
+    const src = `
+      const x = <div {...props}>hi</div>
+    `
     const { code, mappings } = buildMappings(src)
     expect(code).toMatch(/h\("div",\s*\{\s*\.\.\.props\s*\}/)
     const spreadSrc = src.indexOf("{...props}")
@@ -206,11 +222,13 @@ describe("convertSourceMap — structural cases", () => {
   })
 
   it("multi-line JSX: mappings span line boundaries cleanly", () => {
-    const src = `const view = (
-  <div>
-    <span>hi</span>
-  </div>
-)`
+    const src = `
+      const view = (
+        <div>
+          <span>hi</span>
+        </div>
+      )
+    `
     const { code, mappings } = buildMappings(src)
     expect(code).toContain('h("div"')
     expect(code).toContain('h("span"')
@@ -229,7 +247,9 @@ describe("convertSourceMap — structural cases", () => {
   })
 
   it("fragment <>...</>: mappings exist for the fragment tags", () => {
-    const src = `const view = <>hello</>`
+    const src = `
+      const view = <>hello</>
+    `
     const { code, mappings } = buildMappings(src)
     expect(code).toContain("Fragment")
     // The opening `<>` is at the start.
@@ -238,8 +258,10 @@ describe("convertSourceMap — structural cases", () => {
   })
 
   it("member-expression tag: <X.Y>...</X.Y> emits h(X.Y, ...)", () => {
-    const src = `import * as M from "./mod"
-const view = <M.X />`
+    const src = `
+      import * as M from "./mod"
+      const view = <M.X />
+    `
     const { code, mappings } = buildMappings(src)
     expect(code).toContain("h(M.X")
     // The `M.X` source identifiers map into the h(M.X, ...) call.
@@ -250,7 +272,9 @@ const view = <M.X />`
   it("auto-injected import line has no overlap with user code mappings", () => {
     // The compiler injects `import { h } from "@efx/runtime"` for files using JSX.
     // That insertion shouldn't claim source territory that belongs to user code.
-    const src = `const view = <div>hi</div>`
+    const src = `
+      const view = <div>hi</div>
+    `
     const { code, mappings } = buildMappings(src)
     expect(code).toContain('import { h }')
     // Find user-code source positions: every char in `src`. Each should be
@@ -264,8 +288,10 @@ const view = <M.X />`
   })
 
   it("no JSX in file: mappings still produced from passthrough source map", () => {
-    const src = `export const x = 42
-export const y = "hello"`
+    const src = `
+      export const x = 42
+      export const y = "hello"
+    `
     const { code, mappings } = buildMappings(src)
     // With no JSX, the compiler doesn't inject anything; code is mostly source.
     expect(code).toContain("export const x = 42")
@@ -278,7 +304,9 @@ export const y = "hello"`
 
 describe("convertSourceMap — CodeInformation profiles", () => {
   it("JSX angle brackets get the structural-only profile (no navigation)", () => {
-    const src = `const x = <div>hi</div>`
+    const src = `
+      const x = <div>hi</div>
+    `
     const { mappings } = buildMappings(src)
     // Find the mapping for `<` (the opening angle bracket).
     const ltSrc = src.indexOf("<div")
@@ -290,8 +318,10 @@ describe("convertSourceMap — CodeInformation profiles", () => {
   })
 
   it("normal source code outside JSX gets the full profile", () => {
-    const src = `const x = 1
-const view = <div>hi</div>`
+    const src = `
+      const x = 1
+      const view = <div>hi</div>
+    `
     const { mappings } = buildMappings(src)
     // The `const` keyword on line 1 is outside any JSX node.
     const constSrc = src.indexOf("const x")

--- a/packages/vite-plugin/src/index.test.ts
+++ b/packages/vite-plugin/src/index.test.ts
@@ -15,7 +15,9 @@ const runTransform = (code: string, id: string) => {
 
 describe("efx() transform", () => {
   it("rewrites JSX to h() calls and emits plain JavaScript", async () => {
-    const out = await runTransform(`const v = <div class="x">{1}</div>`, "/abs/Test.efx")
+    const out = await runTransform(`
+      const v = <div class="x">{1}</div>
+    `, "/abs/Test.efx")
     expect(out).not.toBeNull()
     expect(out!.code).toContain('h("div"')
     expect(out!.code).not.toContain("<div") // JSX is gone
@@ -25,29 +27,35 @@ describe("efx() transform", () => {
   it("strips TypeScript types (Oxc step ran)", async () => {
     const out = await runTransform(
       `
-        const n: number = 1
-        const v = <div>{n}</div>
-      `,
+      const n: number = 1
+      const v = <div>{n}</div>
+    `,
       "/abs/Typed.efx",
     )
     expect(out!.code).not.toContain(": number")
   })
 
   it("returns a source map whose sources point at the original .efx", async () => {
-    const out = await runTransform(`const v = <div>{1}</div>`, "/abs/Counter.efx")
+    const out = await runTransform(`
+      const v = <div>{1}</div>
+    `, "/abs/Counter.efx")
     expect(out!.map).toBeTruthy()
     expect(JSON.stringify(out!.map!.sources)).toContain("Counter.efx")
   })
 
   it("ignores non-.efx ids", async () => {
-    const out = await runTransform(`const x = 1`, "/abs/plain.ts")
+    const out = await runTransform(`
+      const x = 1
+    `, "/abs/plain.ts")
     expect(out).toBeNull()
   })
 
   it("fails loudly on a real syntax error (errorRecovery: false)", async () => {
     // Build path must not silently ship a recovered/garbage module.
     await expect(
-      runTransform(`const v = <div>{`, "/abs/Broken.efx"),
+      runTransform(`
+        const v = <div>{
+      `, "/abs/Broken.efx"),
     ).rejects.toBeTruthy()
   })
 })

--- a/packages/vite-plugin/src/index.test.ts
+++ b/packages/vite-plugin/src/index.test.ts
@@ -24,7 +24,10 @@ describe("efx() transform", () => {
 
   it("strips TypeScript types (Oxc step ran)", async () => {
     const out = await runTransform(
-      `const n: number = 1\nconst v = <div>{n}</div>`,
+      `
+        const n: number = 1
+        const v = <div>{n}</div>
+      `,
       "/abs/Typed.efx",
     )
     expect(out!.code).not.toContain(": number")


### PR DESCRIPTION
Stacks on #45.

Readability follow-up: format **all source-code fixtures** in tests as multi-line block template literals — including single-statement ones — so a fixture reads as a distinct code block, not inline string soup:

```ts
// before
const out = compile(`const x = <div>hi</div>`)

// after
const out = compile(`
  const x = <div>hi</div>
`)
```

**75 fixtures** converted across `transform.test.ts`, both `source-map.test.ts` files, and `vite-plugin/index.test.ts`.

Safe because the consuming helpers are either output-normalizing (`compile` does `.replace(/\s+/g," ").trim()`; vite-plugin asserts on emitted code) or offset-**relative** (the source-map tests locate spans via `src.indexOf(...)`/`src.slice(...)` and assert relative span lengths/kinds), so the added indentation shifts positions consistently and changes nothing under test.

### Deliberately left as `\n`-escapes
- The `obj.\n\nreturn` **error-recovery fixtures** — the exact byte sequence (dot, blank line, keyword) is precisely what's under test.
- **ts-plugin `classify-references`** multi-file content fixtures — byte offsets and trailing newlines are load-bearing.

### Verification
- `pnpm -r test` → EXIT 0 (compiler 77, runtime 44, language 15, vite-plugin 5, testing 10, ts-plugin 31)
- `pnpm -r typecheck` → EXIT 0

> Base is `feat/track-value-in-statements` (#45). Merge/rebase #45 first; this PR then retargets to `main`.