### PR TITLE
refactor: publish the core package as @verrex/core

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ fatal.
 So this project deliberately **never lets `tsc` see JSX**:
 
 1. Source files use a custom `.vx` extension.
-2. `verrex/compiler` (Babel-based) rewrites every JSX node into an
+2. `@verrex/core/compiler` (Babel-based) rewrites every JSX node into an
    `h(tag, props, ...children)` call **before** tsc sees the file.
 3. `h()`'s generic signature in `verrex` uses conditional
    types (`FoldE`/`FoldR`) to union every child's `E` and `R` into
@@ -75,32 +75,32 @@ subpath export per surface (the subdirs self-reference via `verrex/*`). The
 editor plugin is the one separate package, because tsserver resolves Language
 Service plugins only by bare package name.
 
-- **[`src/runtime/`](./packages/verrex/src/runtime/AGENTS.md)** — export `verrex`. `h`,
+- **[`src/runtime/`](./packages/verrex/src/runtime/AGENTS.md)** — export `@verrex/core`. `h`,
   `mount`, `Await`, `list`, the View IR (mount switches on it), reactivity
   wiring, channel-fold types. The thing components import from.
 - **[`src/compiler/`](./packages/verrex/src/compiler/AGENTS.md)** — export
-  `verrex/compiler`. The Babel transform: JSX → `h()`, `.value` → `h.read()`,
+  `@verrex/core/compiler`. The Babel transform: JSX → `h()`, `.value` → `h.read()`,
   `<expr>.value.map(arrow → JSX)` → `list(<expr>, arrow)`. Smart-skip wrap.
 - **[`src/language/`](./packages/verrex/src/language/AGENTS.md)** — export
