### PR TITLE
build: publish verrex + @verrex/ts-plugin to npm (release-please, trusted publishing)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,65 @@
+name: Release
+
+# Driven by conventional commits. On every push to main, release-please
+# opens/updates a "Release PR" (per-package version bumps + CHANGELOGs derived
+# from the commit history). Merging that PR tags the releases, and the publish
+# job below pushes `verrex` and `@verrex/ts-plugin` to npm with provenance.
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
+permissions: {}
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # create the Release PR + tags
+      pull-requests: write # open/update the Release PR
+    outputs:
+      releases_created: ${{ steps.rp.outputs.releases_created }}
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4
+        id: rp
+        with:
+          # A PAT lets the Release PR trigger CI; GITHUB_TOKEN works too, but its
+          # checks must then be re-run manually.
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  publish:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # OIDC trusted publishing + provenance — no NPM_TOKEN needed
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        with:
+          version: 11.3.0
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm -r --filter "./packages/*" build
+      # Tokenless: pnpm exchanges the GitHub OIDC id-token for short-lived npm
+      # credentials. Requires a Trusted Publisher (this repo + this workflow)
+      # configured on each package at npmjs.com — see AGENTS.md "Releasing".
+      - name: Publish to npm (trusted publishing + provenance)
+        run: pnpm -r publish --provenance --access public --no-git-checks

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,4 @@
+{
+  "packages/verrex": "0.0.0",
+  "packages/ts-plugin": "0.0.0"
+}

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "packages/verrex": "0.0.0",
-  "packages/ts-plugin": "0.0.0"
+  "packages/verrex": "0.1.0",
+  "packages/ts-plugin": "0.1.0"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,10 +208,17 @@ the publish job pushes to npm.
   (`verrex-v…`, `@verrex/ts-plugin-v…`).
 - **Still pre-1.0:** `bump-minor-pre-major` + `bump-patch-for-minor-pre-major`
   keep `feat`→minor / `fix`→patch *within* 0.x until you cut a 1.0.
-- **Tokenless publish:** OIDC trusted publishing + provenance, no `NPM_TOKEN`.
-  Requires a Trusted Publisher (this repo + `release.yml`) configured per
-  package at npmjs.com. `minimumReleaseAge` still applies to *our* installs —
-  never bypass it.
+- **Tokenless publish:** OIDC trusted publishing, no `NPM_TOKEN`. Provenance is
+  turned on by the `--provenance` flag in `release.yml` (deliberately *not* in
+  `publishConfig`, so a one-time local bootstrap publish doesn't try to attest
+  outside CI and fail). Requires a Trusted Publisher (this repo + `release.yml`)
+  configured per package at npmjs.com. `minimumReleaseAge` still applies to
+  *our* installs — never bypass it.
+- **First publish (bootstrap):** trusted publishing needs the package to exist
+  on npm first, so the very first version of each package is published manually
+  (`pnpm --filter <pkg> publish --access public`) — no provenance on that one.
+  Configure the Trusted Publisher afterward; every release from then on is
+  tokenless CI with provenance.
 - **go-to-definition lands in source.** Each publishable package keeps its
   dev `exports` pointing at `src/*` (what the workspace and editors resolve,
   so go-to-def jumps into `.ts`), and a `publishConfig.exports` override

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,6 +188,41 @@ UI changes especially require the dev server pass — type checks
 catch contract regressions but not "the click handler didn't
 re-render."
 
