### PR TITLE
fix(compiler): collapse intra-text JSX newlines to a single space

### DIFF
--- a/packages/compiler/AGENTS.md
+++ b/packages/compiler/AGENTS.md
@@ -182,11 +182,24 @@ identifier (no alias) are skipped to avoid duplicates.
 
 ## JSX text whitespace
 
-`transformChild` collapses newlines-surrounded whitespace via
-`replace(/\s*\n\s*/g, "")`. Pure-whitespace nodes drop. Internal
-spaces inside non-newline text are preserved. This matches React's
-JSX whitespace rules closely enough for the cases the demo
-exercises — diverge with care.
+`transformChild` runs JSX text through `cleanJsxText`, a faithful port
+of Babel's `cleanJSXElementLiteralChild`: tabs → spaces, leading spaces
+trimmed on every line but the first, trailing spaces on every line but
+the last, blank lines dropped, surviving lines joined with a single
+space. Pure-whitespace nodes drop.
+
+The subtlety that bit us: a newline *between two words* must collapse to
+one space, not to nothing — otherwise multi-line prose renders
+`whosepoint`. The earlier `replace(/\s*\n\s*/g, "")` deleted that space;
+the port restores it. Whitespace adjacent to an element/expression
+boundary still trims to nothing, so — exactly as in React — a tag on its
+own line concatenates with neighbouring text unless the source adds an
+explicit `{" "}`.
+
+(Watch the JSDoc on `cleanJsxText`: don't write the literal
+newline-stripping regex inside a block comment — the `*` `/` it contains
+closes the comment early. The function comment spells the rule out in
+prose for that reason.)
 
 ## Babel ESM gotcha
 

--- a/packages/compiler/src/transform.test.ts
+++ b/packages/compiler/src/transform.test.ts
@@ -695,3 +695,41 @@ describe("parse-error tolerance (mid-edit source)", () => {
     expect(() => transformEfx(src, "test.efx")).not.toThrow()
   })
 })
+
+describe("JSX text whitespace (cleanJSXElementLiteralChild parity)", () => {
+  it("collapses a newline between two words to a single space", () => {
+    const src = `const x = <p>a framework whose
+      point is honesty</p>`
+    expect(compile(src)).toContain(`"a framework whose point is honesty"`)
+  })
+
+  it("preserves internal spaces in single-line text", () => {
+    expect(compile(`const x = <span> clicks: </span>`))
+      .toContain(`h("span", {}, " clicks: ")`)
+  })
+
+  it("drops pure-whitespace / blank-line nodes", () => {
+    const src = `const x = <div>
+
+      hi
+
+    </div>`
+    expect(compile(src)).toContain(`h("div", {}, "hi")`)
+  })
+
+  it("trims whitespace adjacent to an element boundary (React parity: a tag on its own line concatenates)", () => {
+    const src = `const x = <p>paired
+      <code>unmount</code></p>`
+    // "paired" carries no trailing space — the source must add {" "} for one,
+    // exactly as in React.
+    expect(compile(src)).toContain(`"paired"`)
+    expect(compile(src)).not.toContain(`"paired "`)
+  })
+
+  it("keeps an explicit {\" \"} spacer between text and an element", () => {
+    const src = `const x = <p>use a{" "}
+      <code>.efx</code> file</p>`
+    expect(compile(src)).toContain(`"use a"`)
+    expect(compile(src)).toContain(`" "`)
+  })
+})

--- a/packages/compiler/src/transform.ts
+++ b/packages/compiler/src/transform.ts
@@ -375,16 +375,42 @@ const jsxMemberToMember = (m: t.JSXMemberExpression): t.MemberExpression => {
   return copyLoc(t.memberExpression(object, property), m)
 }
 
+/**
+ * Collapse JSX text whitespace per the JSX spec — a faithful port of Babel's
+ * `cleanJSXElementLiteralChild`. Tabs become spaces; leading spaces are trimmed
+ * on every line but the first, trailing spaces on every line but the last;
+ * blank lines drop; surviving lines join with a single space.
+ *
+ * The load-bearing difference from the old newline-stripping regex: a newline
+ * between two words collapses to one space, not to nothing — so multi-line prose
+ * reads "whose point" instead of "whosepoint". Whitespace adjacent to an
+ * element/expression boundary still trims to nothing, so (exactly as in React)
+ * a tag on its own line concatenates unless the source adds an explicit space.
+ */
+const cleanJsxText = (value: string): string => {
+  const lines = value.split(/\r\n|\n|\r/)
+  let lastNonEmpty = 0
+  for (let i = 0; i < lines.length; i++) {
+    if (/[^ \t]/.test(lines[i]!)) lastNonEmpty = i
+  }
+  let out = ""
+  for (let i = 0; i < lines.length; i++) {
+    let line = lines[i]!.replace(/\t/g, " ")
+    if (i !== 0) line = line.replace(/^ +/, "")
+    if (i !== lines.length - 1) line = line.replace(/ +$/, "")
+    if (line === "") continue
+    out += i !== lastNonEmpty ? line + " " : line
+  }
+  return out
+}
+
 /** Transform a single JSX child node into an expression. */
 const transformChild = (
   child: t.JSXElement["children"][number],
   state: RewriteState,
 ): t.Expression | null => {
   if (t.isJSXText(child)) {
-    // Collapse JSX whitespace per JSX spec: trim trailing newlines, keep
-    // internal whitespace, drop pure-whitespace nodes.
-    const text = child.value
-      .replace(/\s*\n\s*/g, "") // collapse newline-surrounded whitespace
+    const text = cleanJsxText(child.value)
     if (text === "") return null
     return t.stringLiteral(text)
   }


### PR DESCRIPTION
## Summary

JSX text whitespace was collapsed by deleting newline-surrounded whitespace outright (`replace(/\s*\n\s*/g, "")`). That deletes a newline *between two words*, so multi-line prose in a `.efx` file renders **`whosepoint`** instead of **`whose point`** — the angle-bracket form is fine on one line, but wraps lose the inter-word space.

The comment claimed "per JSX spec," but it wasn't. This replaces it with `cleanJsxText`, a faithful port of Babel's `cleanJSXElementLiteralChild`:

- tabs → spaces
- trim leading spaces on every line but the first
- trim trailing spaces on every line but the last
- drop blank lines
- join surviving lines with a **single space**

The load-bearing change: a newline between two words now collapses to one space, not to nothing. Whitespace adjacent to an element/expression boundary still trims to nothing, so — exactly as in React — a tag on its own line concatenates with neighbouring text unless the source adds an explicit `{" "}`. That keeps the existing single-line behavior (`<span> clicks: {count} </span>` → `" clicks: "`) byte-for-byte identical.

## Test plan

- [x] `pnpm --filter @efx/compiler test` — **82 pass** (+5 new): newline→space, single-line spaces preserved, blank-line drop, element-boundary trim (React parity), explicit `{" "}` spacer.
- [x] `pnpm -r test` — all suites green (runtime 44, language 15, vite-plugin 5, testing 10, ts-plugin 31 + integration, check OK). No snapshot/offset regressions.
- [x] `pnpm -r typecheck` — every package clean.

## Notes

- New helper lives next to `transformChild` in `transform.ts`; `AGENTS.md` "JSX text whitespace" section rewritten to describe the real rule.
- Footgun documented in the AGENTS note: don't write the literal newline-stripping regex inside a `/** */` block comment — the `*` `/` it contains closes the comment early (it bit me once). The function's docstring spells the rule out in prose for that reason.
- Demo improvements that surfaced this bug are intentionally **not** in this PR — they'll land separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)