-  `verrex/language`. The Volar `LanguagePlugin` describing `.vx` files (file id,
+  `@verrex/core/language`. The Volar `LanguagePlugin` describing `.vx` files (file id,
   virtual code, source-map conversion, JSX region tagging). Bridges
-  `verrex/compiler` to Volar's contracts; consumed by the ts-plugin and check.
-- **[`src/check/`](./packages/verrex/src/check/AGENTS.md)** — export `verrex/check`, bin
+  `@verrex/core/compiler` to Volar's contracts; consumed by the ts-plugin and check.
+- **[`src/check/`](./packages/verrex/src/check/AGENTS.md)** — export `@verrex/core/check`, bin
   `verrex-check`. Standalone CLI/programmatic type-checker on `@volar/kit` +
   the language plugin. Replaces `tsc --noEmit` for `.vx`.
 - **[`src/vite-plugin/`](./packages/verrex/src/vite-plugin/AGENTS.md)** — export
-  `verrex/vite`. Owns the full `.vx` compile (Babel JSX→`h()`, then Oxc
+  `@verrex/core/vite`. Owns the full `.vx` compile (Babel JSX→`h()`, then Oxc
   type-strip via `transformWithOxc`, `moduleType: "js"`); rewrites `.vx` URLs
   with `?import` so strict-MIME browsers accept the response.
 - **[`src/testing/`](./packages/verrex/src/testing/AGENTS.md)** — export
-  `verrex/testing`. In-process component test harness; `render(app, layer?)`
+  `@verrex/core/testing`. In-process component test harness; `render(app, layer?)`
   mounts into a happy-dom DOM and drives it. The `layer` requirement is
   type-enforced so a missing service is a compile error.
 - **[`packages/ts-plugin/`](./packages/ts-plugin/AGENTS.md)** (publishes as
   `@verrex/ts-plugin`) — the Volar-based TS Language Service plugin (editor
   integration): JSX tag-pair
   highlights, inlay-hint filtering, reference dedup/sort, native cross-file
-  go-to-def. esbuild-bundles `verrex/language` into one CJS file.
+  go-to-def. esbuild-bundles `@verrex/core/language` into one CJS file.
 - **[`apps/demo/`](./apps/demo/AGENTS.md)** — usage patterns by primitive; home
   to `channels.test-d.ts`, the compile-time proof.
 - **[`scripts/`](./scripts/AGENTS.md)** — manual Playwright probes
@@ -126,9 +126,9 @@ Service plugins only by bare package name.
   alongside Effect, you're probably on the wrong side of this
   line.
 - **`.vx` files never reach `tsc` directly.** A plugin always
-  intercepts: `verrex/language` (consumed by the TS plugin and by
-  `verrex/check`) hands tsc a JSX-free virtual TS buffer, and
-  `verrex/vite` does the same for Vite. Source files keep
+  intercepts: `@verrex/core/language` (consumed by the TS plugin and by
+  `@verrex/core/check`) hands tsc a JSX-free virtual TS buffer, and
+  `@verrex/core/vite` does the same for Vite. Source files keep
   their angle brackets; only the compiled buffer is JSX-free.
 - **Imports of `.vx` files use the explicit `.vx` extension.**
   `import { X } from "./Foo.vx"` — not `"./Foo"`. TS's resolver
@@ -159,7 +159,7 @@ Service plugins only by bare package name.
 
 ## Tooling at a glance
 
-- pnpm workspace, 2 packages (`verrex` + `@verrex/ts-plugin`) + demo + workspace root.
+- pnpm workspace, 2 packages (`@verrex/core` + `@verrex/ts-plugin`) + demo + workspace root.
 - Effect v4 / `effect-smol` (currently `effect@4.0.0-beta.71`).
 - Vitest — compiler tests use plain `vitest`; runtime channel-fold
   type-tests via `expectTypeOf` at typecheck time.
@@ -180,7 +180,7 @@ Service plugins only by bare package name.
 ```
 pnpm -r test         # compiler tests + ts-plugin integration tests
 pnpm -r typecheck    # fans out: every package runs `tsc --noEmit`,
-                     # apps/demo runs `verrex/check` (the .vx-aware checker)
+                     # apps/demo runs `@verrex/core/check` (the .vx-aware checker)
 pnpm --filter verrex-demo dev   # browser-test interactive features
 ```
 
@@ -190,7 +190,7 @@ re-render."
 
 ## Releasing
 
-Two packages publish to npm — **`verrex`** and **`@verrex/ts-plugin`** —
+Two packages publish to npm — **`@verrex/core`** and **`@verrex/ts-plugin`** —
 driven by conventional commits via release-please
 (`release-please-config.json` + `.release-please-manifest.json`,
 `.github/workflows/release.yml`). On every push to `main`, release-please
@@ -198,14 +198,14 @@ opens/updates one combined **Release PR**; merging it tags the releases and
 the publish job pushes to npm.
 
 - **A commit bumps a package by the path of the files it changes, not by the
-  commit scope.** Files under `packages/verrex/**` bump `verrex`; files under
+  commit scope.** Files under `packages/verrex/**` bump `@verrex/core`; files under
   `packages/ts-plugin/**` bump `@verrex/ts-plugin`; a commit spanning both
   bumps both; a commit touching neither (root, `apps/demo/`, `.github/`, docs)
   releases nothing. The `(scope)` in `feat(compiler):` is changelog-cosmetic
   only — keep a commit's edits inside one package dir to bump just that one.
 - **Versions are independent** (no linked-versions plugin) — each package
   bumps off its own commits and carries its own CHANGELOG + tag
-  (`verrex-v…`, `@verrex/ts-plugin-v…`).
+  (`@verrex/core-v…`, `@verrex/ts-plugin-v…`).
 - **Still pre-1.0:** `bump-minor-pre-major` + `bump-patch-for-minor-pre-major`
   keep `feat`→minor / `fix`→patch *within* 0.x until you cut a 1.0.
 - **Tokenless publish:** OIDC trusted publishing, no `NPM_TOKEN`. Provenance is
@@ -225,7 +225,7 @@ the publish job pushes to npm.
   repoints every subpath to `dist/*` at publish time. The tarball ships
   **both** `dist` and `src` plus declaration maps (`declarationMap` +
   `sourceMap`), so a consumer's go-to-def resolves through `.d.ts.map` into the
-  shipped `.ts`. `verrex` builds via `tsc -p tsconfig.build.json`
+  shipped `.ts`. `@verrex/core` builds via `tsc -p tsconfig.build.json`
   (`rewriteRelativeImportExtensions` turns `./x.ts` imports into `./x.js`);
   `@verrex/ts-plugin` is the esbuild bundle (`dist/index.cjs`), so it ships
   `dist` only.

--- a/README.md
+++ b/README.md
@@ -67,11 +67,11 @@ pre-exported for the probe scripts).
 ## Install
 
 ```bash
-pnpm add verrex effect            # the framework (effect is a peer dependency)
+pnpm add @verrex/core effect            # the framework (effect is a peer dependency)
 pnpm add -D @verrex/ts-plugin     # editor support for .vx files (see below)
 ```
 
-`verrex` ships its compiled `dist` alongside the original `src` with declaration
+`@verrex/core` ships its compiled `dist` alongside the original `src` with declaration
 maps, so go-to-definition jumps straight into the framework's TypeScript source.
 Releases are cut from conventional commits (release-please) and published to npm
 with provenance. It's `0.x` and experimental — expect breaking changes between
@@ -99,7 +99,7 @@ export const Counter = Effect.fn("Counter")(function* (_props: {} = {}) {
 ```ts
 // main.vx
 import { Effect, Layer } from "effect"
-import { VerrexLive, mount } from "verrex"
+import { VerrexLive, mount } from "@verrex/core"
 import { Counter } from "./Counter.vx"
 
 const program = Effect.gen(function* () {
@@ -118,12 +118,12 @@ Effect.runFork(program)
 ```
 packages/
   verrex/             one package, subpath exports:
-    src/runtime/        export `verrex`     — View IR, h(), mount(), Await(), list()
-    src/compiler/       export `verrex/compiler` — .vx → plain TypeScript (Babel)
-    src/language/       export `verrex/language` — Volar language plugin
-    src/check/          export `verrex/check`, bin `verrex-check`
-    src/vite-plugin/    export `verrex/vite`  — Vite integration
-    src/testing/        export `verrex/testing`
+    src/runtime/        export `@verrex/core`     — View IR, h(), mount(), Await(), list()
+    src/compiler/       export `@verrex/core/compiler` — .vx → plain TypeScript (Babel)
+    src/language/       export `@verrex/core/language` — Volar language plugin
+    src/check/          export `@verrex/core/check`, bin `verrex-check`
+    src/vite-plugin/    export `@verrex/core/vite`  — Vite integration
+    src/testing/        export `@verrex/core/testing`
   ts-plugin/   publishes as `@verrex/ts-plugin` — TS Language Service plugin (editor)
 apps/
   demo/               Counter, UserPage, AsyncUserPage, LiveUser, Todos, Lifecycle
@@ -133,7 +133,7 @@ apps/
 
 | You import from      | What you get                                                                              |
 |----------------------|-------------------------------------------------------------------------------------------|
-| `verrex`      | `h`, `mount`, `Await`, `list`, `Fragment`, `View`, `VerrexLive`                             |
+| `@verrex/core`      | `h`, `mount`, `Await`, `list`, `Fragment`, `View`, `VerrexLive`                             |
 | `effect`             | `Effect`, `Layer`, `Context.Service`, `Data.TaggedError`, `Cause`, `Option`, `Result`, …  |
 | `effect/unstable/reactivity` | `AtomRef`, `Atom`, `AtomRegistry`, `AsyncResult`                                  |
 
@@ -147,9 +147,9 @@ JSX expression is automatically wrapped in a tracking scope.
 | Command            | What it does                                                  |
 |--------------------|---------------------------------------------------------------|
 | `pnpm dev`         | Vite dev server with HMR on `.vx` files                      |
-| `pnpm typecheck`   | Per-package `tsc --noEmit`; apps/demo uses `verrex/check` (.vx-aware) |
-| `pnpm build`       | Production build via Vite (`verrex/vite` owns the transform) |
-| `pnpm test`        | All package suites — compiler, runtime, language, vite-plugin, testing, ts-plugin (incl. its tsserver integration probe) + `verrex/check` |
+| `pnpm typecheck`   | Per-package `tsc --noEmit`; apps/demo uses `@verrex/core/check` (.vx-aware) |
+| `pnpm build`       | Production build via Vite (`@verrex/core/vite` owns the transform) |
+| `pnpm test`        | All package suites — compiler, runtime, language, vite-plugin, testing, ts-plugin (incl. its tsserver integration probe) + `@verrex/core/check` |
 
 ## Bundle size
 
@@ -170,8 +170,8 @@ and their mock services. Verified interactive after build — Counter increments
 the `Await` boundaries load then resolve, Todos add/remove/toggle, Lifecycle's
 per-row scope fires releases on row removal.
 
-Vite serves `.vx` files directly through `verrex/vite` at dev time;
-type-checking goes through `verrex/check`, which feeds `.vx` to tsc as virtual
+Vite serves `.vx` files directly through `@verrex/core/vite` at dev time;
+type-checking goes through `@verrex/core/check`, which feeds `.vx` to tsc as virtual
 TypeScript via the shared Volar language plugin. No sibling `.ts` files are
 emitted to disk.
 

--- a/apps/demo/AGENTS.md
+++ b/apps/demo/AGENTS.md
@@ -26,14 +26,14 @@ they can be exercised in a browser side-by-side.
 Cross-file `.vx` imports carry an explicit `.vx` extension (see
 the root [AGENTS.md](../../AGENTS.md) invariant). As a result
 nothing in this demo's build pipeline emits sibling `.ts` files:
-`pnpm typecheck` runs [`verrex/check`](../../packages/verrex/src/check/AGENTS.md)
+`pnpm typecheck` runs [`@verrex/core/check`](../../packages/verrex/src/check/AGENTS.md)
 directly, `vite build` runs
-[`verrex/vite`](../../packages/verrex/src/vite-plugin/AGENTS.md)
+[`@verrex/core/vite`](../../packages/verrex/src/vite-plugin/AGENTS.md)
 directly, and the editor's
 [TS plugin](../../packages/ts-plugin/AGENTS.md) maps virtual-code
 results back to source `.vx` positions natively. (An earlier
 demo build script ran an `verrex-compile` CLI that emitted sibling
-`.ts` files for tsc to pick up — `verrex/compiler` itself was, and
+`.ts` files for tsc to pick up — `@verrex/core/compiler` itself was, and
 still is, a pure in-memory `transformVerrex`. The CLI is gone.)
 
 ## `channels.test-d.ts`
@@ -64,7 +64,7 @@ purely a typing assertion.
 ## Vite dev server
 
 `vite.config.ts` is intentionally minimal — it wires
-`verrex/vite`. The plugin's `configureServer` middleware adds
+`@verrex/core/vite`. The plugin's `configureServer` middleware adds
 `?import` to any `.vx` URL so Vite treats it as a module rather
 than serving raw text on direct GET. Don't add a separate
 filename-rewrite shim; the plugin already handles it.

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -10,7 +10,7 @@
     "typecheck": "node --experimental-strip-types ../../packages/verrex/src/check/cli.ts"
   },
   "dependencies": {
-    "verrex": "workspace:*",
+    "@verrex/core": "workspace:*",
     "effect": "4.0.0-beta.71"
   },
   "devDependencies": {

--- a/apps/demo/src/AsyncUserPage.vx
+++ b/apps/demo/src/AsyncUserPage.vx
@@ -1,5 +1,5 @@
 import { Cause, Effect } from "effect"
-import { Await } from "verrex"
+import { Await } from "@verrex/core"
 import { Http } from "./services.ts"
 
 /**

--- a/apps/demo/src/LiveUser.vx
+++ b/apps/demo/src/LiveUser.vx
@@ -1,6 +1,6 @@
 import { Cause, Effect } from "effect"
 import { AtomRef } from "effect/unstable/reactivity"
-import { Await } from "verrex"
+import { Await } from "@verrex/core"
 import { Http } from "./services.ts"
 
 /**

--- a/apps/demo/src/channels.test-d.ts
+++ b/apps/demo/src/channels.test-d.ts
@@ -6,7 +6,7 @@
  */
 import type { Chunk, Effect, Option, Result, Scope } from "effect"
 import type { AtomRegistry } from "effect/unstable/reactivity"
-import { h, type View } from "verrex"
+import { h, type View } from "@verrex/core"
 import { AsyncUserPage } from "./AsyncUserPage.vx"
 import { Counter } from "./Counter.vx"
 import { LiveUser } from "./LiveUser.vx"

--- a/apps/demo/src/main.vx
+++ b/apps/demo/src/main.vx
@@ -1,6 +1,6 @@
 import { Cause, Effect, Exit, Fiber, Layer, Scope } from "effect"
 import { AtomRegistry } from "effect/unstable/reactivity"
-import { VerrexLive, mount, type View } from "verrex"
+import { VerrexLive, mount, type View } from "@verrex/core"
 import { Counter } from "./Counter.vx"
 import { AsyncUserPage } from "./AsyncUserPage.vx"
 import { flashOnUpdate } from "./flash.ts"

--- a/apps/demo/vite.config.ts
+++ b/apps/demo/vite.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from "vite"
-import { verrex } from "verrex/vite"
+import { verrex } from "@verrex/core/vite"
 
 export default defineConfig({
   root: ".",

--- a/packages/ts-plugin/AGENTS.md
+++ b/packages/ts-plugin/AGENTS.md
@@ -11,7 +11,7 @@ heavy lifting (file discovery, content transformation, position
 mapping) and wrap the resulting LanguageService with a thin proxy
 for the things Volar doesn't quite do out of the box.
 
-After the `verrex/language` extraction this package contains only the
+After the `@verrex/core/language` extraction this package contains only the
 tsserver-facing pieces; esbuild bundles them into `dist/index.cjs`
 for tsserver to `require()`.
 
@@ -32,8 +32,8 @@ for tsserver to `require()`.
 
 The LanguagePlugin itself (the Volar contract), `convertSourceMap`,
 the `VerrexVirtualCode` class, and the three `CodeInformation` profiles
-live in [`verrex/language`](../verrex/src/language/AGENTS.md) — shared with
-`verrex/check`.
+live in [`@verrex/core/language`](../verrex/src/language/AGENTS.md) — shared with
+`@verrex/core/check`.
 
 ## How it fits together
 
@@ -66,7 +66,7 @@ The plugin itself — `getLanguageId`, `createVirtualCode`,
 `typescript.extraFileExtensions`, `typescript.getServiceScript`,
 source-map conversion, the three `CodeInformation` profiles for
 h-call vs. punctuation vs. normal source — lives in
-[`verrex/language`](../verrex/src/language/AGENTS.md). Read that node for the full
+[`@verrex/core/language`](../verrex/src/language/AGENTS.md). Read that node for the full
 picture; the short version is:
 
 - `service-proxy.ts` calls `createVerrexLanguagePlugin<string>((s) => s)`
@@ -83,7 +83,7 @@ picture; the short version is:
 
 If a bug points at file enumeration, virtual-code content, the
 `VerrexVirtualCode` class, or the source-map mappings, the fix is in
-`verrex/language`, not here. The proxy wrapper below is this
+`@verrex/core/language`, not here. The proxy wrapper below is this
 package's actual responsibility.
 
 `getVerrexVirtualCode(fileName)` resolves
@@ -145,7 +145,7 @@ hand-rolled.
 
 - **`getCompletionsAtPosition`** — `.vx`-only span clamp. When the
   user types `count.` mid-edit and triggers completions, Babel's
-  `errorRecovery: true` (in `verrex/compiler`) parses
+  `errorRecovery: true` (in `@verrex/core/compiler`) parses
   `count.\n\nreturn yield*` as `count.return` (the next keyword
   becomes the synthesized property name). That gives us the right
   completion list — members of `count` — but tsserver's
@@ -182,7 +182,7 @@ hand-rolled.
 Find-references and go-to-definition cross `.vx` files natively
 because user code writes `import { X } from "./Foo.vx"` (the
 root invariant) — TS's resolver picks up `.vx` via the
-`extraFileExtensions` registered by [`verrex/language`](../verrex/src/language/AGENTS.md),
+`extraFileExtensions` registered by [`@verrex/core/language`](../verrex/src/language/AGENTS.md),
 the file lands in the program as virtual code, and TS's reference
 index sees usages across files. No sibling `.ts` shim is involved.
 
@@ -195,15 +195,15 @@ index sees usages across files. No sibling `.ts` shim is involved.
   The `_?` in the regex makes it tolerate both the prefixed and
   unprefixed variants.
 
-- **`verrex/compiler` `copyLoc`** — the compiler preserves source
+- **`@verrex/core/compiler` `copyLoc`** — the compiler preserves source
   locations on emitted nodes. Without that, Babel's source map
   collapses everything to the start of the JSX expression, and
   go-to-definition lands on the wrong token.
 
-- **`verrex/compiler` `jsxRanges`** — `TransformResult.jsxRanges` is
+- **`@verrex/core/compiler` `jsxRanges`** — `TransformResult.jsxRanges` is
   load-bearing for two features: classifying source positions as
   "inside h()" or "JSX punctuation" during source-map conversion
-  (in `verrex/language`), and finding tag-pair partners for document
+  (in `@verrex/core/language`), and finding tag-pair partners for document
   highlights (`jsx-tags.ts` here). If the compiler ever stops
   emitting it (e.g. swc swap), both features break silently. The
   array is stored on `VerrexVirtualCode` next to `mappings` so neither
@@ -213,7 +213,7 @@ index sees usages across files. No sibling `.ts` shim is involved.
   `language.scripts.get(fileName)`, keyed by the `.vx` file-path
   string tsserver hands us — the same string `createVerrexLanguagePlugin`
   is configured with (`asFileName` is identity here). If that key
-  convention changes in `verrex/language`, the lookup here breaks with
+  convention changes in `@verrex/core/language`, the lookup here breaks with
   it.
 
 ## Anti-patterns
@@ -244,10 +244,10 @@ index sees usages across files. No sibling `.ts` shim is involved.
   `extraFileExtensions.isMixedContent` /
   `getServiceScript.scriptKind` independently. They form a
   contract with tsc that's load-bearing across both this plugin's
-  tsserver path and `verrex/check`'s kit path. The current
+  tsserver path and `@verrex/core/check`'s kit path. The current
   combination (Deferred + isMixedContent: true + TS for the
   virtual code) is documented in
-  [`verrex/language` AGENTS.md](../verrex/src/language/AGENTS.md#the-extrafileextensions-shape-is-load-bearing).
+  [`@verrex/core/language` AGENTS.md](../verrex/src/language/AGENTS.md#the-extrafileextensions-shape-is-load-bearing).
   Change all three together or not at all.
 
 ## Test loop
@@ -272,7 +272,7 @@ shape check.
   semantics" framing this plugin enforces
 - [`verrex`](../verrex/src/runtime/AGENTS.md) — the `_tag/_props/_children`
   parameter naming
-- [`verrex/compiler`](../verrex/src/compiler/AGENTS.md) — the source-location
+- [`@verrex/core/compiler`](../verrex/src/compiler/AGENTS.md) — the source-location
   preservation that the source map depends on
-- [`verrex/language`](../verrex/src/language/AGENTS.md) — the shared Volar
+- [`@verrex/core/language`](../verrex/src/language/AGENTS.md) — the shared Volar
   language plugin that does the heavy lifting

--- a/packages/ts-plugin/package.json
+++ b/packages/ts-plugin/package.json
@@ -27,7 +27,7 @@
     "typescript": "^6.0.3"
   },
   "devDependencies": {
-    "verrex": "workspace:*",
+    "@verrex/core": "workspace:*",
     "@volar/language-core": "^2.4.28",
     "@volar/typescript": "^2.4.28",
     "@effect/vitest": "4.0.0-beta.71",

--- a/packages/ts-plugin/src/jsx-tags.test.ts
+++ b/packages/ts-plugin/src/jsx-tags.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import type { JsxRange } from "verrex/language"
+import type { JsxRange } from "@verrex/core/language"
 import { findJsxTagPair, type JsxTagProvider } from "./jsx-tags.ts"
 
 const mockProvider = (ranges: ReadonlyArray<JsxRange>): JsxTagProvider => ({

--- a/packages/ts-plugin/src/jsx-tags.ts
+++ b/packages/ts-plugin/src/jsx-tags.ts
@@ -1,4 +1,4 @@
-import type { JsxRange } from "verrex/language"
+import type { JsxRange } from "@verrex/core/language"
 
 export interface NameSpan {
   readonly start: number

--- a/packages/ts-plugin/src/service-proxy.ts
+++ b/packages/ts-plugin/src/service-proxy.ts
@@ -1,7 +1,7 @@
 import { createLanguageServicePlugin } from "@volar/typescript/lib/quickstart/createLanguageServicePlugin"
 import type { Language } from "@volar/language-core"
 import type * as ts from "typescript"
-import { createVerrexLanguagePlugin, VerrexVirtualCode } from "verrex/language"
+import { createVerrexLanguagePlugin, VerrexVirtualCode } from "@verrex/core/language"
 import { findJsxTagPair, type JsxTagProvider } from "./jsx-tags.ts"
 import { classifyRefs, dedupeRefs, sortClassifiedRefs } from "./classify-references.ts"
 import { hintText, SUPPRESS_RE } from "./hint-text.ts"

--- a/packages/verrex/README.md
+++ b/packages/verrex/README.md
@@ -15,7 +15,7 @@ borrows: `V + E + R + X` → **verrex** (and the `.vx` source extension).
 ## Install
 
 ```bash
-pnpm add verrex effect            # effect is a peer dependency
+pnpm add @verrex/core effect            # effect is a peer dependency
 pnpm add -D @verrex/ts-plugin     # editor support for .vx files
 ```
 
@@ -41,12 +41,12 @@ export const Counter = Effect.fn("Counter")(function* (_props: {} = {}) {
 
 | Import | What you get |
 |---|---|
-| `verrex` | `h`, `mount`, `Await`, `list`, `Fragment`, `View`, `VerrexLive` |
-| `verrex/vite` | Vite plugin that compiles `.vx` |
-| `verrex/check` (+ `verrex-check` bin) | `.vx`-aware type-checker (replaces `tsc --noEmit`) |
-| `verrex/compiler`, `verrex/language`, `verrex/testing` | compiler, Volar language plugin, test harness |
+| `@verrex/core` | `h`, `mount`, `Await`, `list`, `Fragment`, `View`, `VerrexLive` |
+| `@verrex/core/vite` | Vite plugin that compiles `.vx` |
+| `@verrex/core/check` (+ `verrex-check` bin) | `.vx`-aware type-checker (replaces `tsc --noEmit`) |
+| `@verrex/core/compiler`, `@verrex/core/language`, `@verrex/core/testing` | compiler, Volar language plugin, test harness |
 
-`verrex` ships its compiled `dist` alongside the original `src` with
+`@verrex/core` ships its compiled `dist` alongside the original `src` with
 declaration maps, so go-to-definition lands in the framework's TypeScript
 source.
 

--- a/packages/verrex/package.json
+++ b/packages/verrex/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "verrex",
+  "name": "@verrex/core",
   "version": "0.1.0",
   "description": "An Effect-native UI framework where Effect's <A, E, R> channels propagate from every leaf of the view tree to the root — a forgotten Layer becomes a compile-time error that names the missing service.",
   "license": "MIT",

--- a/packages/verrex/src/check/AGENTS.md
+++ b/packages/verrex/src/check/AGENTS.md
@@ -117,7 +117,7 @@ LSP protocol.
 ## Tests
 
 ```
-pnpm --filter verrex test
+pnpm --filter @verrex/core test
 ```
 
 Runs `test/check/integration.mjs` with `--experimental-strip-types`.

--- a/packages/verrex/src/check/AGENTS.md
+++ b/packages/verrex/src/check/AGENTS.md
@@ -1,8 +1,8 @@
-# `verrex/check` — standalone type-checker for `.vx` projects
+# `@verrex/core/check` — standalone type-checker for `.vx` projects
 
 Replaces `tsc --noEmit` for projects with `.vx` files. Wraps
 `@volar/kit`'s `createTypeScriptChecker` plus the shared
-`verrex/language` plugin, runs in-process, prints tsc-style
+`@verrex/core/language` plugin, runs in-process, prints tsc-style
 diagnostics, exits non-zero on errors.
 
 Used in `apps/demo`'s `typecheck` script. Modeled on Astro's
@@ -22,7 +22,7 @@ Used in `apps/demo`'s `typecheck` script. Modeled on Astro's
 Programmatic:
 
 ```ts
-import { runCheck } from "verrex/check"
+import { runCheck } from "@verrex/core/check"
 const result = await runCheck({ cwd: "/path/to/project" })
 // result: { filesChecked: number, errors: number, warnings: number }
 ```
@@ -37,7 +37,7 @@ verrex-check --root /some/project  # cwd override
 
 In `apps/demo` the script wires it via `node --experimental-strip-types`
 because the workspace ships `.ts` source, not a built CLI. If
-`verrex/check` ever gets published, build an emitted CJS for the bin
+`@verrex/core/check` ever gets published, build an emitted CJS for the bin
 entry — `apps/demo`'s pattern won't work for external consumers.
 
 ## Why kit, not vue-tsc-style tsc-wrapping
@@ -81,7 +81,7 @@ LSP protocol.
 
 ## Coupling
 
-- **`verrex/language`** — provides `createVerrexLanguagePlugin`. The CLI
+- **`@verrex/core/language`** — provides `createVerrexLanguagePlugin`. The CLI
   instantiates the plugin with `<URI>(uri => uri.fsPath)` because kit
   uses `URI` as its script-id type. No registry is threaded: the kit
   checker owns the virtual-code lifetime per `runCheck` call.
@@ -107,7 +107,7 @@ LSP protocol.
   flag here, mirror the Astro name and semantics so future code
   ports cleanly.
 - Don't reintroduce on-disk sibling `.ts` files. The whole point
-  of `verrex/check` replacing the old `verrex-compile + tsc --noEmit`
+  of `@verrex/core/check` replacing the old `verrex-compile + tsc --noEmit`
   flow is that no auxiliary on-disk shim is needed — `.vx`
   enters the program directly through the language plugin's
   virtual code. If you find yourself emitting `.ts` siblings,
@@ -132,7 +132,7 @@ cleanly with only the workspace `node_modules` resolution path.
 
 - Root [`AGENTS.md`](../../../../AGENTS.md) — why `.vx` files never
   reach `tsc` directly.
-- [`verrex/language`](../language/AGENTS.md) — the LanguagePlugin
+- [`@verrex/core/language`](../language/AGENTS.md) — the LanguagePlugin
   this package consumes.
 - [`apps/demo`](../../../../apps/demo/AGENTS.md) — typecheck script
   wiring.

--- a/packages/verrex/src/check/index.ts
+++ b/packages/verrex/src/check/index.ts
@@ -3,7 +3,7 @@ import * as ts from "typescript"
 import * as kit from "@volar/kit"
 import { create as createTypeScriptServices } from "volar-service-typescript"
 import { URI } from "vscode-uri"
-import { createVerrexLanguagePlugin } from "verrex/language"
+import { createVerrexLanguagePlugin } from "@verrex/core/language"
 
 // LSP DiagnosticSeverity constants (stable wire protocol). `@volar/language-service`
 // re-exports the type but not the values, so we inline these to avoid pulling in

--- a/packages/verrex/src/compiler/AGENTS.md
+++ b/packages/verrex/src/compiler/AGENTS.md
@@ -299,7 +299,7 @@ once, here, in the compiler.
 `transform.test.ts` — 28 cases via `vitest`. Coverage includes:
 each rewrite category, wrap-skip when nothing rewrote, import
 injection / dedup, JSX whitespace, tag dispatch shapes, spread
-attributes, source maps. Run with `pnpm --filter verrex test`.
+attributes, source maps. Run with `pnpm --filter @verrex/core test`.
 
 ## What this package does NOT do
 

--- a/packages/verrex/src/compiler/AGENTS.md
+++ b/packages/verrex/src/compiler/AGENTS.md
@@ -1,4 +1,4 @@
-# `verrex/compiler` — `.vx` → plain TypeScript
+# `@verrex/core/compiler` — `.vx` → plain TypeScript
 
 Single Babel transform. Takes `.vx` source (TypeScript with
 angle-bracket `<div>...</div>` syntax — JSX-shape only, no JSX
@@ -11,7 +11,7 @@ tool sees the file.
 Entry point: `transformVerrex(source, filename) → { code, map, jsxRanges, mappings }`.
 
 - `code` — compiled TypeScript output.
-- `map` — Babel V3 source map. Used by `verrex/vite` for HMR /
+- `map` — Babel V3 source map. Used by `@verrex/core/vite` for HMR /
   dev-server source maps.
 - `jsxRanges` — source-side metadata about each `JSXElement` /
   `JSXFragment` (opening/closing tag positions). Used by
@@ -21,7 +21,7 @@ Entry point: `transformVerrex(source, filename) → { code, map, jsxRanges, mapp
   with explicit lengths on both sides and a `kind` tag (`"user"` /
   `"h-call"` / `"punctuation"`). Built by `computeMappings` in
   `source-map.ts`. This is the single source of truth for
-  position translation; `verrex/language` translates it directly into
+  position translation; `@verrex/core/language` translates it directly into
   Volar's `Mapping<CodeInformation>[]` without touching `map` or
   `jsxRanges`. See "Source-map mappings" below.
 
@@ -164,7 +164,7 @@ left as-is and does not track.
 ## Auto-injected imports
 
 If any JSX rewrote to an `h()` call **or** the whole-body pass emitted any
-`h.read(...)`, the transform ensures `import { h } from "verrex"`
+`h.read(...)`, the transform ensures `import { h } from "@verrex/core"`
 exists (tracked via `usedH || usedHRead` in `transformVerrex`). `Fragment`
 is added when `<>...</>` is used. `list` is added when the
 `.value.map → list(...)` rewrite fires. `ensureRuntimeImports` finds an
@@ -290,7 +290,7 @@ to drift one column to the left (`( : numbern)` instead of
 `(n: number)`). See `source-map.test.ts` — that test asserts
 the exact `(source: 2, generated: 1)` shape for the PR #12 case.
 
-`verrex/language` uses `mappings` directly and never re-decodes the
+`@verrex/core/language` uses `mappings` directly and never re-decodes the
 Babel source map. The bidirectional length asymmetry is captured
 once, here, in the compiler.
 
@@ -308,7 +308,7 @@ attributes, source maps. Run with `pnpm --filter verrex test`.
   the compiler only emits *calls* to them.
 - No `CodeInformation` profile assignment. The compiler classifies
   each span as `"user"` / `"h-call"` / `"punctuation"` (a
-  Volar-free taxonomy); `verrex/language` translates kind → Volar
+  Volar-free taxonomy); `@verrex/core/language` translates kind → Volar
   `CodeInformation`. Keeps the compiler Volar-agnostic.
 - No file watching, no caching. Pure function of `(source, filename)`.
   Callers cache.

--- a/packages/verrex/src/compiler/transform.test.ts
+++ b/packages/verrex/src/compiler/transform.test.ts
@@ -201,7 +201,7 @@ describe(".value.map(arrow → JSX) → list(...) rewrite", () => {
       const x = <ul>{coll.value.map((item) => <Row item={item} />)}</ul>
     `,
     )
-    expect(out).toMatch(/import \{[^}]*\blist\b[^}]*\} from "verrex"/)
+    expect(out).toMatch(/import \{[^}]*\blist\b[^}]*\} from "@verrex\/core"/)
   })
 
   it("supports block-body arrow returning only a JSX node", () => {
@@ -366,7 +366,7 @@ describe("whole-body `.value` reads (tracking outside JSX)", () => {
       const get = () => ref.value
     `)
     expect(out).toContain(`h.read(ref)`)
-    expect(out).toMatch(/import \{[^}]*\bh\b[^}]*\} from "verrex"/)
+    expect(out).toMatch(/import \{[^}]*\bh\b[^}]*\} from "@verrex\/core"/)
   })
 
   it("leaves a body `.value` *write* bare (assignment + update)", () => {
@@ -477,7 +477,7 @@ describe("whole-body `.value` reads (tracking outside JSX)", () => {
     `)
     // body read + JSX read both go through h.read
     expect(out.match(/h\.read\(count\)/g)?.length).toBe(2)
-    const importLines = out.split(";").filter((s) => s.includes(`from "verrex"`))
+    const importLines = out.split(";").filter((s) => s.includes(`from "@verrex/core"`))
     expect(importLines.length).toBe(1)
   })
 
@@ -495,34 +495,34 @@ describe("runtime auto-imports", () => {
     const out = compile(`
       const x = <div />
     `)
-    expect(out).toContain(`import { h } from "verrex"`)
+    expect(out).toContain(`import { h } from "@verrex/core"`)
   })
 
   it("adds `Fragment` too when <>...</> is used", () => {
     const out = compile(`
       const x = <><span /></>
     `)
-    expect(out).toMatch(/import \{[^}]*Fragment[^}]*\} from "verrex"/)
-    expect(out).toMatch(/import \{[^}]*h[^}]*\} from "verrex"/)
+    expect(out).toMatch(/import \{[^}]*Fragment[^}]*\} from "@verrex\/core"/)
+    expect(out).toMatch(/import \{[^}]*h[^}]*\} from "@verrex\/core"/)
   })
 
   it("does NOT inject if `h` is already imported under its own name", () => {
     const src = `
-      import { h } from "verrex"
+      import { h } from "@verrex/core"
       const x = <div />
     `
-    const matches = compile(src).match(/import \{[^}]*\bh\b[^}]*\} from "verrex"/g)
+    const matches = compile(src).match(/import \{[^}]*\bh\b[^}]*\} from "@verrex\/core"/g)
     expect(matches?.length).toBe(1)
   })
 
   it("extends an existing verrex import instead of adding a new one", () => {
     const src = `
-      import { mount } from "verrex"
+      import { mount } from "@verrex/core"
       const x = <div />
     `
     const out = compile(src)
-    expect(out).toMatch(/import \{[^}]*mount[^}]*h[^}]*\} from "verrex"/)
-    const importLines = out.split(";").filter((s) => s.includes(`from "verrex"`))
+    expect(out).toMatch(/import \{[^}]*mount[^}]*h[^}]*\} from "@verrex\/core"/)
+    const importLines = out.split(";").filter((s) => s.includes(`from "@verrex/core"`))
     expect(importLines.length).toBe(1)
   })
 