+## Releasing
+
+Two packages publish to npm — **`verrex`** and **`@verrex/ts-plugin`** —
+driven by conventional commits via release-please
+(`release-please-config.json` + `.release-please-manifest.json`,
+`.github/workflows/release.yml`). On every push to `main`, release-please
+opens/updates one combined **Release PR**; merging it tags the releases and
+the publish job pushes to npm.
+
+- **A commit bumps a package by the path of the files it changes, not by the
+  commit scope.** Files under `packages/verrex/**` bump `verrex`; files under
+  `packages/ts-plugin/**` bump `@verrex/ts-plugin`; a commit spanning both
+  bumps both; a commit touching neither (root, `apps/demo/`, `.github/`, docs)
+  releases nothing. The `(scope)` in `feat(compiler):` is changelog-cosmetic
+  only — keep a commit's edits inside one package dir to bump just that one.
+- **Versions are independent** (no linked-versions plugin) — each package
+  bumps off its own commits and carries its own CHANGELOG + tag
+  (`verrex-v…`, `@verrex/ts-plugin-v…`).
+- **Still pre-1.0:** `bump-minor-pre-major` + `bump-patch-for-minor-pre-major`
+  keep `feat`→minor / `fix`→patch *within* 0.x until you cut a 1.0.
+- **Tokenless publish:** OIDC trusted publishing + provenance, no `NPM_TOKEN`.
+  Requires a Trusted Publisher (this repo + `release.yml`) configured per
+  package at npmjs.com. `minimumReleaseAge` still applies to *our* installs —
+  never bypass it.
+- **go-to-definition lands in source.** Each publishable package keeps its
+  dev `exports` pointing at `src/*` (what the workspace and editors resolve,
+  so go-to-def jumps into `.ts`), and a `publishConfig.exports` override
+  repoints every subpath to `dist/*` at publish time. The tarball ships
+  **both** `dist` and `src` plus declaration maps (`declarationMap` +
+  `sourceMap`), so a consumer's go-to-def resolves through `.d.ts.map` into the
+  shipped `.ts`. `verrex` builds via `tsc -p tsconfig.build.json`
+  (`rewriteRelativeImportExtensions` turns `./x.ts` imports into `./x.js`);
+  `@verrex/ts-plugin` is the esbuild bundle (`dist/index.cjs`), so it ships
+  `dist` only.
+
 ## Reference docs (outlinks)
 
 - [`README.md`](./README.md) — public-facing intro + editor setup.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Mathieu Post
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,19 @@ On Nix, `nix develop` drops you into a shell with Node, Corepack (for
 `pnpm` via the `packageManager` field), and Chromium (with `VERREX_CHROMIUM`
 pre-exported for the probe scripts).
 
