### PR TITLE
feat(demo): guided tour — highlighted source, inferred types, reactivity flash

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# GitHub / Linguist: highlight .efx files as TSX.
+#
+# .efx is TypeScript that borrows JSX's angle-bracket syntax — the compiler
+# rewrites every <tag/> to an h() call before tsc ever sees the file (see
+# CLAUDE.md). The TSX TextMate grammar is the correct highlighter and matches
+# the editor's `typescriptreact` filetype mapping. This override also makes
+# .efx files count toward the repo's language stats instead of going
+# undetected.
+*.efx linguist-language=TSX

--- a/apps/demo/index.html
+++ b/apps/demo/index.html
@@ -3,38 +3,174 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>efx demo</title>
+    <title>efx — a guided tour</title>
     <style>
-      :root { color-scheme: dark; }
+      :root {
+        color-scheme: dark;
+        --bg: #0d0f12;
+        --panel: #14171c;
+        --border: #262b33;
+        --text: #e6e8eb;
+        --muted: #8a93a0;
+        --accent: #7ee0c0;
+        --accent-dim: #4fa98f;
+        --code-bg: #0a0c0f;
+      }
+      * { box-sizing: border-box; }
       body {
         font-family: ui-sans-serif, system-ui, sans-serif;
-        background: #111;
-        color: #eee;
+        background: var(--bg);
+        color: var(--text);
         margin: 0;
-        padding: 2rem;
-        max-width: 720px;
+        padding: 2.5rem 1.5rem 4rem;
+        max-width: 1040px;
         margin-inline: auto;
-        line-height: 1.5;
+        line-height: 1.6;
       }