--- a/packages/verrex/src/compiler/transform.test.ts
+++ b/packages/verrex/src/compiler/transform.test.ts
@@ -491,7 +491,7 @@ describe("whole-body `.value` reads (tracking outside JSX)", () => {
 })
 
 describe("runtime auto-imports", () => {
-  it("adds `import { h } from \"verrex\"` when JSX is present", () => {
+  it("adds `import { h } from \"@verrex/core\"` when JSX is present", () => {
     const out = compile(`
       const x = <div />
     `)

--- a/packages/verrex/src/compiler/transform.ts
+++ b/packages/verrex/src/compiler/transform.ts
@@ -426,7 +426,7 @@ const transformChild = (
   return transformJsxNode(child, state)
 }
 
-const RUNTIME_PKG = "verrex"
+const RUNTIME_PKG = "@verrex/core"
 
 const ensureRuntimeImports = (program: t.Program, wanted: Set<string>): void => {
   // First pass: find an existing import from the runtime; drop names that
@@ -614,7 +614,7 @@ export const transformVerrex = (
   })
 
   // Auto-inject the runtime imports the rewritten code now depends on.
-  // Looks for an existing `import … from "verrex"` and adds the
+  // Looks for an existing `import … from "@verrex/core"` and adds the
   // missing names there; otherwise prepends a new import. Keeps the user's
   // imports untouched and avoids duplicate specifiers. `h` is needed if the
   // JSX pass emitted `h(...)` OR pass 3 emitted any `h.read(...)`.

--- a/packages/verrex/src/language/AGENTS.md
+++ b/packages/verrex/src/language/AGENTS.md
@@ -1,4 +1,4 @@
-# `verrex/language` — Volar language plugin for `.vx`
+# `@verrex/core/language` — Volar language plugin for `.vx`
 
 The single source of truth describing `.vx` files to Volar:
 how to identify them, how to produce the virtual TypeScript that
@@ -8,7 +8,7 @@ generated code.
 Shared by two consumers:
 
 - **`@verrex/ts-plugin`** — wraps it for tsserver (editor integration).
-- **`verrex/check`** — wraps it for `@volar/kit` (standalone CLI).
+- **`@verrex/core/check`** — wraps it for `@volar/kit` (standalone CLI).
 
 If you reach for the LanguagePlugin from a third place, you almost
 certainly want to depend on this package rather than copy it.
@@ -18,7 +18,7 @@ certainly want to depend on this package rather than copy it.
 | File | Purpose |
 |---|---|
 | `language-plugin.ts` | `createVerrexLanguagePlugin<T>(asFileName)` factory. Builds the Volar `LanguagePlugin` with `getLanguageId`, `createVirtualCode`, and `typescript: { extraFileExtensions, getServiceScript }`. Returns each per-`.vx` `VerrexVirtualCode` to Volar, which owns and indexes it. Returns `LanguagePlugin<T, VerrexVirtualCode>` so consumers can rely on the concrete class type at the boundary. |
-| `source-map.ts` | `convertSourceMap` — thin translator from `verrex/compiler`'s `CompilerMapping[]` to Volar's `Mapping<CodeInformation>[]`. Maps the compiler's `"user"` / `"h-call"` / `"punctuation"` kinds to Volar profiles. ~15 LOC of actual logic + the three profile objects. |
+| `source-map.ts` | `convertSourceMap` — thin translator from `@verrex/core/compiler`'s `CompilerMapping[]` to Volar's `Mapping<CodeInformation>[]`. Maps the compiler's `"user"` / `"h-call"` / `"punctuation"` kinds to Volar profiles. ~15 LOC of actual logic + the three profile objects. |
 | `virtual-code.ts` | `VerrexVirtualCode` class — implements Volar's `VirtualCode` interface so Volar and downstream consumers share one object per `.vx` file. Holds `source` / `compiled` / `mappings` / `jsxRanges` alongside Volar's `id` / `languageId` / `snapshot` / `embeddedCodes`. Volar owns the instance; consumers read it back via `language.scripts.get(id).generated.root`. |
 | `source-map.test.ts` | Vitest suite pinning `convertSourceMap`'s span-length passthrough and the user/h-call/punctuation profile assignments. |
 | `index.ts` | Re-exports. |
@@ -108,7 +108,7 @@ by the compiler; we map it to a Volar `CodeInformation` profile:
 The compiler decides `kind` while building the mappings — it
 already knows what each emitted byte represents. This package's
 job is the Volar-shape translation only. See
-[`verrex/compiler` AGENTS.md → "Source-map mappings"](../compiler/AGENTS.md#source-map-mappings--typed-sourcegenerated-spans)
+[`@verrex/core/compiler` AGENTS.md → "Source-map mappings"](../compiler/AGENTS.md#source-map-mappings--typed-sourcegenerated-spans)
 for the algorithm.
 
 ### Source and generated lengths come from the compiler
@@ -125,7 +125,7 @@ territory for that mapping — swallowing positions that belong to
 the next mapping. Inlay-hint positions get this wrong most
 visibly: a `: number` parameter-type hint that should render
 after `n` lands at the `n`'s position instead, displaying as
-`( : numbern)`. Both `verrex/compiler` and `@verrex/ts-plugin` have
+`( : numbern)`. Both `@verrex/core/compiler` and `@verrex/ts-plugin` have
 tests pinning this exact case.
 
 `convertSourceMap` just copies the lengths through — the compiler
@@ -162,7 +162,7 @@ holds no state that could drift.
 Earlier versions threaded a `VirtualCodeRegistry` (a
 `Map<string, VerrexVirtualCode>`) through the factory so consumers could
 look compiled files back up. But that registry was a *second index of
-the very objects Volar already owns* — `verrex/check` constructed one
+the very objects Volar already owns* — `@verrex/core/check` constructed one
 and never read it (pure write-only ceremony), and picking the wrong
 instance silently yielded stale `jsxRanges` with no compile-time
 guard. Resolving through `language.scripts.get(id).generated.root`
@@ -177,7 +177,7 @@ parameter.
 `VerrexVirtualCode`'s constructor does NOT use TypeScript parameter
 properties (the `constructor(readonly x: T)` form). Fields are
 declared and assigned manually instead, because Node's
-`--experimental-strip-types` mode — used by `verrex/check`'s CLI
+`--experimental-strip-types` mode — used by `@verrex/core/check`'s CLI
 and its integration test, both of which load the package's `.ts`
 sources directly — rejects parameter properties as non-type
 syntax. The class still uses readonly field declarations, just
@@ -186,7 +186,7 @@ without arranging for a build step.
 
 ## Coupling to other packages
 
-- **`verrex/compiler`** — required at runtime. `createVirtualCode`
+- **`@verrex/core/compiler`** — required at runtime. `createVirtualCode`
   calls `transformVerrex`; `convertSourceMap` consumes the
   `CompilerMapping[]` the compiler produces (it has both source
   and generated lengths plus a kind tag, ready for translation to
@@ -215,13 +215,13 @@ without arranging for a build step.
   (`instanceof VerrexVirtualCode` to narrow) instead of building a
   second index that can fall out of sync. A new consumer captures
   the `Language` from its host (the `setup(language)` hook for
-  tsserver; the kit checker for `verrex/check`) and reads from it.
+  tsserver; the kit checker for `@verrex/core/check`) and reads from it.
 - Don't switch `VerrexVirtualCode`'s constructor to parameter
   properties (`constructor(readonly source: string, ...)`). They
   desugar into field assignments and break Node's
   `--experimental-strip-types` mode — see the "Parameter properties
   are deliberately avoided" note above.
-- Don't import this package from `verrex` or `verrex/compiler`.
+- Don't import this package from `verrex` or `@verrex/core/compiler`.
   The dependency direction is one-way: `language` consumes
   `compiler`. Reversing it would create a cycle.
 
@@ -246,7 +246,7 @@ If you need more fine-grained tests, follow the existing pattern
 
 - Root [`AGENTS.md`](../../../../AGENTS.md) — the "JSX syntax, not JSX
   semantics" framing.
-- [`verrex/compiler`](../compiler/AGENTS.md) — source location
+- [`@verrex/core/compiler`](../compiler/AGENTS.md) — source location
   preservation and `JsxRange` emission this package depends on.
 - [`@verrex/ts-plugin`](../../../ts-plugin/AGENTS.md) — tsserver consumer.
-- [`verrex/check`](../check/AGENTS.md) — kit consumer.
+- [`@verrex/core/check`](../check/AGENTS.md) — kit consumer.

--- a/packages/verrex/src/language/index.ts
+++ b/packages/verrex/src/language/index.ts
@@ -1,4 +1,4 @@
 export { createVerrexLanguagePlugin, type TypeScriptConfig } from "./language-plugin.ts"
 export { convertSourceMap } from "./source-map.ts"
 export { VerrexVirtualCode } from "./virtual-code.ts"
-export type { JsxRange } from "verrex/compiler"
+export type { JsxRange } from "@verrex/core/compiler"

--- a/packages/verrex/src/language/language-plugin.ts
+++ b/packages/verrex/src/language/language-plugin.ts
@@ -1,6 +1,6 @@
 import type { LanguagePlugin, VirtualCode } from "@volar/language-core"
 import type * as ts from "typescript"
-import { transformVerrex } from "verrex/compiler"
+import { transformVerrex } from "@verrex/core/compiler"
 import { convertSourceMap } from "./source-map.ts"
 import { VerrexVirtualCode } from "./virtual-code.ts"
 

--- a/packages/verrex/src/language/source-map.test.ts
+++ b/packages/verrex/src/language/source-map.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { transformVerrex } from "verrex/compiler"
+import { transformVerrex } from "@verrex/core/compiler"
 import { convertSourceMap } from "./source-map.ts"
 
 /**
@@ -270,7 +270,7 @@ describe("convertSourceMap — structural cases", () => {
   })
 
   it("auto-injected import line has no overlap with user code mappings", () => {
-    // The compiler injects `import { h } from "verrex"` for files using JSX.
+    // The compiler injects `import { h } from "@verrex/core"` for files using JSX.
     // That insertion shouldn't claim source territory that belongs to user code.
     const src = `
       const view = <div>hi</div>

--- a/packages/verrex/src/language/source-map.ts
+++ b/packages/verrex/src/language/source-map.ts
@@ -1,6 +1,6 @@
 import type { CodeInformation } from "@volar/language-core"
 import type { Mapping } from "@volar/source-map"
-import type { CompilerMapping, CompilerMappingKind } from "verrex/compiler"
+import type { CompilerMapping, CompilerMappingKind } from "@verrex/core/compiler"
 
 /**
  * Translate the compiler's typed `CompilerMapping[]` into Volar's

--- a/packages/verrex/src/language/virtual-code.ts
+++ b/packages/verrex/src/language/virtual-code.ts
@@ -1,6 +1,6 @@
 import type { CodeInformation, VirtualCode } from "@volar/language-core"
 import type { Mapping } from "@volar/source-map"
-import type { JsxRange } from "verrex/compiler"
+import type { JsxRange } from "@verrex/core/compiler"
 import type * as ts from "typescript"
 
 /**

--- a/packages/verrex/src/runtime/AGENTS.md
+++ b/packages/verrex/src/runtime/AGENTS.md
@@ -395,7 +395,7 @@ by the compiler, so it never reaches `h.read`.
 If you change `h()`'s signature or any of the `Fold*` types, run:
 
 ```
-pnpm --filter verrex typecheck
+pnpm --filter @verrex/core typecheck
 # and (for end-to-end JSX shape coverage):
 pnpm --filter verrex-demo typecheck
 ```

--- a/packages/verrex/src/testing/AGENTS.md
+++ b/packages/verrex/src/testing/AGENTS.md
@@ -1,4 +1,4 @@
-# `verrex/testing` — in-process component test harness
+# `@verrex/core/testing` — in-process component test harness
 
 Mount an verrex component into an in-process DOM, drive it, and tear it
 down — without a browser or the Vite dev server. Fills the gap between

--- a/packages/verrex/src/testing/await-autotrack.test.ts
+++ b/packages/verrex/src/testing/await-autotrack.test.ts
@@ -7,7 +7,7 @@
 import { describe, it, expect } from "vitest"
 import { Context, Effect, Layer, Scope } from "effect"
 import { AtomRef } from "effect/unstable/reactivity"
-import { Await, h, type View } from "verrex"
+import { Await, h, type View } from "@verrex/core"
 import { render } from "./index.ts"
 
 class Users extends Context.Service<Users, {

--- a/packages/verrex/src/testing/await.test.ts
+++ b/packages/verrex/src/testing/await.test.ts
@@ -7,7 +7,7 @@
  */
 import { describe, it, expect } from "vitest"
 import { Context, Effect, Layer, Scope } from "effect"
-import { Await, h, type View } from "verrex"
+import { Await, h, type View } from "@verrex/core"
 import { render } from "./index.ts"
 
 class Greeter extends Context.Service<Greeter, {

--- a/packages/verrex/src/testing/index.test.ts
+++ b/packages/verrex/src/testing/index.test.ts
@@ -2,7 +2,7 @@
 import { describe, it, expect } from "vitest"
 import { Context, Effect, Layer } from "effect"
 import { AtomRef } from "effect/unstable/reactivity"
-import { h } from "verrex"
+import { h } from "@verrex/core"
 import { render } from "./index.ts"
 
 // Components are built with raw `h()` calls (no `.vx` compiler needed in the

--- a/packages/verrex/src/testing/index.ts
+++ b/packages/verrex/src/testing/index.ts
@@ -1,6 +1,6 @@
 import { Effect, Exit, Layer, Scope } from "effect"
 import type { AtomRegistry } from "effect/unstable/reactivity"
-import { VerrexLive, mount, type View } from "verrex"
+import { VerrexLive, mount, type View } from "@verrex/core"
 
 /**
  * Services the harness provides for you: the `AtomRegistry` (via `VerrexLive`)

--- a/packages/verrex/src/vite-plugin/AGENTS.md
+++ b/packages/verrex/src/vite-plugin/AGENTS.md
@@ -1,4 +1,4 @@
-# `verrex/vite` — Vite integration for `.vx`
+# `@verrex/core/vite` — Vite integration for `.vx`
 
 Tiny plugin (~70 LOC). Responsible for getting `.vx` files through
 Vite's dev pipeline as if they were `.ts` files.
@@ -50,7 +50,7 @@ and build, so both paths fixed at once.
 ### Build vs. editor error policy
 
 `transformVerrex`'s default `errorRecovery: true` lets the editor tolerate
-mid-edit unparseable source (see [`verrex/compiler`](../compiler/AGENTS.md)).
+mid-edit unparseable source (see [`@verrex/core/compiler`](../compiler/AGENTS.md)).
 The build path passes **`errorRecovery: false`** so a genuine syntax
 error throws here — a Vite error overlay in dev, a failed build in CI —
 instead of the compiler silently recovering and us shipping a broken
@@ -119,7 +119,7 @@ vs Vite id vs path-only). Don't unify naively.
   becomes one, cache by file mtime.
 - No production-build divergence. The same `transform` runs at
   build time. The type-check path (where Vite isn't in the loop)
-  goes through [`verrex/check`](../check/AGENTS.md), which calls
+  goes through [`@verrex/core/check`](../check/AGENTS.md), which calls
   the compiler directly via the shared language plugin.
 
 ## Anti-patterns
@@ -134,7 +134,7 @@ vs Vite id vs path-only). Don't unify naively.
 
 ## Related context
 
-- [`verrex/compiler`](../compiler/AGENTS.md) — the `transformVerrex`
+- [`@verrex/core/compiler`](../compiler/AGENTS.md) — the `transformVerrex`
   function this plugin wraps
 - Root [`AGENTS.md`](../../../../AGENTS.md) — why JSX must never reach
   the downstream TS-aware tools (esbuild's type-stripping step is

--- a/packages/verrex/src/vite-plugin/index.ts
+++ b/packages/verrex/src/vite-plugin/index.ts
@@ -1,6 +1,6 @@
 import { readFile } from "node:fs/promises"
 import { type Plugin, transformWithOxc } from "vite"
-import { transformVerrex } from "verrex/compiler"
+import { transformVerrex } from "@verrex/core/compiler"
 
 const VERREX_RE = /\.vx(?:\?[^.]*)?$/
 const VERREX_PATH_RE = /\.vx$/

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,12 +23,12 @@ importers:
 
   apps/demo:
     dependencies:
+      '@verrex/core':
+        specifier: workspace:*
+        version: link:../../packages/verrex
       effect:
         specifier: 4.0.0-beta.71
         version: 4.0.0-beta.71
-      verrex:
-        specifier: workspace:*
-        version: link:../../packages/verrex
     devDependencies:
       '@verrex/ts-plugin':
         specifier: workspace:*
@@ -42,6 +42,9 @@ importers:
       '@effect/vitest':
         specifier: 4.0.0-beta.71
         version: 4.0.0-beta.71(effect@4.0.0-beta.71)(vitest@4.1.8(@types/node@25.9.1)(happy-dom@20.9.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(yaml@2.9.0)))
+      '@verrex/core':
+        specifier: workspace:*
+        version: link:../verrex
       '@volar/language-core':
         specifier: ^2.4.28
         version: 2.4.28
@@ -54,9 +57,6 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
-      verrex:
-        specifier: workspace:*
-        version: link:../verrex
 
   packages/verrex:
     dependencies:

--- a/scripts/test-compiler.mjs
+++ b/scripts/test-compiler.mjs
@@ -2,7 +2,7 @@ import { transformVerrex } from "../packages/verrex/src/compiler/index.ts"
 
 const src = `
 import { Effect } from "effect"
-import { h, Fragment } from "verrex"
+import { h, Fragment } from "@verrex/core"
 
 export const Demo = (name: string) => Effect.gen(function*() {
   return yield* (


### PR DESCRIPTION
The unscoped **`verrex`** name is blocked by npm's typosquat-similarity guard (too close to the existing `verror` package — an automated rejection for new *unscoped* names). So the core package is scoped under the org instead: **`verrex` → `@verrex/core`**.

`@verrex/ts-plugin@0.1.0` is unaffected — it's already scoped and already published.

## What changed
- **Package name** `verrex` → `@verrex/core` (+ the demo and ts-plugin `workspace:*` deps).
- **Every `from "verrex…"` import specifier** → `@verrex/core…`, including the compiler's emitted runtime import (`RUNTIME_PKG`), so compiled `.vx` now imports `@verrex/core`.
- **Self-referencing subpath imports** (`@verrex/core/compiler`, `/language`, `/check`) resolve through the renamed package's own exports map — verified in the built `dist`.
- **Docs**: literal specifiers (`from`, `pnpm add`, subpath exports, the import tables, the release tag format `@verrex/core-v…`) updated; the framework *name* "verrex" in prose is left alone.
- Escaped the `/` in the compiler tests' regex-literal assertions (`@verrex/core` would otherwise close the `/…/` regex).

## What deliberately did NOT change
- The framework is still **verrex** — the `.vx` extension, `VerrexLive`, the `verrex-check` bin, the `packages/verrex` directory, and all brand prose.
- `packages/verrex/` keeps its directory name (mirrors `@verrex/ts-plugin` living in `packages/ts-plugin` — dir ≠ package name is already the pattern). Say the word if you'd rather rename it to `packages/core`.

## Verified
- `pnpm --filter @verrex/core build` clean; all 6 subpaths emit, self-imports resolve to `@verrex/core/*` in dist.
- `pnpm -r typecheck` — 0 errors (demo 11 files). `pnpm -r test` — `@verrex/core` 156 + check integration, `@verrex/ts-plugin` 31 + go-to-def/find-refs probes — all pass.

## After merge
The bootstrap publish targets the new name (the earlier `verrex`/`verrex-v0.1.0` commands become `@verrex/core` / `@verrex/core-v0.1.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