+## Install
+
+```bash
+pnpm add verrex effect            # the framework (effect is a peer dependency)
+pnpm add -D @verrex/ts-plugin     # editor support for .vx files (see below)
+```
+
+`verrex` ships its compiled `dist` alongside the original `src` with declaration
+maps, so go-to-definition jumps straight into the framework's TypeScript source.
+Releases are cut from conventional commits (release-please) and published to npm
+with provenance. It's `0.x` and experimental — expect breaking changes between
+minor versions.
+
 ## Smallest possible example
 
 ```tsx

--- a/packages/ts-plugin/README.md
+++ b/packages/ts-plugin/README.md
@@ -1,0 +1,42 @@
+# @verrex/ts-plugin
+
+The Volar-based TypeScript Language Service plugin for [verrex](https://github.com/m9tdev/verrex)'s
+`.vx` files: diagnostics, hover, go-to-definition, find-references, inlay
+hints, and JSX tag-pair highlights — full editor support for the angle-bracket
+syntax verrex compiles into `h()` calls.
+
+> Status: proof-of-concept, `0.x`, not for production.
+
+## Install
+
+```bash
+pnpm add -D @verrex/ts-plugin
+```
+
+## Setup
+
+Add it to your `tsconfig.json` and tell your editor to treat `.vx` as
+TypeScript:
+
+```jsonc
+// tsconfig.json
+{
+  "compilerOptions": {
+    "plugins": [{ "name": "@verrex/ts-plugin" }]
+  }
+}
+```
+
+- **VS Code:** run "TypeScript: Select TypeScript Version → Use Workspace
+  Version" so the editor's TS server loads the plugin.
+- **Neovim:** `autocmd BufRead,BufNewFile *.vx setfiletype typescriptreact`
+  (plus `tsserver` configured for `typescriptreact`).
+
+The plugin ships as a single bundled `dist/index.cjs` that tsserver loads via
+`require()`.
+
+Full docs: **https://github.com/m9tdev/verrex**
+
+## License
+
+MIT © Mathieu Post

--- a/packages/ts-plugin/package.json
+++ b/packages/ts-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verrex/ts-plugin",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Volar-based TypeScript Language Service plugin for .vx files — diagnostics, hover, go-to-definition, find-references, inlay hints, and JSX tag-pair highlights.",
   "license": "MIT",
   "author": "Mathieu Post",

--- a/packages/ts-plugin/package.json
+++ b/packages/ts-plugin/package.json
@@ -15,11 +15,11 @@
   "main": "./dist/index.cjs",
   "files": ["dist"],
   "publishConfig": {
-    "access": "public",
-    "provenance": true
+    "access": "public"
   },
   "scripts": {
     "build": "node build.mjs",
+    "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "test": "vitest run && pnpm run build && node test/integration.mjs"
   },

--- a/packages/ts-plugin/package.json
+++ b/packages/ts-plugin/package.json
@@ -1,8 +1,23 @@
 {
   "name": "@verrex/ts-plugin",
   "version": "0.0.0",
-  "private": true,
+  "description": "Volar-based TypeScript Language Service plugin for .vx files — diagnostics, hover, go-to-definition, find-references, inlay hints, and JSX tag-pair highlights.",
+  "license": "MIT",
+  "author": "Mathieu Post",
+  "homepage": "https://github.com/m9tdev/verrex#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/m9tdev/verrex.git",
+    "directory": "packages/ts-plugin"
+  },
+  "bugs": "https://github.com/m9tdev/verrex/issues",
+  "keywords": ["effect", "verrex", "vx", "typescript", "language-service-plugin", "volar"],
   "main": "./dist/index.cjs",
+  "files": ["dist"],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "scripts": {
     "build": "node build.mjs",
     "typecheck": "tsc --noEmit",

--- a/packages/verrex/README.md
+++ b/packages/verrex/README.md
@@ -1,0 +1,58 @@
+# verrex
+
+An experimental TypeScript UI framework where Effect's `<A, E, R>` channels
+propagate from every leaf of the view tree to the root. Forgetting to provide
+a service `Layer` becomes a **compile-time error that names the missing
+service**.
+
+The name carries the channels of an `Effect<View, E, R>` — **V** (View, the
+`A`), **E** (Error), **R** (Requirements) — plus **X** for the JSX/TSX it
+borrows: `V + E + R + X` → **verrex** (and the `.vx` source extension).
+
+> Status: proof-of-concept, `0.x`, not for production. Expect breaking changes
+> between minor versions.
+
+## Install
+
+```bash
+pnpm add verrex effect            # effect is a peer dependency
+pnpm add -D @verrex/ts-plugin     # editor support for .vx files
+```
+
+## Example
+
+```tsx
+// Counter.vx
+import { Effect } from "effect"
+import { AtomRef } from "effect/unstable/reactivity"
+
+export const Counter = Effect.fn("Counter")(function* (_props: {} = {}) {
+  const count = AtomRef.make(0)
+  return yield* (
+    <div>
+      <button onclick={() => count.update((n) => n + 1)}>+</button>
+      <span> {count} clicks </span>
+    </div>
+  )
+})
+```
+
+## Subpath exports
+
+| Import | What you get |
+|---|---|
+| `verrex` | `h`, `mount`, `Await`, `list`, `Fragment`, `View`, `VerrexLive` |
+| `verrex/vite` | Vite plugin that compiles `.vx` |
+| `verrex/check` (+ `verrex-check` bin) | `.vx`-aware type-checker (replaces `tsc --noEmit`) |
+| `verrex/compiler`, `verrex/language`, `verrex/testing` | compiler, Volar language plugin, test harness |
+
+`verrex` ships its compiled `dist` alongside the original `src` with
+declaration maps, so go-to-definition lands in the framework's TypeScript
+source.
+
+Full docs, architecture, and the live demo:
+**https://github.com/m9tdev/verrex**
+
+## License
+
+MIT © Mathieu Post

--- a/packages/verrex/package.json
+++ b/packages/verrex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "verrex",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "An Effect-native UI framework where Effect's <A, E, R> channels propagate from every leaf of the view tree to the root — a forgotten Layer becomes a compile-time error that names the missing service.",
   "license": "MIT",
   "author": "Mathieu Post",

--- a/packages/verrex/package.json
+++ b/packages/verrex/package.json
@@ -1,25 +1,88 @@
 {
   "name": "verrex",
   "version": "0.0.0",
-  "private": true,
+  "description": "An Effect-native UI framework where Effect's <A, E, R> channels propagate from every leaf of the view tree to the root — a forgotten Layer becomes a compile-time error that names the missing service.",
+  "license": "MIT",
+  "author": "Mathieu Post",
+  "homepage": "https://github.com/m9tdev/verrex#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/m9tdev/verrex.git",
+    "directory": "packages/verrex"
+  },
+  "bugs": "https://github.com/m9tdev/verrex/issues",
+  "keywords": ["effect", "ui", "framework", "jsx", "reactivity", "verrex", "vx"],
   "type": "module",
+  "sideEffects": false,
   "exports": {
-    ".": "./src/runtime/index.ts",
-    "./compiler": "./src/compiler/index.ts",
-    "./language": "./src/language/index.ts",
-    "./vite": "./src/vite-plugin/index.ts",
-    "./testing": "./src/testing/index.ts",
-    "./check": "./src/check/index.ts"
+    ".": {
+      "types": "./src/runtime/index.ts",
+      "default": "./src/runtime/index.ts"
+    },
+    "./compiler": {
+      "types": "./src/compiler/index.ts",
+      "default": "./src/compiler/index.ts"
+    },
+    "./language": {
+      "types": "./src/language/index.ts",
+      "default": "./src/language/index.ts"
+    },
+    "./vite": {
+      "types": "./src/vite-plugin/index.ts",
+      "default": "./src/vite-plugin/index.ts"
+    },
+    "./testing": {
+      "types": "./src/testing/index.ts",
+      "default": "./src/testing/index.ts"
+    },
+    "./check": {
+      "types": "./src/check/index.ts",
+      "default": "./src/check/index.ts"
+    }
   },
   "bin": {
     "verrex-check": "./src/check/cli.ts"
   },
+  "files": ["dist", "src", "!**/*.test.ts", "!**/*.test-d.ts"],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true,
+    "exports": {
+      ".": {
+        "types": "./dist/runtime/index.d.ts",
+        "default": "./dist/runtime/index.js"
+      },
+      "./compiler": {
+        "types": "./dist/compiler/index.d.ts",
+        "default": "./dist/compiler/index.js"
+      },
+      "./language": {
+        "types": "./dist/language/index.d.ts",
+        "default": "./dist/language/index.js"
+      },
+      "./vite": {
+        "types": "./dist/vite-plugin/index.d.ts",
+        "default": "./dist/vite-plugin/index.js"
+      },
+      "./testing": {
+        "types": "./dist/testing/index.d.ts",
+        "default": "./dist/testing/index.js"
+      },
+      "./check": {
+        "types": "./dist/check/index.d.ts",
+        "default": "./dist/check/index.js"
+      }
+    },
+    "bin": {
+      "verrex-check": "./dist/check/cli.js"
+    }
+  },
   "scripts": {
+    "build": "rm -rf dist && tsc -p tsconfig.build.json",
     "typecheck": "tsc --noEmit",
     "test": "vitest run && node --experimental-strip-types test/check/integration.mjs"
   },
   "dependencies": {
-    "effect": "4.0.0-beta.71",
     "@babel/parser": "^7.29.7",
     "@babel/traverse": "^7.29.7",
     "@babel/generator": "^7.29.7",
@@ -33,6 +96,7 @@
     "vscode-uri": "^3.1.0"
   },
   "peerDependencies": {
+    "effect": "4.0.0-beta.71",
     "typescript": "^6.0.3",
     "vite": "^8.0.16"
   },
@@ -41,6 +105,7 @@
     "vite": { "optional": true }
   },
   "devDependencies": {
+    "effect": "4.0.0-beta.71",
     "@effect/vitest": "4.0.0-beta.71",
     "@types/babel__generator": "^7",
     "@types/babel__traverse": "^7",

--- a/packages/verrex/package.json
+++ b/packages/verrex/package.json
@@ -43,10 +43,9 @@
   "bin": {
     "verrex-check": "./src/check/cli.ts"
   },
-  "files": ["dist", "src", "!**/*.test.ts", "!**/*.test-d.ts"],
+  "files": ["dist", "src", "!**/*.test.ts", "!**/*.test-d.ts", "!**/AGENTS.md"],
   "publishConfig": {
     "access": "public",
-    "provenance": true,
     "exports": {
       ".": {
         "types": "./dist/runtime/index.d.ts",
@@ -79,6 +78,7 @@
   },
   "scripts": {
     "build": "rm -rf dist && tsc -p tsconfig.build.json",
+    "prepack": "pnpm run build",
     "typecheck": "tsc --noEmit",
     "test": "vitest run && node --experimental-strip-types test/check/integration.mjs"
   },

--- a/packages/verrex/tsconfig.build.json
+++ b/packages/verrex/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "rewriteRelativeImportExtensions": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "exclude": ["src/**/*.test.ts", "src/**/*.test-d.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,9 +87,6 @@ importers:
       '@volar/source-map':
         specifier: ^2.4.28
         version: 2.4.28
-      effect:
-        specifier: 4.0.0-beta.71
-        version: 4.0.0-beta.71
       volar-service-typescript:
         specifier: ^0.0.71
         version: 0.0.71(@volar/language-service@2.4.28)
@@ -106,6 +103,9 @@ importers:
       '@types/babel__traverse':
         specifier: ^7
         version: 7.28.0
+      effect:
+        specifier: 4.0.0-beta.71
+        version: 4.0.0-beta.71
       happy-dom:
         specifier: ^20.9.0
         version: 20.9.0

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "release-type": "node",
+  "separate-pull-requests": false,
+  "include-component-in-tag": true,
+  "bump-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": true,
+  "packages": {
+    "packages/verrex": {},
+    "packages/ts-plugin": {}
+  }
+}


### PR DESCRIPTION
Wires up npm publishing for the consolidated **verrex** structure (rebuilt on top of #51 — the old `@m9tdev/efx-*` version of this branch targeted the pre-consolidation 7-package layout and was reset).

Two packages publish: **`verrex`** and **`@verrex/ts-plugin`**. Nothing publishes on merge — this only installs the machinery; the first npm push happens later when the release-please **Release PR** is merged.

## Releases: conventional commits → release-please
- `release-please-config.json` + `.release-please-manifest.json` + `.github/workflows/release.yml`.
- On push to `main`, release-please opens/updates **one combined Release PR** (per-package version bumps + CHANGELOGs).
- **Independent versions** (no linked-versions) — each package bumps off its own commits and carries its own tag (`verrex-v…`, `@verrex/ts-plugin-v…`).
- **A commit bumps a package by the path of its changed files**, not the commit scope: `packages/verrex/**` → `verrex`, `packages/ts-plugin/**` → `@verrex/ts-plugin`, both → both, neither (root / `apps/demo` / `.github` / docs) → no release.
- Pre-1.0: `bump-minor-pre-major` + `bump-patch-for-minor-pre-major` keep `feat`→minor / `fix`→patch within `0.x`.

## Publishing: tokenless + provenance
- OIDC **trusted publishing** — no `NPM_TOKEN`. `id-token: write`, `pnpm publish --provenance`.
- Requires a Trusted Publisher (this repo + `release.yml`) configured per package at npmjs.com.
- Supply-chain hardening kept: `harden-runner`, SHA-pinned actions, `pnpm install --frozen-lockfile`. `minimumReleaseAge` untouched.

## Publishable package shape (go-to-def into source)
- Dev `exports` point at `src/*` (workspace + editors resolve source, so go-to-def lands in `.ts`); `publishConfig.exports` override each subpath to `dist/*` at publish time.
- Tarball ships **both** `dist` and `src` + declaration maps (`declarationMap` + `sourceMap`), so a consumer's go-to-def resolves through `.d.ts.map` into the shipped `.ts`.
- `verrex` builds via `tsc -p tsconfig.build.json` (`rewriteRelativeImportExtensions` rewrites `./x.ts` → `./x.js`); `effect` becomes a peer dependency.
- `@verrex/ts-plugin` is the esbuild bundle (`dist/index.cjs`), ships `dist` only.
- MIT `LICENSE` added.

## Verified
- [x] `pnpm --filter verrex build` + `@verrex/ts-plugin build` — clean; all 6 verrex subpaths emit `index.js` + `.d.ts` + `.d.ts.map`; `verrex-check` shebang preserved.
- [x] `pnpm pack` (publishConfig applied): exports/bin → `dist/*`, ships dist + 18 `.ts` source files, **no test files leaked**, no `private`. ts-plugin → `dist/index.cjs` only.
- [x] `pnpm -r typecheck` — 0 errors (demo 11 files). `dist` is gitignored.
- [x] `pnpm -r test` — verrex 156, check integration, `@verrex/ts-plugin` 31 + go-to-def/find-refs probes — all pass.

## Follow-up (out of band, on npmjs.com)
- Create each package on npm and configure its Trusted Publisher (repo `m9tdev/verrex`, workflow `release.yml`) before the first Release PR is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