-      h1 { font-size: 1.5rem; }
-      h2 { font-size: 1rem; color: #888; text-transform: uppercase; letter-spacing: 0.05em; margin-top: 2rem; }
-      .section { border: 1px solid #333; padding: 1rem 1.25rem; border-radius: 8px; margin-block: 1rem; }
-      .counter button { background: #222; color: #eee; border: 1px solid #444; padding: 0.25rem 0.75rem; border-radius: 4px; cursor: pointer; }
-      .counter button:hover { background: #2a2a2a; }
-      .counter .count { font-variant-numeric: tabular-nums; }
-      .user-page h1 { font-size: 1.25rem; margin: 0 0 0.5rem; }
-      .user-page .bio { color: #aaa; font-style: italic; }
-      .user-page .posts { padding-inline-start: 1rem; }
-      .user-page .empty { color: #888; }
-      .todos ul { list-style: none; padding: 0; margin: 0.5rem 0; }
+      a { color: var(--accent); text-decoration: none; }
+      a:hover { text-decoration: underline; }
+      code {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 0.85em;
+        background: var(--code-bg);
+        border: 1px solid var(--border);
+        padding: 0.05em 0.35em;
+        border-radius: 4px;
+        color: var(--accent);
+      }
+      pre code { border: none; padding: 0; background: none; }
+
+      /* ─── Hero ─────────────────────────────────────────────── */
+      .hero { margin-bottom: 3rem; }
+      .eyebrow {
+        text-transform: uppercase; letter-spacing: 0.18em;
+        font-size: 0.72rem; color: var(--accent-dim); margin: 0 0 0.25rem;
+      }
+      .hero h1 { font-size: 3rem; margin: 0 0 0.5rem; letter-spacing: -0.02em; }
+      .tagline { font-size: 1.1rem; color: var(--text); max-width: 64ch; }
+      .tagline code { font-size: 0.9em; }
+      .how {
+        margin-top: 1.75rem; padding: 1.25rem 1.5rem;
+        background: var(--panel); border: 1px solid var(--border);
+        border-radius: 10px;
+      }
+      .how h3 {
+        margin: 0 0 0.5rem; font-size: 0.78rem; text-transform: uppercase;
+        letter-spacing: 0.08em; color: var(--muted);
+      }
+      .how p { margin: 0.5rem 0 0; font-size: 0.95rem; color: #c6cbd2; max-width: 72ch; }
+      .how-note { font-size: 0.88rem !important; color: var(--muted) !important; }
+
+      /* ─── Tour section: copy left, live demo right ─────────── */
+      .tour {
+        display: grid;
+        grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr);
+        gap: 1.5rem;
+        align-items: start;
+        padding: 1.75rem 0;
+        border-top: 1px solid var(--border);
+      }
+      @media (max-width: 820px) {
+        .tour { grid-template-columns: 1fr; gap: 1rem; }
+      }
+      .tour-head { display: flex; align-items: baseline; gap: 0.6rem; }
+      .step {
+        font-family: ui-monospace, monospace; font-size: 0.8rem;
+        color: var(--accent-dim); border: 1px solid var(--border);
+        border-radius: 5px; padding: 0.05rem 0.4rem;
+      }
+      .tour-copy h2 { font-size: 1.15rem; margin: 0; }
+      .concept { color: #c6cbd2; font-size: 0.95rem; margin: 0.6rem 0 1rem; }
+      .sig-label {
+        text-transform: uppercase; letter-spacing: 0.08em;
+        font-size: 0.66rem; color: var(--muted); margin: 0 0 0.25rem;
+      }
+      pre.sig, pre.code {
+        background: var(--code-bg); border: 1px solid var(--border);
+        border-radius: 8px; padding: 0.7rem 0.9rem; margin: 0 0 0.9rem;
+        overflow-x: auto;
+      }
+      pre.sig { margin-bottom: 1rem; }
+      pre.sig code {
+        color: var(--accent); font-size: 0.82rem; white-space: pre;
+      }
+      pre.code code {
+        color: #c5ccd6; font-size: 0.8rem; line-height: 1.55; white-space: pre;
+      }
+      /* Syntax tokens (from src/highlight.ts) */
+      .tok-com   { color: #5f6b7a; font-style: italic; }
+      .tok-str   { color: #9ece6a; }
+      .tok-kw    { color: #c792ea; }
+      .tok-num   { color: #f78c6c; }
+      .tok-type  { color: #82d2c4; }
+      .tok-fn    { color: #82aaff; }
+      .tok-tag   { color: #f07178; }
+      .tok-punct { color: #7f8c9a; }
+      .tok-plain { color: #c5ccd6; }
+
+      /* Fine-grained reactivity flash: src/flash.ts paints a transient overlay
+         rectangle over the exact node that re-rendered (DevTools-style). */
+      @keyframes efx-flash-overlay {
+        from {
+          background-color: rgba(126, 224, 192, 0.32);
+          box-shadow: 0 0 0 1px rgba(126, 224, 192, 0.6);
+        }
+        to {
+          background-color: rgba(126, 224, 192, 0);
+          box-shadow: 0 0 0 1px rgba(126, 224, 192, 0);
+        }
+      }
+      .src {
+        font-size: 0.82rem; color: var(--muted);
+      }
+      .src:hover { color: var(--accent); }
+
+      /* ─── Live demo panel ──────────────────────────────────── */
+      .tour-demo {
+        position: relative;
+        background: var(--panel); border: 1px solid var(--border);
+        border-radius: 10px; padding: 1.5rem 1.25rem 1.25rem;
+      }
+      .demo-label {
+        position: absolute; top: 0.6rem; right: 0.75rem;
+        font-size: 0.62rem; text-transform: uppercase; letter-spacing: 0.1em;
+        color: var(--accent-dim); border: 1px solid var(--accent-dim);
+        border-radius: 999px; padding: 0.05rem 0.5rem;
+      }
+
+      .site-footer {
+        margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid var(--border);
+        color: var(--muted); font-size: 0.9rem;
+      }
+
+      /* ─── Component styles ─────────────────────────────────── */
+      h3 { font-size: 0.95rem; margin: 0 0 0.5rem; }
+      .counter button, .controls button {
+        background: #1c2128; color: var(--text); border: 1px solid var(--border);
+        padding: 0.25rem 0.75rem; border-radius: 5px; cursor: pointer;
+      }
+      .counter button:hover, .controls button:hover { background: #232932; }
+      .counter .count, .remaining { font-variant-numeric: tabular-nums; }
+      .user-page h1, .user-body h1, .async-user-page h1 { font-size: 1.2rem; margin: 0 0 0.5rem; }
+      .user-page .bio, .user-body .bio, .user-card .bio { color: var(--muted); font-style: italic; }
+      .posts { padding-inline-start: 1rem; margin: 0.5rem 0 0; }
+      .empty { color: var(--muted); }
+      .loading { color: var(--muted); }
+      .error { color: #e08a8a; }
+      .user-card strong { font-size: 1.05rem; }
+      .live-user .controls { display: flex; gap: 0.5rem; margin: 0.5rem 0 1rem; flex-wrap: wrap; }
+      .todos ul, .lifecycle ul { list-style: none; padding: 0; margin: 0.75rem 0 0; }
       .todos li { display: flex; align-items: center; gap: 0.5rem; padding: 0.25rem 0; }
-      .todos li.done .text { color: #666; text-decoration: line-through; }
-      .todos li .toggle, .todos li .remove { background: transparent; color: #aaa; border: 1px solid #333; padding: 0 0.5rem; min-width: 1.5rem; border-radius: 4px; cursor: pointer; }
-      .todos li .toggle:hover, .todos li .remove:hover { background: #222; color: #eee; }
+      .todos li.done .text { color: var(--muted); text-decoration: line-through; }
+      .todos li .toggle, .todos li .remove {
+        background: transparent; color: var(--muted); border: 1px solid var(--border);
+        padding: 0 0.5rem; min-width: 1.6rem; border-radius: 5px; cursor: pointer;
+      }
+      .todos li .toggle:hover, .todos li .remove:hover { background: #1c2128; color: var(--text); }
       .todos li .text { flex: 1; }
-      .todos .controls { display: flex; gap: 1rem; align-items: center; }
-      .todos .controls button { background: #222; color: #eee; border: 1px solid #444; padding: 0.25rem 0.75rem; border-radius: 4px; cursor: pointer; }
-      .todos .remaining { color: #888; font-variant-numeric: tabular-nums; }
+      .todos .controls, .lifecycle .controls { display: flex; gap: 0.75rem; align-items: center; }
+      .lifecycle li { padding: 0.2rem 0; }
+      .lifecycle .hint { font-size: 0.82rem; color: var(--muted); margin-top: 0.75rem; }
     </style>
   </head>
   <body>

--- a/apps/demo/index.html
+++ b/apps/demo/index.html
@@ -127,16 +127,26 @@
 
       /* ─── Live demo panel ──────────────────────────────────── */
       .tour-demo {
-        position: relative;
         background: var(--panel); border: 1px solid var(--border);
-        border-radius: 10px; padding: 1.5rem 1.25rem 1.25rem;
+        border-radius: 10px; padding: 0.7rem 1.25rem 1.25rem;
+      }
+      .demo-bar {
+        display: flex; align-items: center; justify-content: space-between;
+        margin-bottom: 0.85rem; padding-bottom: 0.6rem;
+        border-bottom: 1px solid var(--border);
       }
       .demo-label {
-        position: absolute; top: 0.6rem; right: 0.75rem;
         font-size: 0.62rem; text-transform: uppercase; letter-spacing: 0.1em;
         color: var(--accent-dim); border: 1px solid var(--accent-dim);
         border-radius: 999px; padding: 0.05rem 0.5rem;
       }
+      .demo-refresh {
+        background: transparent; color: var(--muted); border: 1px solid var(--border);
+        border-radius: 5px; padding: 0.12rem 0.55rem; font-size: 0.72rem;
+        cursor: pointer; font-family: inherit;
+      }
+      .demo-refresh:hover { background: #1c2128; color: var(--accent); border-color: var(--accent-dim); }
+      .demo-refresh:active { transform: translateY(1px); }
 
       .site-footer {
         margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid var(--border);

--- a/apps/demo/src/AsyncUserPage.efx
+++ b/apps/demo/src/AsyncUserPage.efx
@@ -1,6 +1,6 @@
 import { Cause, Effect } from "effect"
 import { Await } from "@efx/runtime"
-import { Http, Theme } from "./services.ts"
+import { Http } from "./services.ts"
 
 /**
  * The `Await` boundary, once form — the non-blocking counterpart to
@@ -11,17 +11,22 @@ import { Http, Theme } from "./services.ts"
  * root. `AsyncUserPage` wraps the same fetch in `Await(() => http.getUser(id))`:
  * a pending placeholder shows immediately and failure is handled locally
  * (`onError`), so `E` is discharged to `never`. The thunk reads no reactive
- * refs, so it runs once. `Http`/`Theme` are extracted up front, so they fold
- * into `R` — a forgotten layer is still a compile error.
+ * refs, so it runs once. `Http` is extracted up front, so it folds into `R` —
+ * a forgotten layer is still a compile error. `Scope` is added by `Await`
+ * itself: it doesn't create a scope, it borrows the *enclosing* one (via
+ * `Effect.scope`) and forks the fetch into it with `Effect.forkScoped`, so the
+ * request is interrupted when that scope closes. The framework supplies the
+ * scope where the component is mounted — placed statically here, that's the
+ * root app scope; under a `Reactive`/`List` slot it's the per-slot scope, so
+ * the fetch is cancelled exactly on that element's unmount.
  *
- * Inferred type: `Effect<View, never, Http | Theme | Scope>`
+ * Inferred type: `Effect<View, never, Http | Scope>`
  */
 export const AsyncUserPage = Effect.fn("AsyncUserPage")(function* (props: { userId: string }) {
-  const theme = yield* Theme
   const http = yield* Http
 
   return yield* (
-    <article class={`async-user-page ${theme.mode}`}>
+    <article class="async-user-page">
       {Await(() => http.getUser(props.userId), {
         pending: <p class="loading">  loading user…</p>,
         onError: (cause) => <p class="error">error: {Cause.pretty(cause)}</p>,

--- a/apps/demo/src/Counter.efx
+++ b/apps/demo/src/Counter.efx
@@ -18,7 +18,6 @@ export const Counter = Effect.fn("Counter")(function* (_props: {} = {}) {
     <div class="counter">
       <button onclick={() => count.update((n) => n + 1)}>+</button>
       <span class="count"> clicks: {count} </span>
-      <button onclick={() => count.set(0)}>reset</button>
     </div>
   )
 })

--- a/apps/demo/src/Lifecycle.efx
+++ b/apps/demo/src/Lifecycle.efx
@@ -10,9 +10,6 @@ interface Item {
   readonly id: number
 }
 
-const items = AtomRef.collection<Item>([{ id: 1 }, { id: 2 }])
-let nextId = 3
-
 const Row = Effect.fn("Row")(function* (props: {
   readonly item: AtomRef.AtomRef<Item>
 }) {
@@ -30,13 +27,17 @@ const Row = Effect.fn("Row")(function* (props: {
   )
 })
 
-const addRow = () => items.push({ id: nextId++ })
-const removeLast = () => {
-  const current = items.value
-  if (current.length > 0) items.remove(current[current.length - 1]!)
-}
-
 export const Lifecycle = Effect.fn("Lifecycle")(function* (_props: {} = {}) {
+  // State lives in the component, so the demo's reset button recreates it back
+  // to two rows (the event log on `__lifecycle` is module-level and persists).
+  const items = AtomRef.collection<Item>([{ id: 1 }, { id: 2 }])
+  let nextId = 3
+  const addRow = () => items.push({ id: nextId++ })
+  const removeLast = () => {
+    const current = items.value
+    if (current.length > 0) items.remove(current[current.length - 1]!)
+  }
+
   return yield* (
     <div class="lifecycle">
       <h3>Per-component lifecycle (Effect.acquireRelease)</h3>

--- a/apps/demo/src/Lifecycle.efx
+++ b/apps/demo/src/Lifecycle.efx
@@ -48,7 +48,7 @@ export const Lifecycle = Effect.fn("Lifecycle")(function* (_props: {} = {}) {
         {items.value.map((item) => <Row item={item} />)}
       </ul>
       <p class="hint">
-        Open devtools and inspect <code>__lifecycle</code> — expect a paired
+        Open devtools and inspect <code>__lifecycle</code> — expect a paired{" "}
         <code>unmount:N</code> for every <code>mount:N</code> once that row is removed.
       </p>
     </div>

--- a/apps/demo/src/Todos.efx
+++ b/apps/demo/src/Todos.efx
@@ -6,28 +6,19 @@ interface Todo {
   readonly done: boolean
 }
 
-// Reactive collection — each item is wrapped in its own AtomRef so per-row
-// updates don't tear down the whole list.
-const todos = AtomRef.collection<Todo>([
-  { text: "build a UI framework", done: true },
-  { text: "use it for something", done: false },
-  { text: "write a blog post", done: false },
-])
-
-const addTodo = () => todos.push({ text: "new todo", done: false })
-
 /**
  * One row. Reads from a single item ref; toggling `done` updates only this
  * row, not the rest of the list (because the framework's reactive bindings
- * subscribe per-ref).
+ * subscribe per-ref). `remove` is passed in so the row needn't reach for the
+ * collection — that lives inside `Todos`.
  */
 const TodoRow = Effect.fn("TodoRow")(function* (props: {
   readonly item: AtomRef.AtomRef<Todo>
+  readonly remove: () => void
 }) {
   const ref = props.item
   const done = ref.map((t) => t.done)         // ReadonlyRef<boolean>
   const toggle = () => ref.update((t) => ({ ...t, done: !t.done }))
-  const remove = () => todos.remove(ref)
 
   // The compiler wraps every JSX expression in `h.track(() => …)` and
   // rewrites `.value` reads inside to `h.read(…)`, tracking AtomRef
@@ -39,23 +30,32 @@ const TodoRow = Effect.fn("TodoRow")(function* (props: {
         {done.value ? "✓" : "·"}
       </button>
       <span class="text">{ref.value.text}</span>
-      <button class="remove" onclick={remove}>×</button>
+      <button class="remove" onclick={props.remove}>×</button>
     </li>
   )
 })
 
-const remaining: AtomRef.ReadonlyRef<number> = todos.map((items) => {
-  let n = 0
-  for (const ref of items) if (!ref.value.done) n++
-  return n
-})
-
 /**
- * The list. `todos.value.map(item => <TodoRow />)` in JSX position is
- * compiled to a keyed `View.List` IR node; `mount` reconciles rows by ref
- * identity on add/remove.
+ * The list. State lives *inside* the component, so recreating it (the demo's
+ * reset button) starts from the initial todos again. `todos.value.map(item =>
+ * <TodoRow />)` in JSX position is compiled to a keyed `View.List` IR node;
+ * `mount` reconciles rows by ref identity on add/remove.
  */
 export const Todos = Effect.fn("Todos")(function* (_props: {} = {}) {
+  // Reactive collection — each item is wrapped in its own AtomRef so per-row
+  // updates don't tear down the whole list.
+  const todos = AtomRef.collection<Todo>([
+    { text: "build a UI framework", done: true },
+    { text: "use it for something", done: false },
+    { text: "write a blog post", done: false },
+  ])
+  const addTodo = () => todos.push({ text: "new todo", done: false })
+  const remaining: AtomRef.ReadonlyRef<number> = todos.map((items) => {
+    let n = 0
+    for (const ref of items) if (!ref.value.done) n++
+    return n
+  })
+
   return yield* (
     <div class="todos">
       <div class="controls">
@@ -65,7 +65,7 @@ export const Todos = Effect.fn("Todos")(function* (_props: {} = {}) {
         </span>
       </div>
       <ul>
-        {todos.value.map((item) => <TodoRow item={item} />)}
+        {todos.value.map((item) => <TodoRow item={item} remove={() => todos.remove(item)} />)}
       </ul>
     </div>
   )

--- a/apps/demo/src/channels.test-d.ts
+++ b/apps/demo/src/channels.test-d.ts
@@ -24,12 +24,12 @@ assertEquals<UserPageType, Effect.Effect<View, HttpError, Http | Theme>>()
 
 // ─── AsyncUserPage: the same fetch behind an `Await` boundary. The boundary
 //     handles failure locally (onError), so E is `never`; Http still folds
-//     (fetch on the mount fiber) and Theme is read in-component, plus Scope
-//     from the fork. Same data, opposite E — the boundary vs. fold-to-root
-//     contrast, both compile-time enforced.
+//     (fetch on the mount fiber), plus Scope from the fork (`forkScoped`).
+//     Same data, opposite E — the boundary vs. fold-to-root contrast, both
+//     compile-time enforced.
 
 type AsyncUserPageType = ReturnType<typeof AsyncUserPage>
-assertEquals<AsyncUserPageType, Effect.Effect<View, never, Http | Theme | Scope.Scope>>()
+assertEquals<AsyncUserPageType, Effect.Effect<View, never, Http | Scope.Scope>>()
 
 // ─── Counter is pure (no E or R from the component itself; AtomRegistry
 //     is added at mount) ──────────────────────────────────────────────────

--- a/apps/demo/src/flash.ts
+++ b/apps/demo/src/flash.ts
@@ -1,0 +1,88 @@
+/**
+ * Visualize fine-grained reactivity: when efx re-renders a node, briefly flash
+ * exactly that node — matching what Chrome DevTools' Elements panel highlights
+ * on a DOM change.
+ *
+ * Parity detail: DevTools targets the *precise* node, not a convenient parent.
+ * A reactive text swap (`{count}`) highlights only the text node, so updating
+ * `clicks: 0` flashes the `0`, not the whole `<span>`. A child removal
+ * highlights the container that lost the child. We can't style a text node with
+ * CSS, so — exactly like DevTools — we don't style the node at all: we measure
+ * its box and paint a transient overlay rectangle over it.
+ *
+ * This is pure demo sugar, framework-agnostic: a `MutationObserver` on the app
+ * root catches the same DOM ops efx performs (a `Reactive` node swap is a
+ * childList change; a reactive `class` binding is an attribute change; a list
+ * insert/remove adds/removes an element). Overlays are appended to `<body>`,
+ * outside the observed root, so they never feed back into the observer.
+ */
+
+const DURATION = 600 // ms, matches the efx-flash-overlay keyframe
+
+// The exact viewport-space box of a node, the way DevTools would outline it:
+//   - element with a layout box → its own rect
+//   - text node, or a `display:contents` wrapper (no box of its own) → the
+//     union of its contents, via a Range (this is what makes the `0` text node
+//     and the list container measurable)
+const rectOf = (node: Node): DOMRect | null => {
+  if (node.nodeType === Node.ELEMENT_NODE) {
+    const el = node as Element
+    if (getComputedStyle(el).display !== "contents") {
+      return el.getBoundingClientRect()
+    }
+  }
+  const range = document.createRange()
+  try {
+    range.selectNodeContents(node)
+    return range.getBoundingClientRect()
+  } catch {
+    return null
+  }
+}
+
+const paint = (rect: DOMRect): void => {
+  if (rect.width < 1 && rect.height < 1) return // nothing visible to flash
+  const pad = 1
+  const o = document.createElement("div")
+  o.style.cssText =
+    "position:fixed;pointer-events:none;z-index:9999;border-radius:3px;" +
+    `left:${rect.left - pad}px;top:${rect.top - pad}px;` +
+    `width:${rect.width + pad * 2}px;height:${rect.height + pad * 2}px;` +
+    `animation:efx-flash-overlay ${DURATION}ms ease-out forwards;`
+  document.body.appendChild(o)
+  o.addEventListener("animationend", () => o.remove(), { once: true })
+}
+
+export const flashOnUpdate = (root: HTMLElement): MutationObserver => {
+  const observer = new MutationObserver((records) => {
+    // Dedupe: several mutations can name the same node in one batch.
+    const nodes = new Set<Node>()
+    for (const r of records) {
+      if (r.type === "childList") {
+        if (r.addedNodes.length > 0) {
+          // Reactive text swap or list insert → the node(s) that appeared.
+          r.addedNodes.forEach((n) => nodes.add(n))
+        } else if (r.removedNodes.length > 0) {
+          // Pure removal (e.g. "remove last row") → the container that changed.
+          nodes.add(r.target)
+        }
+      } else {
+        // characterData (in-place text) or attributes (reactive class) → target.
+        nodes.add(r.target)
+      }
+    }
+    for (const node of nodes) {
+      if (node === root) continue
+      const rect = rectOf(node)
+      if (rect) paint(rect)
+    }
+  })
+  observer.observe(root, {
+    subtree: true,
+    childList: true,
+    characterData: true,
+    attributes: true,
+    attributeFilter: ["class"],
+  })
+  return observer
+}

--- a/apps/demo/src/flash.ts
+++ b/apps/demo/src/flash.ts
@@ -17,7 +17,8 @@
  * outside the observed root, so they never feed back into the observer.
  */
 
-const DURATION = 600 // ms, matches the efx-flash-overlay keyframe
+const DURATION = 400 // ms — kept shorter than the simulated fetch latency
+                     // (services.ts) so a reset's flash blips before content loads
 
 // The exact viewport-space box of a node, the way DevTools would outline it:
 //   - element with a layout box → its own rect

--- a/apps/demo/src/flash.ts
+++ b/apps/demo/src/flash.ts
@@ -44,10 +44,13 @@ const rectOf = (node: Node): DOMRect | null => {
 const paint = (rect: DOMRect): void => {
   if (rect.width < 1 && rect.height < 1) return // nothing visible to flash
   const pad = 1
+  // Position absolutely in *page* coordinates (viewport rect + scroll offset),
+  // not `fixed` — so the overlay stays glued to the element if the user scrolls
+  // during the animation, rather than drifting with the viewport.
   const o = document.createElement("div")
   o.style.cssText =
-    "position:fixed;pointer-events:none;z-index:9999;border-radius:3px;" +
-    `left:${rect.left - pad}px;top:${rect.top - pad}px;` +
+    "position:absolute;pointer-events:none;z-index:9999;border-radius:3px;" +
+    `left:${rect.left + window.scrollX - pad}px;top:${rect.top + window.scrollY - pad}px;` +
     `width:${rect.width + pad * 2}px;height:${rect.height + pad * 2}px;` +
     `animation:efx-flash-overlay ${DURATION}ms ease-out forwards;`
   document.body.appendChild(o)

--- a/apps/demo/src/highlight.ts
+++ b/apps/demo/src/highlight.ts
@@ -95,8 +95,11 @@ export const highlight = (src: string): ReadonlyArray<Token> => {
       continue
     }
 
-    // JSX tag open: `<name` or `</name` in expression position
-    if (c === "<" && isExprPos(prev) && /[A-Za-z/]/.test(src[i + 1] ?? "")) {
+    // JSX tag: `</name` is unambiguously a closing tag (highlight it wherever
+    // it appears, e.g. `failed</p>`); `<name` only *opens* a tag in expression
+    // position, so generics like `collection<Todo>` aren't mistaken for tags.
+    const afterLt = src[i + 1] ?? ""
+    if (c === "<" && (afterLt === "/" || (isExprPos(prev) && /[A-Za-z]/.test(afterLt)))) {
       let j = i + 1
       let open = "<"
       if (src[j] === "/") { open = "</"; j++ }

--- a/apps/demo/src/highlight.ts
+++ b/apps/demo/src/highlight.ts
@@ -1,0 +1,142 @@
+/**
+ * A tiny, dependency-free TSX-ish tokenizer for the guided-tour code blocks.
+ *
+ * Why hand-rolled instead of Shiki/Prism: efx builds DOM from a View tree and
+ * has no `innerHTML` seam, so a highlighter that emits HTML strings doesn't
+ * fit. Emitting tokens lets `main.efx` render each as a `<span>` View node —
+ * highlighting becomes just another efx child array, no new dependency, no
+ * bundle weight. The snippets are short and curated, so a pragmatic lexer
+ * (not a full TS grammar) is plenty.
+ */
+
+export type Token = {
+  readonly text: string
+  readonly kind:
+    | "kw"
+    | "str"
+    | "com"
+    | "num"
+    | "type"
+    | "fn"
+    | "tag"
+    | "punct"
+    | "plain"
+}
+
+const KEYWORDS = new Set([
+  "const", "let", "var", "yield", "return", "new", "function", "if", "else",
+  "for", "of", "in", "true", "false", "null", "undefined", "void", "await",
+  "async", "import", "export", "from", "as", "interface", "type", "extends",
+  "class", "typeof",
+])
+
+const isSpace = (c: string) => c === " " || c === "\t" || c === "\n" || c === "\r"
+const isDigit = (c: string) => c >= "0" && c <= "9"
+const isIdentStart = (c: string) => /[A-Za-z_$]/.test(c)
+const isIdent = (c: string) => /[A-Za-z0-9_$]/.test(c)
+// `<` opens a JSX tag only in expression position — after `(`, `{`, `=>`, etc.
+// After an identifier/`)`/`]` (e.g. `collection<Todo>`) it's a generic/less-than.
+const isExprPos = (prev: string) => prev === "" || !/[A-Za-z0-9_)\]]/.test(prev)
+
+export const highlight = (src: string): ReadonlyArray<Token> => {
+  const toks: Token[] = []
+  const push = (text: string, kind: Token["kind"]) => {
+    if (text) toks.push({ text, kind })
+  }
+  let i = 0
+  const n = src.length
+  let prev = "" // last significant (non-space) char, for JSX detection
+
+  while (i < n) {
+    const c = src[i]!
+
+    if (isSpace(c)) {
+      let j = i + 1
+      while (j < n && isSpace(src[j]!)) j++
+      const ws = src.slice(i, j)
+      push(ws, "plain")
+      // A newline resets expression position: a `<` starting a fresh line is a
+      // JSX tag, not a less-than against the previous line's trailing `)`/ident.
+      if (ws.includes("\n")) prev = ""
+      i = j
+      continue
+    }
+
+    // line comment
+    if (c === "/" && src[i + 1] === "/") {
+      let j = i + 2
+      while (j < n && src[j] !== "\n") j++
+      push(src.slice(i, j), "com")
+      prev = ""
+      i = j
+      continue
+    }
+
+    // string / template (whole template, incl. ${…}, colored as one string)
+    if (c === "`" || c === '"' || c === "'") {
+      let j = i + 1
+      while (j < n) {
+        if (src[j] === "\\") { j += 2; continue }
+        if (src[j] === c) { j++; break }
+        j++
+      }
+      push(src.slice(i, j), "str")
+      prev = c
+      i = j
+      continue
+    }
+
+    if (isDigit(c)) {
+      let j = i + 1
+      while (j < n && (isDigit(src[j]!) || src[j] === ".")) j++
+      push(src.slice(i, j), "num")
+      prev = "0"
+      i = j
+      continue
+    }
+
+    // JSX tag open: `<name` or `</name` in expression position
+    if (c === "<" && isExprPos(prev) && /[A-Za-z/]/.test(src[i + 1] ?? "")) {
+      let j = i + 1
+      let open = "<"
+      if (src[j] === "/") { open = "</"; j++ }
+      let k = j
+      while (k < n && /[A-Za-z0-9_.]/.test(src[k]!)) k++
+      const name = src.slice(j, k)
+      push(open, "punct")
+      push(name, "tag")
+      prev = name ? name[name.length - 1]! : "<"
+      i = k
+      continue
+    }
+
+    if (isIdentStart(c)) {
+      let j = i + 1
+      while (j < n && isIdent(src[j]!)) j++
+      const word = src.slice(i, j)
+      let kind: Token["kind"] = "plain"
+      if (KEYWORDS.has(word)) kind = "kw"
+      else if (/^[A-Z]/.test(word)) kind = "type"
+      else {
+        let p = j
+        while (p < n && src[p] === " ") p++
+        if (src[p] === "(") kind = "fn"
+      }
+      push(word, kind)
+      prev = word[word.length - 1]!
+      i = j
+      continue
+    }
+
+    // punctuation / operators — group a run (but never swallow a `<`, which is
+    // re-decided at the top of the loop as either a JSX open or less-than)
+    const PUNCT = /[{}()[\].,;:=+\-*/%!&|?>~^@]/
+    let j = i + 1
+    while (j < n && PUNCT.test(src[j]!)) j++
+    push(src.slice(i, j), "punct")
+    prev = src[j - 1]!
+    i = j
+  }
+
+  return toks
+}

--- a/apps/demo/src/main.efx
+++ b/apps/demo/src/main.efx
@@ -63,7 +63,7 @@ const demoSlot = (id: string) => (
         title="recreate this component from scratch"
         onclick={() => refreshers.get(id)?.()}
       >
-        ↻ refresh
+        ↻ reset
       </button>
     </div>
     <div class="demo-mount" data-demo={id}></div>
@@ -104,7 +104,7 @@ const App = (
           . Each section pairs the source on the left with the running component
           on the right. Interact with any demo — the brief highlight marks the
           exact DOM node that re-rendered; nothing around it does. Hit{" "}
-          <strong>↻ refresh</strong> to recreate a component and watch its
+          <strong>↻ reset</strong> to recreate a component and watch its
           initial state (loading, count 0) from the top.
         </p>
       </div>
@@ -149,7 +149,7 @@ const user = yield* http.getUser(id)
         step: "03",
         title: "Await boundary (non-blocking)",
         concept:
-          "Same fetch, wrapped in Await. A pending placeholder shows immediately; onError handles failure locally, so E is discharged to never. Http still folds into R from the thunk — a forgotten Layer is still a compile error across the boundary. The Scope is Await's own contribution: it borrows the enclosing scope and forks the fetch into it, so the request is cancelled when that scope closes — here the element's own demo scope, so refresh interrupts an in-flight fetch.",
+          "Same fetch, wrapped in Await. A pending placeholder shows immediately; onError handles failure locally, so E is discharged to never. Http still folds into R from the thunk — a forgotten Layer is still a compile error across the boundary. The Scope is Await's own contribution: it borrows the enclosing scope and forks the fetch into it, so the request is cancelled when that scope closes — here the element's own demo scope, so reset interrupts an in-flight fetch.",
         type: "Effect<View, never, Http | Scope>",
         code: `Await(() => http.getUser(id), {
   pending:   <p>loading…</p>,
@@ -199,7 +199,7 @@ Await(() => http.getUser(userId.value), { … })
         step: "06",
         title: "Per-component lifecycle",
         concept:
-          "Every row mounts in its own Effect Scope, so a finalizer registered with Effect.acquireRelease fires when that row's DOM is removed — not when the whole app unmounts. Open devtools and watch the __lifecycle log: a paired unmount:N for every mount:N. (Refresh closes the demo's scope, firing every remaining row's finalizer at once.)",
+          "Every row mounts in its own Effect Scope, so a finalizer registered with Effect.acquireRelease fires when that row's DOM is removed — not when the whole app unmounts. Open devtools and watch the __lifecycle log: a paired unmount:N for every mount:N. (Reset closes the demo's scope, firing every remaining row's finalizer at once.)",
         type: "Effect<View, never, never>",
         code: `yield* Effect.acquireRelease(
   Effect.sync(() => log(\`mount:\${id}\`)),

--- a/apps/demo/src/main.efx
+++ b/apps/demo/src/main.efx
@@ -281,9 +281,10 @@ const program = Effect.gen(function* () {
     setupDemo("todos", () => Todos())
     setupDemo("lifecycle", () => Lifecycle())
   })
-  // Start the reactivity flash once the initial mounts settle (incl. the 250ms
-  // blocking fetch), so only interactions and refreshes flash — not page load.
-  yield* Effect.sleep("500 millis")
+  // Start the reactivity flash once the initial mounts settle (incl. the
+  // simulated fetch latency), so only interactions and resets flash — not page
+  // load. Keep this comfortably past the latency in services.ts.
+  yield* Effect.sleep("1600 millis")
   yield* Effect.sync(() => flashOnUpdate(rootEl))
   // Keep App's scope alive so the refresh buttons' listeners persist.
   yield* Effect.never

--- a/apps/demo/src/main.efx
+++ b/apps/demo/src/main.efx
@@ -284,7 +284,7 @@ const program = Effect.gen(function* () {
   // Start the reactivity flash once the initial mounts settle (incl. the
   // simulated fetch latency), so only interactions and resets flash — not page
   // load. Keep this comfortably past the latency in services.ts.
-  yield* Effect.sleep("1200 millis")
+  yield* Effect.sleep("900 millis")
   yield* Effect.sync(() => flashOnUpdate(rootEl))
   // Keep App's scope alive so the refresh buttons' listeners persist.
   yield* Effect.never

--- a/apps/demo/src/main.efx
+++ b/apps/demo/src/main.efx
@@ -117,10 +117,16 @@ const App = (
         concept:
           "Local state is an Effect AtomRef — efx ships no signal of its own. Drop the ref straight into child position and h() emits a reactive node; on update, only that text node re-renders. No services, so R is never.",
         type: "Effect<View, never, never>",
-        code: `const count = AtomRef.make(0)
+        code: `export const Counter = Effect.fn("Counter")(function* () {
+  const count = AtomRef.make(0)
 
-<button onclick={() => count.update(n => n + 1)}>+</button>
-<span class="count">clicks: {count}</span>`,
+  return yield* (
+    <div class="counter">
+      <button onclick={() => count.update(n => n + 1)}>+</button>
+      <span class="count">clicks: {count}</span>
+    </div>
+  )
+})`,
         file: "Counter.efx",
       })}
       {demoSlot("counter")}
@@ -133,12 +139,20 @@ const App = (
         concept:
           "Fetch inside the component. `yield* Http` adds Http to R; the request can fail, so HttpError rides E. Both surface in the type and must be satisfied at mount — drop HttpLive below and main stops compiling. The subtree blocks until the request resolves.",
         type: "Effect<View, HttpError, Http | Theme>",
-        code: `// adds Http to R
-const http = yield* Http
-// can fail → HttpError in E
-const user = yield* http.getUser(id)
+        code: `export const UserPage = Effect.fn("UserPage")(function* (props: {
+  userId: string
+}) {
+  const http = yield* Http        // adds Http to R
+  const theme = yield* Theme      // adds Theme to R
+  const user = yield* http.getUser(props.userId) // may fail → HttpError in E
 
-<h1>{user.name}</h1>`,
+  return yield* (
+    <article class={\`user-page \${theme.mode}\`}>
+      <h1>{user.name}</h1>
+      {user.bio && <p class="bio">{user.bio}</p>}
+    </article>
+  )
+})`,
         file: "UserPage.efx",
       })}
       {demoSlot("userpage")}
@@ -151,10 +165,20 @@ const user = yield* http.getUser(id)
         concept:
           "Same fetch, wrapped in Await. A pending placeholder shows immediately; onError handles failure locally, so E is discharged to never. Http still folds into R from the thunk — a forgotten Layer is still a compile error across the boundary. The Scope is Await's own contribution: it borrows the enclosing scope and forks the fetch into it, so the request is cancelled when that scope closes — here the element's own demo scope, so reset interrupts an in-flight fetch.",
         type: "Effect<View, never, Http | Scope>",
-        code: `Await(() => http.getUser(id), {
-  pending:   <p>loading…</p>,
-  onError:   cause => <p>error</p>, // E → never
-  onSuccess: user  => <UserCard user={user} />,
+        code: `export const AsyncUserPage = Effect.fn("AsyncUserPage")(function* (props: {
+  userId: string
+}) {
+  const http = yield* Http   // folds into R; Scope comes from Await
+
+  return yield* (
+    <article>
+      {Await(() => http.getUser(props.userId), {
+        pending:   <p class="loading">loading…</p>,
+        onError:   cause => <p class="error">{Cause.pretty(cause)}</p>,
+        onSuccess: user  => <h1>{user.name}</h1>,
+      })}
+    </article>
+  )
 })`,
         file: "AsyncUserPage.efx",
       })}
@@ -168,11 +192,24 @@ const user = yield* http.getUser(id)
         concept:
           "The Await thunk reads userId.value, so the compiler tracks it as a dependency and re-runs the fetch whenever the id changes — interrupting the stale request. Deps are discovered, not declared: there is no `from`, no key array. Click the buttons to refetch.",
         type: "Effect<View, never, Http | Scope>",
-        code: `// buttons call userId.set(...)
-const userId = AtomRef.make("42")
+        code: `export const LiveUser = Effect.fn("LiveUser")(function* () {
+  const userId = AtomRef.make("42")
+  const http = yield* Http
 
-Await(() => http.getUser(userId.value), { … })
-// reads .value → tracked dep → refetch on change`,
+  return yield* (
+    <div class="live-user">
+      <button onclick={() => userId.set("7")}>Grace</button>
+      <button onclick={() => userId.set("999")}>Bad id</button>
+
+      {Await(() => http.getUser(userId.value), {
+        pending:   <span>loading…</span>,
+        onError:   () => <span>not found</span>,
+        onSuccess: user => <strong>{user.name}</strong>,
+      })}
+      {/* the thunk reads userId.value → refetch when it changes */}
+    </div>
+  )
+})`,
         file: "LiveUser.efx",
       })}
       {demoSlot("live")}
@@ -185,10 +222,20 @@ Await(() => http.getUser(userId.value), { … })
         concept:
           "A collection where each row is its own AtomRef. `coll.value.map(x => <Row/>)` in JSX compiles to a keyed View.List node; mount reconciles by ref identity on add/remove. Each row subscribes to its own ref, so toggling one doesn't re-render the rest.",
         type: "Effect<View, never, never>",
-        code: `const todos = AtomRef.collection<Todo>([...])
+        code: `export const Todos = Effect.fn("Todos")(function* () {
+  const todos = AtomRef.collection<Todo>([
+    { text: "build a UI framework", done: true },
+    { text: "write a blog post", done: false },
+  ])
 
-<ul>{todos.value.map(item => <TodoRow item={item} />)}</ul>
-// → keyed View.List; reconciled by ref identity`,
+  return yield* (
+    <ul>
+      {todos.value.map(item =>
+        <TodoRow item={item} remove={() => todos.remove(item)} />)}
+    </ul>
+  )
+})
+// → keyed View.List; mount reconciles rows by ref identity`,
         file: "Todos.efx",
       })}
       {demoSlot("todos")}
@@ -201,10 +248,18 @@ Await(() => http.getUser(userId.value), { … })
         concept:
           "Every row mounts in its own Effect Scope, so a finalizer registered with Effect.acquireRelease fires when that row's DOM is removed — not when the whole app unmounts. Open devtools and watch the __lifecycle log: a paired unmount:N for every mount:N. (Reset closes the demo's scope, firing every remaining row's finalizer at once.)",
         type: "Effect<View, never, never>",
-        code: `yield* Effect.acquireRelease(
-  Effect.sync(() => log(\`mount:\${id}\`)),
-  () => Effect.sync(() => log(\`unmount:\${id}\`)),
-)`,
+        code: `const Row = Effect.fn("Row")(function* (props: {
+  item: AtomRef<Item>
+}) {
+  const id = props.item.value.id
+  yield* Effect.acquireRelease(
+    Effect.sync(() => log(\`mount:\${id}\`)),
+    () => Effect.sync(() => log(\`unmount:\${id}\`)),
+  )
+  return yield* <li>row {id}</li>
+})
+
+<ul>{items.value.map(item => <Row item={item} />)}</ul>`,
         file: "Lifecycle.efx",
       })}
       {demoSlot("lifecycle")}

--- a/apps/demo/src/main.efx
+++ b/apps/demo/src/main.efx
@@ -121,9 +121,9 @@ const App = (
   const count = AtomRef.make(0)
 
   return yield* (
-    <div class="counter">
+    <div>
       <button onclick={() => count.update(n => n + 1)}>+</button>
-      <span class="count">clicks: {count}</span>
+      <span>clicks: {count}</span>
     </div>
   )
 })`,
@@ -147,9 +147,8 @@ const App = (
   const user = yield* http.getUser(props.userId) // may fail → HttpError in E
 
   return yield* (
-    <article class={\`user-page \${theme.mode}\`}>
+    <article class={theme.mode}>
       <h1>{user.name}</h1>
-      {user.bio && <p class="bio">{user.bio}</p>}
     </article>
   )
 })`,
@@ -170,15 +169,11 @@ const App = (
 }) {
   const http = yield* Http   // folds into R; Scope comes from Await
 
-  return yield* (
-    <article>
-      {Await(() => http.getUser(props.userId), {
-        pending:   <p class="loading">loading…</p>,
-        onError:   cause => <p class="error">{Cause.pretty(cause)}</p>,
-        onSuccess: user  => <h1>{user.name}</h1>,
-      })}
-    </article>
-  )
+  return yield* Await(() => http.getUser(props.userId), {
+    pending:   <p>loading…</p>,
+    onError:   () => <p>failed</p>,
+    onSuccess: user => <h1>{user.name}</h1>,
+  })
 })`,
         file: "AsyncUserPage.efx",
       })}
@@ -197,19 +192,17 @@ const App = (
   const http = yield* Http
 
   return yield* (
-    <div class="live-user">
+    <div>
       <button onclick={() => userId.set("7")}>Grace</button>
-      <button onclick={() => userId.set("999")}>Bad id</button>
 
       {Await(() => http.getUser(userId.value), {
         pending:   <span>loading…</span>,
-        onError:   () => <span>not found</span>,
         onSuccess: user => <strong>{user.name}</strong>,
       })}
-      {/* the thunk reads userId.value → refetch when it changes */}
     </div>
   )
-})`,
+})
+// the thunk reads userId.value → refetch when it changes`,
         file: "LiveUser.efx",
       })}
       {demoSlot("live")}

--- a/apps/demo/src/main.efx
+++ b/apps/demo/src/main.efx
@@ -1,28 +1,30 @@
-import { Cause, Effect, Fiber, Layer } from "effect"
-import { EfxLive, mount } from "@efx/runtime"
+import { Cause, Effect, Exit, Fiber, Layer, Scope } from "effect"
+import { AtomRegistry } from "effect/unstable/reactivity"
+import { EfxLive, mount, type View } from "@efx/runtime"
 import { Counter } from "./Counter.efx"
 import { AsyncUserPage } from "./AsyncUserPage.efx"
 import { flashOnUpdate } from "./flash.ts"
 import { highlight } from "./highlight.ts"
 import { Lifecycle } from "./Lifecycle.efx"
 import { LiveUser } from "./LiveUser.efx"
-import { HttpLive, ThemeLive } from "./services.ts"
+import { Http, HttpLive, Theme, ThemeLive } from "./services.ts"
 import { Todos } from "./Todos.efx"
 import { UserPage } from "./UserPage.efx"
 
 const REPO = "https://github.com/m9tdev/efx"
 const SRC = `${REPO}/blob/main/apps/demo/src`
 
+// Each demo is mounted independently (see `setupDemo` below); the refresh
+// button recreates it from scratch. `refreshers` maps a demo id to its remount
+// fn so the static button in `App` can trigger it.
+const refreshers = new Map<string, () => void>()
+const teardowns = new Map<string, () => void>()
+
 /**
  * The static left column of a guided-tour section: a step number, the concept
  * the primitive teaches, the *inferred* `Effect<View, E, R>` type, a curated
- * source snippet, and a link to the full file.
- *
- * This is a plain function (not an `Effect.fn` component) returning JSX, so it
- * folds to `Effect<View, never, never>` — pure presentation, no services. The
- * live component is rendered *inline* in `App` (not routed through here) so its
- * real `E`/`R` channels still fold into `main`'s type. That's the whole point:
- * forget a `Layer` below and this entrypoint stops compiling.
+ * source snippet, and a link to the full file. Pure presentation — folds to
+ * `Effect<View, never, never>`.
  */
 const copy = (meta: {
   readonly step: string
@@ -47,6 +49,27 @@ const copy = (meta: {
   </div>
 )
 
+/**
+ * The right column: a "live" label, a refresh button that recreates the
+ * component (so its initial state — loading spinners, count 0, the original
+ * list — can be seen again), and the empty container `setupDemo` mounts into.
+ */
+const demoSlot = (id: string) => (
+  <div class="tour-demo">
+    <div class="demo-bar">
+      <span class="demo-label">live</span>
+      <button
+        class="demo-refresh"
+        title="recreate this component from scratch"
+        onclick={() => refreshers.get(id)?.()}
+      >
+        ↻ refresh
+      </button>
+    </div>
+    <div class="demo-mount" data-demo={id}></div>
+  </div>
+)
+
 const App = (
   <div class="app">
     <header class="hero">
@@ -57,7 +80,7 @@ const App = (
         UI framework where the <code>{"<A, E, R>"}</code> channels survive from
         every leaf of the view tree to the root. Forget to provide a service{" "}
         <code>Layer</code> and you get a <em>compile-time error that names the
-        missing service</em> — not a runtime crash.
+          missing service</em> — not a runtime crash.
       </p>
       <div class="how">
         <h3>the trick, in one breath</h3>
@@ -80,7 +103,9 @@ const App = (
           </a>
           . Each section pairs the source on the left with the running component
           on the right. Interact with any demo — the brief highlight marks the
-          exact DOM node that re-rendered; nothing around it does.
+          exact DOM node that re-rendered; nothing around it does. Hit{" "}
+          <strong>↻ refresh</strong> to recreate a component and watch its
+          initial state (loading, count 0) from the top.
         </p>
       </div>
     </header>
@@ -98,10 +123,7 @@ const App = (
 <span class="count">clicks: {count}</span>`,
         file: "Counter.efx",
       })}
-      <div class="tour-demo">
-        <span class="demo-label">live</span>
-        <Counter />
-      </div>
+      {demoSlot("counter")}
     </section>
 
     <section class="tour">
@@ -111,16 +133,15 @@ const App = (
         concept:
           "Fetch inside the component. `yield* Http` adds Http to R; the request can fail, so HttpError rides E. Both surface in the type and must be satisfied at mount — drop HttpLive below and main stops compiling. The subtree blocks until the request resolves.",
         type: "Effect<View, HttpError, Http | Theme>",
-        code: `const http = yield* Http              // → adds Http to R
-const user = yield* http.getUser(id)  // can fail → HttpError in E
+        code: `// adds Http to R
+const http = yield* Http
+// can fail → HttpError in E
+const user = yield* http.getUser(id)
 
 <h1>{user.name}</h1>`,
         file: "UserPage.efx",
       })}
-      <div class="tour-demo">
-        <span class="demo-label">live</span>
-        <UserPage userId="42" />
-      </div>
+      {demoSlot("userpage")}
     </section>
 
     <section class="tour">
@@ -128,19 +149,16 @@ const user = yield* http.getUser(id)  // can fail → HttpError in E
         step: "03",
         title: "Await boundary (non-blocking)",
         concept:
-          "Same fetch, wrapped in Await. A pending placeholder shows immediately; onError handles failure locally, so E is discharged to never. Http still folds into R from the thunk — a forgotten Layer is still a compile error across the boundary. The Scope is Await's own contribution: it borrows the enclosing scope and forks the fetch into it, so the request is cancelled when that scope closes — here the root app scope, but under a reactive/list slot it's the element's own scope.",
+          "Same fetch, wrapped in Await. A pending placeholder shows immediately; onError handles failure locally, so E is discharged to never. Http still folds into R from the thunk — a forgotten Layer is still a compile error across the boundary. The Scope is Await's own contribution: it borrows the enclosing scope and forks the fetch into it, so the request is cancelled when that scope closes — here the element's own demo scope, so refresh interrupts an in-flight fetch.",
         type: "Effect<View, never, Http | Scope>",
         code: `Await(() => http.getUser(id), {
   pending:   <p>loading…</p>,
-  onError:   cause => <p>error</p>,         // E → never
+  onError:   cause => <p>error</p>, // E → never
   onSuccess: user  => <UserCard user={user} />,
 })`,
         file: "AsyncUserPage.efx",
       })}
-      <div class="tour-demo">
-        <span class="demo-label">live</span>
-        <AsyncUserPage userId="42" />
-      </div>
+      {demoSlot("async")}
     </section>
 
     <section class="tour">
@@ -157,10 +175,7 @@ Await(() => http.getUser(userId.value), { … })
 // reads .value → tracked dep → refetch on change`,
         file: "LiveUser.efx",
       })}
-      <div class="tour-demo">
-        <span class="demo-label">live</span>
-        <LiveUser />
-      </div>
+      {demoSlot("live")}
     </section>
 
     <section class="tour">
@@ -176,10 +191,7 @@ Await(() => http.getUser(userId.value), { … })
 // → keyed View.List; reconciled by ref identity`,
         file: "Todos.efx",
       })}
-      <div class="tour-demo">
-        <span class="demo-label">live</span>
-        <Todos />
-      </div>
+      {demoSlot("todos")}
     </section>
 
     <section class="tour">
@@ -187,7 +199,7 @@ Await(() => http.getUser(userId.value), { … })
         step: "06",
         title: "Per-component lifecycle",
         concept:
-          "Every row mounts in its own Effect Scope, so a finalizer registered with Effect.acquireRelease fires when that row's DOM is removed — not when the whole app unmounts. Open devtools and watch the __lifecycle log: a paired unmount:N for every mount:N.",
+          "Every row mounts in its own Effect Scope, so a finalizer registered with Effect.acquireRelease fires when that row's DOM is removed — not when the whole app unmounts. Open devtools and watch the __lifecycle log: a paired unmount:N for every mount:N. (Refresh closes the demo's scope, firing every remaining row's finalizer at once.)",
         type: "Effect<View, never, never>",
         code: `yield* Effect.acquireRelease(
   Effect.sync(() => log(\`mount:\${id}\`)),
@@ -195,10 +207,7 @@ Await(() => http.getUser(userId.value), { … })
 )`,
         file: "Lifecycle.efx",
       })}
-      <div class="tour-demo">
-        <span class="demo-label">live</span>
-        <Lifecycle />
-      </div>
+      {demoSlot("lifecycle")}
     </section>
 
     <footer class="site-footer">
@@ -213,13 +222,70 @@ Await(() => http.getUser(userId.value), { … })
 const rootEl = document.getElementById("root")
 if (!rootEl) throw new Error("missing #root")
 
+// The full app Layer. Every demo's requirements must be a subset of what this
+// provides — `setupDemo`'s signature enforces it, so forgetting (say) HttpLive
+// is a compile error at the UserPage/AsyncUserPage/LiveUser call sites, not a
+// runtime crash. That's the thesis, now enforced per-mount.
+const APP_LAYER = Layer.mergeAll(EfxLive, HttpLive, ThemeLive)
+
+// Everything the demos may require, after EfxLive/HttpLive/ThemeLive: the
+// reactivity registry, the two services, and a Scope.
+type DemoR = AtomRegistry.AtomRegistry | Http | Theme | Scope.Scope
+
+/**
+ * Mount a component into its demo container under a Closeable scope we own, and
+ * register a `remount` that tears the old one down (firing its finalizers,
+ * cancelling in-flight Await fetches) and builds a fresh one. Because `make()`
+ * is called anew each time, refresh shows the component's initial state again.
+ *
+ * `make`'s `R` is constrained to `DemoR`, so a component needing a service
+ * APP_LAYER doesn't provide won't type-check here.
+ */
+const setupDemo = <E>(id: string, make: () => Effect.Effect<View, E, DemoR>): void => {
+  const container = rootEl.querySelector<HTMLElement>(`[data-demo="${id}"]`)
+  if (!container) throw new Error(`missing demo container: ${id}`)
+
+  let teardown: (() => void) | null = null
+  const remount = (): void => {
+    teardown?.()
+    const scope = Scope.makeUnsafe()
+    Effect.runFork(
+      Scope.provide(
+        mount(make(), container).pipe(
+          Effect.catchCause((cause) =>
+            Effect.sync(() => console.error(`[efx demo: ${id}]`, Cause.pretty(cause))),
+          ),
+          Effect.provide(APP_LAYER),
+        ),
+        scope,
+      ),
+    )
+    teardown = () => {
+      const closing = Scope.closeUnsafe(scope, Exit.void)
+      if (closing) Effect.runFork(closing)
+    }
+  }
+
+  refreshers.set(id, remount)
+  teardowns.set(id, () => teardown?.())
+  remount()
+}
+
 const program = Effect.gen(function* () {
   yield* mount(App, rootEl)
-  // Demo sugar: flash each node as efx re-renders it, so fine-grained
-  // reactivity is visible. Started after mount so the initial render doesn't
-  // flash; later updates (interactions, async resolves) do.
+  yield* Effect.sync(() => {
+    setupDemo("counter", () => Counter())
+    setupDemo("userpage", () => UserPage({ userId: "42" }))
+    setupDemo("async", () => AsyncUserPage({ userId: "42" }))
+    setupDemo("live", () => LiveUser())
+    setupDemo("todos", () => Todos())
+    setupDemo("lifecycle", () => Lifecycle())
+  })
+  // Start the reactivity flash once the initial mounts settle (incl. the 250ms
+  // blocking fetch), so only interactions and refreshes flash — not page load.
+  yield* Effect.sleep("500 millis")
   yield* Effect.sync(() => flashOnUpdate(rootEl))
-  // Keep the scope alive so subscriptions and DOM persist for the page's lifetime.
+  // Keep App's scope alive so the refresh buttons' listeners persist.
   yield* Effect.never
 }).pipe(
   Effect.scoped,
@@ -228,14 +294,16 @@ const program = Effect.gen(function* () {
       console.error("App failed:", Cause.pretty(cause))
     }),
   ),
-  Effect.provide(Layer.mergeAll(EfxLive, HttpLive, ThemeLive)),
+  Effect.provide(APP_LAYER),
 )
 
 const fiber = Effect.runFork(program)
 
 // Test affordance: scripts/probe-lifecycle.mjs calls this to trigger a full
-// unmount via fiber interruption. Closing the program scope cascades through
-// every per-row / per-Reactive sub-scope and fires their finalizers.
+// teardown. Closing each demo's scope cascades through every per-row /
+// per-Reactive sub-scope and fires their finalizers; interrupting the App
+// fiber tears down the static shell.
 ;(globalThis as { __teardown?: () => void }).__teardown = () => {
+  for (const close of teardowns.values()) close()
   Effect.runFork(Fiber.interrupt(fiber))
 }

--- a/apps/demo/src/main.efx
+++ b/apps/demo/src/main.efx
@@ -44,7 +44,7 @@ const copy = (meta: {
     <pre class="sig"><code>{meta.type}</code></pre>
     <pre class="code"><code>{highlight(meta.code).map((t) => <span class={`tok-${t.kind}`}>{t.text}</span>)}</code></pre>
     <a class="src" href={`${SRC}/${meta.file}`} target="_blank" rel="noreferrer">
-      view source ↗
+      view full source ↗
     </a>
   </div>
 )

--- a/apps/demo/src/main.efx
+++ b/apps/demo/src/main.efx
@@ -197,6 +197,7 @@ const App = (
 
       {Await(() => http.getUser(userId.value), {
         pending:   <span>loading…</span>,
+        onError:   () => <span>not found</span>,
         onSuccess: user => <strong>{user.name}</strong>,
       })}
     </div>

--- a/apps/demo/src/main.efx
+++ b/apps/demo/src/main.efx
@@ -284,7 +284,7 @@ const program = Effect.gen(function* () {
   // Start the reactivity flash once the initial mounts settle (incl. the
   // simulated fetch latency), so only interactions and resets flash — not page
   // load. Keep this comfortably past the latency in services.ts.
-  yield* Effect.sleep("1600 millis")
+  yield* Effect.sleep("1200 millis")
   yield* Effect.sync(() => flashOnUpdate(rootEl))
   // Keep App's scope alive so the refresh buttons' listeners persist.
   yield* Effect.never

--- a/apps/demo/src/main.efx
+++ b/apps/demo/src/main.efx
@@ -2,39 +2,211 @@ import { Cause, Effect, Fiber, Layer } from "effect"
 import { EfxLive, mount } from "@efx/runtime"
 import { Counter } from "./Counter.efx"
 import { AsyncUserPage } from "./AsyncUserPage.efx"
+import { flashOnUpdate } from "./flash.ts"
+import { highlight } from "./highlight.ts"
 import { Lifecycle } from "./Lifecycle.efx"
 import { LiveUser } from "./LiveUser.efx"
 import { HttpLive, ThemeLive } from "./services.ts"
 import { Todos } from "./Todos.efx"
 import { UserPage } from "./UserPage.efx"
 
+const REPO = "https://github.com/m9tdev/efx"
+const SRC = `${REPO}/blob/main/apps/demo/src`
+
+/**
+ * The static left column of a guided-tour section: a step number, the concept
+ * the primitive teaches, the *inferred* `Effect<View, E, R>` type, a curated
+ * source snippet, and a link to the full file.
+ *
+ * This is a plain function (not an `Effect.fn` component) returning JSX, so it
+ * folds to `Effect<View, never, never>` — pure presentation, no services. The
+ * live component is rendered *inline* in `App` (not routed through here) so its
+ * real `E`/`R` channels still fold into `main`'s type. That's the whole point:
+ * forget a `Layer` below and this entrypoint stops compiling.
+ */
+const copy = (meta: {
+  readonly step: string
+  readonly title: string
+  readonly concept: string
+  readonly type: string
+  readonly code: string
+  readonly file: string
+}) => (
+  <div class="tour-copy">
+    <div class="tour-head">
+      <span class="step">{meta.step}</span>
+      <h2>{meta.title}</h2>
+    </div>
+    <p class="concept">{meta.concept}</p>
+    <p class="sig-label">inferred type</p>
+    <pre class="sig"><code>{meta.type}</code></pre>
+    <pre class="code"><code>{highlight(meta.code).map((t) => <span class={`tok-${t.kind}`}>{t.text}</span>)}</code></pre>
+    <a class="src" href={`${SRC}/${meta.file}`} target="_blank" rel="noreferrer">
+      view source ↗
+    </a>
+  </div>
+)
+
 const App = (
   <div class="app">
-    <h1>efx demo — channels through the tree</h1>
-    <section class="section">
-      <h2>Reactive counter (AtomRef)</h2>
-      <Counter />
+    <header class="hero">
+      <p class="eyebrow">a guided tour</p>
+      <h1>efx</h1>
+      <p class="tagline">
+        an <a href="https://effect.website" target="_blank" rel="noreferrer">Effect</a>-native
+        UI framework where the <code>{"<A, E, R>"}</code> channels survive from
+        every leaf of the view tree to the root. Forget to provide a service{" "}
+        <code>Layer</code> and you get a <em>compile-time error that names the
+        missing service</em> — not a runtime crash.
+      </p>
+      <div class="how">
+        <h3>the trick, in one breath</h3>
+        <p>
+          TypeScript erases generics at the JSX boundary, collapsing every
+          component to <code>JSX.Element</code> — fatal for a framework whose
+          point is that <code>E</code>/<code>R</code> survive composition. So
+          efx never lets <code>tsc</code> see JSX: source files use a{" "}
+          <code>.efx</code> extension, and <code>@efx/compiler</code> rewrites
+          every <code>{"<tag/>"}</code> into an <code>h(tag, props, …children)</code>{" "}
+          call <em>before</em> tsc parses the file. <code>h()</code>'s
+          conditional-type signature then unions every child's <code>E</code>{" "}
+          and <code>R</code> into the result. tsc only ever type-checks plain
+          function calls — so the channels can't be erased.
+        </p>
+        <p class="how-note">
+          Every <code>inferred type</code> below is real, checked by{" "}
+          <a href={`${REPO}/blob/main/apps/demo/src/channels.test-d.ts`} target="_blank" rel="noreferrer">
+            channels.test-d.ts
+          </a>
+          . Each section pairs the source on the left with the running component
+          on the right. Interact with any demo — the brief highlight marks the
+          exact DOM node that re-rendered; nothing around it does.
+        </p>
+      </div>
+    </header>
+
+    <section class="tour">
+      {copy({
+        step: "01",
+        title: "Reactive state",
+        concept:
+          "Local state is an Effect AtomRef — efx ships no signal of its own. Drop the ref straight into child position and h() emits a reactive node; on update, only that text node re-renders. No services, so R is never.",
+        type: "Effect<View, never, never>",
+        code: `const count = AtomRef.make(0)
+
+<button onclick={() => count.update(n => n + 1)}>+</button>
+<span class="count">clicks: {count}</span>`,
+        file: "Counter.efx",
+      })}
+      <div class="tour-demo">
+        <span class="demo-label">live</span>
+        <Counter />
+      </div>
     </section>
-    <section class="section">
-      <h2>Async data, in-component (E + R fold to root, blocking)</h2>
-      <UserPage userId="42" />
+
+    <section class="tour">
+      {copy({
+        step: "02",
+        title: "Effectful data (channels fold to root)",
+        concept:
+          "Fetch inside the component. `yield* Http` adds Http to R; the request can fail, so HttpError rides E. Both surface in the type and must be satisfied at mount — drop HttpLive below and main stops compiling. The subtree blocks until the request resolves.",
+        type: "Effect<View, HttpError, Http | Theme>",
+        code: `const http = yield* Http              // → adds Http to R
+const user = yield* http.getUser(id)  // can fail → HttpError in E
+
+<h1>{user.name}</h1>`,
+        file: "UserPage.efx",
+      })}
+      <div class="tour-demo">
+        <span class="demo-label">live</span>
+        <UserPage userId="42" />
+      </div>
     </section>
-    <section class="section">
-      <h2>Async data via Await boundary (local loading + error, non-blocking)</h2>
-      <AsyncUserPage userId="42" />
+
+    <section class="tour">
+      {copy({
+        step: "03",
+        title: "Await boundary (non-blocking)",
+        concept:
+          "Same fetch, wrapped in Await. A pending placeholder shows immediately; onError handles failure locally, so E is discharged to never. Http still folds into R from the thunk — a forgotten Layer is still a compile error across the boundary. The Scope is Await's own contribution: it borrows the enclosing scope and forks the fetch into it, so the request is cancelled when that scope closes — here the root app scope, but under a reactive/list slot it's the element's own scope.",
+        type: "Effect<View, never, Http | Scope>",
+        code: `Await(() => http.getUser(id), {
+  pending:   <p>loading…</p>,
+  onError:   cause => <p>error</p>,         // E → never
+  onSuccess: user  => <UserCard user={user} />,
+})`,
+        file: "AsyncUserPage.efx",
+      })}
+      <div class="tour-demo">
+        <span class="demo-label">live</span>
+        <AsyncUserPage userId="42" />
+      </div>
     </section>
-    <section class="section">
-      <h2>Live atom (AsyncResult)</h2>
-      <LiveUser />
+
+    <section class="tour">
+      {copy({
+        step: "04",
+        title: "Await, auto-tracking (deps discovered)",
+        concept:
+          "The Await thunk reads userId.value, so the compiler tracks it as a dependency and re-runs the fetch whenever the id changes — interrupting the stale request. Deps are discovered, not declared: there is no `from`, no key array. Click the buttons to refetch.",
+        type: "Effect<View, never, Http | Scope>",
+        code: `// buttons call userId.set(...)
+const userId = AtomRef.make("42")
+
+Await(() => http.getUser(userId.value), { … })
+// reads .value → tracked dep → refetch on change`,
+        file: "LiveUser.efx",
+      })}
+      <div class="tour-demo">
+        <span class="demo-label">live</span>
+        <LiveUser />
+      </div>
     </section>
-    <section class="section">
-      <h2>Keyed reactive list (AtomRef.collection)</h2>
-      <Todos />
+
+    <section class="tour">
+      {copy({
+        step: "05",
+        title: "Keyed reactive list",
+        concept:
+          "A collection where each row is its own AtomRef. `coll.value.map(x => <Row/>)` in JSX compiles to a keyed View.List node; mount reconciles by ref identity on add/remove. Each row subscribes to its own ref, so toggling one doesn't re-render the rest.",
+        type: "Effect<View, never, never>",
+        code: `const todos = AtomRef.collection<Todo>([...])
+
+<ul>{todos.value.map(item => <TodoRow item={item} />)}</ul>
+// → keyed View.List; reconciled by ref identity`,
+        file: "Todos.efx",
+      })}
+      <div class="tour-demo">
+        <span class="demo-label">live</span>
+        <Todos />
+      </div>
     </section>
-    <section class="section">
-      <h2>Per-component lifecycle scopes</h2>
-      <Lifecycle />
+
+    <section class="tour">
+      {copy({
+        step: "06",
+        title: "Per-component lifecycle",
+        concept:
+          "Every row mounts in its own Effect Scope, so a finalizer registered with Effect.acquireRelease fires when that row's DOM is removed — not when the whole app unmounts. Open devtools and watch the __lifecycle log: a paired unmount:N for every mount:N.",
+        type: "Effect<View, never, never>",
+        code: `yield* Effect.acquireRelease(
+  Effect.sync(() => log(\`mount:\${id}\`)),
+  () => Effect.sync(() => log(\`unmount:\${id}\`)),
+)`,
+        file: "Lifecycle.efx",
+      })}
+      <div class="tour-demo">
+        <span class="demo-label">live</span>
+        <Lifecycle />
+      </div>
     </section>
+
+    <footer class="site-footer">
+      <p>
+        efx is an experimental proof-of-concept.{" "}
+        <a href={REPO} target="_blank" rel="noreferrer">source on GitHub ↗</a>
+      </p>
+    </footer>
   </div>
 )
 
@@ -43,6 +215,10 @@ if (!rootEl) throw new Error("missing #root")
 
 const program = Effect.gen(function* () {
   yield* mount(App, rootEl)
+  // Demo sugar: flash each node as efx re-renders it, so fine-grained
+  // reactivity is visible. Started after mount so the initial render doesn't
+  // flash; later updates (interactions, async resolves) do.
+  yield* Effect.sync(() => flashOnUpdate(rootEl))
   // Keep the scope alive so subscriptions and DOM persist for the page's lifetime.
   yield* Effect.never
 }).pipe(

--- a/apps/demo/src/services.ts
+++ b/apps/demo/src/services.ts
@@ -52,8 +52,9 @@ export const HttpLive: Layer.Layer<Http> = Layer.succeed(
     getUser: (id) =>
       Effect.gen(function* () {
         // Simulate latency — long enough that the loading state is easy to see,
-        // especially after hitting a demo's reset button.
-        yield* Effect.sleep("1200 millis")
+        // especially after hitting a demo's reset button. Kept longer than the
+        // reactivity-flash duration (flash.ts) so the flash blips before content.
+        yield* Effect.sleep("900 millis")
         const user = usersDb[id]
         if (!user) {
           return yield* new HttpError({ status: 404, message: `User ${id} not found` })

--- a/apps/demo/src/services.ts
+++ b/apps/demo/src/services.ts
@@ -54,7 +54,7 @@ export const HttpLive: Layer.Layer<Http> = Layer.succeed(
         // Simulate latency — long enough that the loading state is easy to see,
         // especially after hitting a demo's reset button. Kept longer than the
         // reactivity-flash duration (flash.ts) so the flash blips before content.
-        yield* Effect.sleep("900 millis")
+        yield* Effect.sleep("600 millis")
         const user = usersDb[id]
         if (!user) {
           return yield* new HttpError({ status: 404, message: `User ${id} not found` })

--- a/apps/demo/src/services.ts
+++ b/apps/demo/src/services.ts
@@ -51,8 +51,9 @@ export const HttpLive: Layer.Layer<Http> = Layer.succeed(
   {
     getUser: (id) =>
       Effect.gen(function* () {
-        // Simulate latency
-        yield* Effect.sleep("250 millis")
+        // Simulate latency — long enough that the loading state is easy to see,
+        // especially after hitting a demo's reset button.
+        yield* Effect.sleep("1200 millis")
         const user = usersDb[id]
         if (!user) {
           return yield* new HttpError({ status: 404, message: `User ${id} not found` })

--- a/packages/ts-plugin/test/integration.mjs
+++ b/packages/ts-plugin/test/integration.mjs
@@ -251,11 +251,18 @@ async function main() {
   }
 
   console.log("\n7b. Test go-to-definition on <Counter /> JSX usage...")
-  // Line 16: <Counter />
+  // Locate `<Counter` dynamically so this survives demo edits (the guided-tour
+  // layout moves components around). tsserver positions are 1-based.
+  const mainLines = readFileSync(mainEfx, "utf8").split("\n")
+  const jsxLineIdx = mainLines.findIndex((l) => l.includes("<Counter"))
+  if (jsxLineIdx === -1) throw new Error("could not find <Counter in main.efx")
+  const jsxLine = jsxLineIdx + 1
+  const jsxOffset = mainLines[jsxLineIdx].indexOf("<Counter") + 2 // +1 for 1-based, +1 to land on the 'C'
+  console.log(`   <Counter /> at line ${jsxLine}, offset ${jsxOffset}`)
   const defResponse2 = await client.send("definition", {
     file: mainEfx,
-    line: 16,
-    offset: 8,
+    line: jsxLine,
+    offset: jsxOffset,
   })
   console.log("   Definition response:", JSON.stringify(defResponse2.body, null, 2))
   // Also test on the import to compare

--- a/packages/ts-plugin/test/integration.mjs
+++ b/packages/ts-plugin/test/integration.mjs
@@ -225,61 +225,58 @@ async function main() {
     process.exitCode = 1
   }
 
-  console.log("\n7. Test go-to-definition on Counter import in main.efx...")
+  // Positions are located dynamically (scan for the token) so these survive
+  // demo-layout edits. tsserver positions are 1-based; +1 past `indexOf` lands
+  // on the identifier's first char.
   const mainEfx = join(demoRoot, "src/main.efx")
+  const todosEfx = join(demoRoot, "src/Todos.efx")
   await client.send("open", { file: mainEfx })
-  // Also open Counter.efx so tsserver knows its content
   await client.send("open", { file: counterEfx })
-  // Line 3: import { Counter } from "./Counter"
-  // 'Counter' starts around column 10
+  await client.send("open", { file: todosEfx })
+
+  console.log("\n7. Test cross-file go-to-definition on the Counter import...")
+  // Resolve `Counter` in `import { Counter } from "./Counter.efx"` → Counter.efx.
+  const mainLines = readFileSync(mainEfx, "utf8").split("\n")
+  const importIdx = mainLines.findIndex((l) => l.includes(`from "./Counter.efx"`))
+  if (importIdx === -1) throw new Error("could not find the Counter import in main.efx")
   const defResponse = await client.send("definition", {
     file: mainEfx,
-    line: 3,
-    offset: 10,
+    line: importIdx + 1,
+    offset: mainLines[importIdx].indexOf("Counter") + 1,
   })
-  console.log("   Definition response:", JSON.stringify(defResponse.body, null, 2))
   if (defResponse.body?.length > 0) {
     const def = defResponse.body[0]
     console.log(`   Definition: ${def.file} line ${def.start?.line}`)
-    if (def.file?.endsWith("Counter.efx")) {
-      console.log("   PASS: Go-to-definition works")
-    } else {
-      console.log("   PARTIAL: Definition found but not in .efx file")
-    }
+    console.log(def.file?.endsWith("Counter.efx")
+      ? "   PASS: cross-file go-to-definition works"
+      : "   PARTIAL: Definition found but not in .efx file")
   } else {
     console.log("   FAIL: No definition returned")
   }
 
-  console.log("\n7b. Test go-to-definition on <Counter /> JSX usage...")
-  // Locate `<Counter` dynamically so this survives demo edits (the guided-tour
-  // layout moves components around). tsserver positions are 1-based.
-  const mainLines = readFileSync(mainEfx, "utf8").split("\n")
-  const jsxLineIdx = mainLines.findIndex((l) => l.includes("<Counter"))
-  if (jsxLineIdx === -1) throw new Error("could not find <Counter in main.efx")
-  const jsxLine = jsxLineIdx + 1
-  const jsxOffset = mainLines[jsxLineIdx].indexOf("<Counter") + 2 // +1 for 1-based, +1 to land on the 'C'
-  console.log(`   <Counter /> at line ${jsxLine}, offset ${jsxOffset}`)
+  console.log("\n7b. Test go-to-definition on a <TodoRow /> JSX usage...")
+  // The .efx-specific path: a JSX tag (rewritten to h(TodoRow, …)) must map
+  // back through the source map to the component definition. TodoRow is used
+  // and defined in Todos.efx.
+  const todosLines = readFileSync(todosEfx, "utf8").split("\n")
+  // Match the real JSX usage (`<TodoRow item={item} />`), not the docstring
+  // mention of `<TodoRow />`.
+  const jsxIdx = todosLines.findIndex((l) => l.includes("<TodoRow item"))
+  if (jsxIdx === -1) throw new Error("could not find <TodoRow usage in Todos.efx")
+  const jsxOffset = todosLines[jsxIdx].indexOf("<TodoRow") + 2 // 1-based, land on 'T'
+  console.log(`   <TodoRow /> at line ${jsxIdx + 1}, offset ${jsxOffset}`)
   const defResponse2 = await client.send("definition", {
-    file: mainEfx,
-    line: jsxLine,
+    file: todosEfx,
+    line: jsxIdx + 1,
     offset: jsxOffset,
   })
   console.log("   Definition response:", JSON.stringify(defResponse2.body, null, 2))
-  // Also test on the import to compare
-  const defResponse3 = await client.send("definition", {
-    file: mainEfx,
-    line: 3,
-    offset: 10,
-  })
-  console.log("   Import definition response:", JSON.stringify(defResponse3.body?.[0], null, 2))
   if (defResponse2.body?.length > 0) {
     const def = defResponse2.body[0]
     console.log(`   Definition: ${def.file} line ${def.start?.line}`)
-    if (def.file?.endsWith("Counter.efx")) {
-      console.log("   PASS: JSX go-to-definition works")
-    } else {
-      console.log("   PARTIAL: Definition found but not in .efx file:", def.file)
-    }
+    console.log(def.file?.endsWith("Todos.efx")
+      ? "   PASS: JSX go-to-definition works"
+      : `   PARTIAL: Definition found but not in .efx file: ${def.file}`)
   } else {
     console.log("   FAIL: No definition returned for JSX usage")
   }

--- a/scripts/probe.mjs
+++ b/scripts/probe.mjs
@@ -28,8 +28,8 @@ await runProbe({
     const countAfter3 = await page.locator(".counter .count").innerText()
     console.log("count after 3 clicks:", JSON.stringify(countAfter3))
 
-    // Click reset
-    await page.locator(".counter button").nth(1).click()
+    // Reset via the demo's reset button (recreates the component → count 0)
+    await page.locator('[data-demo="counter"]').locator("..").locator(".demo-refresh").click()
     await page.waitForTimeout(50)
     const countAfterReset = await page.locator(".counter .count").innerText()
     console.log("count after reset:", JSON.stringify(countAfterReset))


### PR DESCRIPTION
## Summary

Turns the demo from a flat feature showcase into a **guided tour** that teaches the framework while demonstrating it, and adds the supporting tooling.

Each primitive gets a two-column section:
- **Left** — a step number, a plain-English concept, the **real inferred `Effect<View, E, R>` type**, a trimmed + syntax-highlighted source snippet, and a "view full source" link.
- **Right** — the running component, with a **↻ reset** button.

A hero up top explains the `.efx` → compiler → fold-types mechanism, and notes that every type shown is checked by `channels.test-d.ts`.

## What's in it

- **Guided tour** (`main.efx`, `index.html`) — hero + six sections. Snippets are trimmed to the essentials (no styling-only classes, no `Cause.pretty`) so they show just the framework usage; the link goes to the full file.
- **Reset per demo** — each demo mounts independently into its own container under a Closeable `Scope`; **reset** tears it down (firing finalizers, cancelling in-flight `Await` fetches) and rebuilds it, so its initial state — loading spinner, count 0, the original list — is visible again. The thesis is enforced per-mount: `setupDemo` constrains a demo's `R` to what `APP_LAYER` provides, so forgetting (say) `HttpLive` is a compile error, not a runtime crash. State lives inside each component so reset truly resets.
- **Syntax highlighting** (`highlight.ts`) — a dependency-free TSX tokenizer; emits tokens rendered as `<span>` View nodes (no `innerHTML`, no new dep). Generics like `collection<Todo>` stay types; closing tags like `failed</p>` highlight.
- **Reactivity flash** (`flash.ts`) — a `MutationObserver` paints a transient overlay over the *exact* node efx re-renders (a text swap flashes the text node, a removal the container), DevTools-style. Page-anchored so it stays put while scrolling. 400ms — shorter than the 600ms simulated fetch latency, so a reset's flash blips before content loads.
- **`refactor(demo)`** — drop `Theme` from `AsyncUserPage` so `Await`'s own `Scope` contribution stands out (`channels.test-d.ts` updated).
- **`chore`** — `.gitattributes` so GitHub/Linguist highlights `.efx` as TSX.
- **`test(ts-plugin)`** — the integration probe locates positions dynamically (cross-file go-to-def via the `Counter` import; JSX go-to-def via `Todos.efx`'s `<TodoRow>`), so it survives demo-layout edits.

## Test plan

- [x] `pnpm -r test` — all suites pass (incl. ts-plugin integration: cross-file + JSX go-to-def)
- [x] `pnpm -r typecheck` — clean; demo 0 errors
- [x] `pnpm --filter @efx/demo build` — succeeds (Vite 8 / Rolldown)
- [x] Browser probes: reset recreates each component (Counter→0, Todos→initial, Lifecycle→2 rows, async shows loading then resolves); flash targets the exact node and is scroll-anchored; snippets highlight with no escaping artifacts; lifecycle teardown fires row finalizers

## Notes

Builds on #47 (the JSX-text-whitespace compiler fix), already on `main`. Once merged, GitHub Pages redeploys with the new tour and Linguist re-highlights `.efx` as TSX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)