### PR TITLE
feat(core)!: extract pure keyed-list reconciler; make list index reactive

### DIFF
--- a/packages/core/src/runtime/AGENTS.md
+++ b/packages/core/src/runtime/AGENTS.md
@@ -283,13 +283,22 @@ keyed-diff decision lives in [`reconcile.ts`](./reconcile.ts) —
 `plan(prevKeys, nextKeys)` returns `remove`/`insert`/`move`/`keep` ops
 over opaque keys, with zero DOM/`Scope`/`Effect` dependency, so the
 runtime's most bug-prone logic is unit-testable without mounting
-(see `reconcile.test.ts`). The `insert`/`move`/`remove` ops are a
-faithful 1:1 port of the old inline single-pass cursor loop — same
-nodes move, same order — so behaviour is unchanged. `mount`'s `List`
-case interprets the ops against real DOM nodes and per-row scopes:
-`remove` closes-then-detaches, `insert` calls `buildScopedChild`,
-`move` repositions, `keep` is index-only. Don't reintroduce the diff
-inline in `mount` — the seam is what gives it a test surface.
+(see `reconcile.test.ts`). The `insert`/`move`/`remove` ops are
+behaviourally equivalent to the old inline single-pass cursor loop —
+each drives exactly one of the same DOM mutations, same nodes, same
+order — so behaviour is unchanged. `mount`'s `List` case interprets the
+ops against real DOM nodes and per-row scopes: `remove` closes-then-
+detaches, `insert` calls `buildScopedChild`, `move` repositions, `keep`
+is index-only. Don't reintroduce the diff inline in `mount` — the seam
+is what gives it a test surface.
+
+> **`move` is currently unreachable through `AtomRef.Collection`.** Its
+> public mutators (`push`/`insertAt`/`remove`) each mint or drop a row's
+> `AtomRef`, so existing rows never change position relative to each other
+> — reordering surfaces as `remove` + `insert` of fresh keys, never `move`.
+> The `move` branch is kept for a future reordering API and is covered by
+> the pure `reconcile.test.ts` (synthetic key arrays), not by an integration
+> test — don't go looking for one.
 
 **Row index is reactive.** `render(item, index)` receives `index` as
 an `AtomRef.ReadonlyRef<number>`, not a plain number. The planner emits

--- a/packages/core/src/runtime/AGENTS.md
+++ b/packages/core/src/runtime/AGENTS.md
@@ -34,9 +34,11 @@ the editor margin. If you rename them, update the regex.
 | `h.ts` | `h()` factory + `track`/`read` reactivity-tracking machinery (built on `trackDeps`/`recordDep` from `coerce.ts`) |
 | `coerce.ts` | `coerceAsync` (any child shape → `Effect<View>`) and `coerceSync` (render-time emission → `View`). Internal; not re-exported from `index.ts`. Owns `isAtomRef` (brand check against `AtomRef.TypeId`) and the shared dependency tracker `trackDeps`/`recordDep` (used by both `h.track` and `Await`) |
 | `View.ts` | `View` IR (intermediate representation) — hand-written union of 6 named interfaces (`ViewText`, `ViewElement`, `ViewFragment`, `ViewReactive`, `ViewList`, `ViewEmpty`); constructors via `Data.taggedEnum<View>()`. The normalized DOM-materialization shape `mount` switches on. Plus `isView`, `VIEW_TAGS` |
-| `mount.ts` | DOM renderer. `buildDom(view, registry, scope) → Node`, `mount(app, el)`. Cleanup is delegated to `Scope` — every subscription/listener/release registers a finalizer on the scope it was created in, and parent-fork cascade tears them down on close |
+| `mount.ts` | DOM renderer. `buildDom(view, registry, scope) → Node`, `mount(app, el)`. Cleanup is delegated to `Scope` — every subscription/listener/release registers a finalizer on the scope it was created in, and parent-fork cascade tears them down on close. Owns `buildScopedChild` (the one place a dynamic subtree gets a parent-linked child scope) and the `List` **interpreter** that applies a `reconcile.ts` plan to real DOM + scopes |
+| `reconcile.ts` | Pure keyed-list diff. `plan(prevKeys, nextKeys) → ReconcileOp[]` over opaque keys — no DOM, no `Scope`, no `Effect`. The runtime's highest-bug-density logic, made exhaustively unit-testable. `mount`'s `List` case interprets the ops |
 | `index.ts` | Public exports + `list`, `Await`, `Fragment`, `VerrexLive` |
 | `coerce.test.ts` | Vitest suite for `coerceAsync` / `coerceSync` (parity + the sync/async asymmetry pin) |
+| `reconcile.test.ts` | Pure diff tests — an apply-to-array oracle (plan turns `prev` into `next`) plus exact op-sequence pins (move-minimality matches the old single-pass; index updates on shift) |
 | `types/Fold.ts` | `ChildE`/`ChildR`/`FoldE`/`FoldR`/`TagE`/`TagR`/`TagProps` — the channel-fold conditional types |
 | `types/Html.ts` | `IntrinsicProps`/`HtmlEventHandlers` — typed event handlers for HTML intrinsics |
 | `types/Fold.test-d.ts` | `expectTypeOf` matrix — every channel-fold shape |
@@ -276,6 +278,29 @@ trigger reconciliation. Per-value updates inside a row are handled
 by the row's own reactive bindings — re-reconciling on those would
 tear down DOM unnecessarily.
 
+**The diff is pure; the `List` case is only its interpreter.** The
+keyed-diff decision lives in [`reconcile.ts`](./reconcile.ts) —
+`plan(prevKeys, nextKeys)` returns `remove`/`insert`/`move`/`keep` ops
+over opaque keys, with zero DOM/`Scope`/`Effect` dependency, so the
+runtime's most bug-prone logic is unit-testable without mounting
+(see `reconcile.test.ts`). The `insert`/`move`/`remove` ops are a
+faithful 1:1 port of the old inline single-pass cursor loop — same
+nodes move, same order — so behaviour is unchanged. `mount`'s `List`
+case interprets the ops against real DOM nodes and per-row scopes:
+`remove` closes-then-detaches, `insert` calls `buildScopedChild`,
+`move` repositions, `keep` is index-only. Don't reintroduce the diff
+inline in `mount` — the seam is what gives it a test surface.
+
+**Row index is reactive.** `render(item, index)` receives `index` as
+an `AtomRef.ReadonlyRef<number>`, not a plain number. The planner emits
+the next-order index on every retained row (`move`/`keep`), and the
+interpreter pushes it into the row's index ref (guarded by an equality
+check so unchanged indices don't notify). A moved or shifted row's
+`{index.value}` therefore updates **without re-rendering the row** —
+the old `index: number` left it stale. Reading `index.value` tracks via
+`h.read` like any ref. A reorder/shift never rebuilds a row's DOM; only
+`insert` builds and `remove` tears down.
+
 **List snapshot must be a copy, not a reference.** Effect's
 `CollectionImpl` mutates its internal array in place on `push`/
 `remove`, so storing `view.source.value` and later comparing
@@ -327,7 +352,10 @@ typically) and keep it alive for the lifetime of the rendered UI.
   orphan scope for a sub-tree. Use `Scope.forkUnsafe(parent, ...)`
   so the sub-scope is parent-linked — closing the surrounding scope
   cascades into the sub-scope. Orphan scopes leak finalizers on
-  unexpected teardown paths.
+  unexpected teardown paths. In practice, route every dynamic subtree
+  (a Reactive emit, a List `insert`) through `buildScopedChild` — it
+  owns the `forkUnsafe → coerceSync → buildDom` triple, so the
+  parent-linked-scope invariant has exactly one home.
 - Don't extend `h.track`'s behavior to handle composite expressions
   — the compiler decides what's rewritten; the runtime just executes.
 - Don't subscribe to `AtomRef.Collection` per-item-value events
@@ -351,7 +379,7 @@ site preserves `T`, and accept a function child instead of a JSX
 `<MyComp<T>>` tag. `list(coll, render)` is the canonical shape:
 
 ```ts
-list<T>(coll: AtomRef.Collection<T>, render: (item: AtomRef.AtomRef<T>, i: number) => …)
+list<T>(coll: AtomRef.Collection<T>, render: (item: AtomRef.AtomRef<T>, i: AtomRef.ReadonlyRef<number>) => …)
 ```
 
 Users normally never write `list()` by hand — the compiler rewrites

--- a/packages/core/src/runtime/View.ts
+++ b/packages/core/src/runtime/View.ts
@@ -31,7 +31,12 @@ export interface ViewList {
   readonly _tag: "List"
   readonly source: AtomRef.Collection<unknown>
   // Returns View or Effect<View, never, never> — mount's valueToView coerces.
-  readonly render: (item: AtomRef.AtomRef<unknown>, index: number) => unknown
+  // `index` is a reactive ref: mount pushes each row's current position into it
+  // on reorder/shift, so `{index.value}` in a row updates without re-rendering.
+  readonly render: (
+    item: AtomRef.AtomRef<unknown>,
+    index: AtomRef.ReadonlyRef<number>,
+  ) => unknown
 }
 export interface ViewEmpty {
   readonly _tag: "Empty"

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -24,6 +24,10 @@ export type { HtmlEventHandlers, IntrinsicProps } from "./types/Html.ts"
  * `mount` pushes the new index into this ref without re-rendering the row. Read
  * it as `index.value` (the compiler routes that through `h.read`, so it tracks
  * like any other ref) to display a live position.
+ *
+ * **Breaking:** `index` was a plain `number` in earlier versions; it is now a
+ * `ReadonlyRef<number>`. Migrate `i` → `i.value` (and note `i` can no longer be
+ * used in arithmetic without `.value`).
  */
 export const list = <T>(
   from: AtomRef.Collection<T>,

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -18,17 +18,26 @@ export type { HtmlEventHandlers, IntrinsicProps } from "./types/Html.ts"
  * Generic `T` is preserved through the function call site (which JSX
  * component tags can't do because of higher-rank polymorphism limits in
  * TypeScript). Use as `{list(coll, (item) => <Row item={item} />)}`.
+ *
+ * `index` is a reactive `ReadonlyRef<number>`, not a plain number: when a row
+ * shifts position (because an earlier row was added or removed) or is reordered,
+ * `mount` pushes the new index into this ref without re-rendering the row. Read
+ * it as `index.value` (the compiler routes that through `h.read`, so it tracks
+ * like any other ref) to display a live position.
  */
 export const list = <T>(
   from: AtomRef.Collection<T>,
   render: (
     item: AtomRef.AtomRef<T>,
-    index: number,
+    index: AtomRef.ReadonlyRef<number>,
   ) => View | Effect.Effect<View, never, Scope.Scope> | Effect.Effect<View, never, never>,
 ): View =>
   View.List({
     source: from as AtomRef.Collection<unknown>,
-    render: render as (item: AtomRef.AtomRef<unknown>, index: number) => unknown,
+    render: render as (
+      item: AtomRef.AtomRef<unknown>,
+      index: AtomRef.ReadonlyRef<number>,
+    ) => unknown,
   })
 
 /**

--- a/packages/core/src/runtime/mount.ts
+++ b/packages/core/src/runtime/mount.ts
@@ -1,6 +1,7 @@
 import { Effect, Exit, Scope } from "effect"
 import { Atom, AtomRef, AtomRegistry } from "effect/unstable/reactivity"
 import { coerceSync, isAtomRef } from "./coerce.ts"
+import { plan } from "./reconcile.ts"
 import { type Props, View } from "./View.ts"
 
 // Subscribe to a ref and register the unsubscribe as a finalizer on the
@@ -91,6 +92,26 @@ const applyProps = (el: Element, props: Props, scope: Scope.Scope): void => {
   }
 }
 
+// Materialize a dynamic value into a DOM node under a fresh child scope forked
+// from `parent`. Every dynamic subtree (a Reactive emit, a List row) goes
+// through here so the "child scope is parent-LINKED, never an orphan" invariant
+// lives in one place — closing `parent` cascades into the returned scope, so
+// finalizers can't leak on an unexpected teardown path (see AGENTS.md).
+const buildScopedChild = (
+  value: unknown,
+  parent: Scope.Scope,
+  registry: AtomRegistry.AtomRegistry,
+): { readonly node: Node; readonly scope: Scope.Closeable } => {
+  const scope = Scope.forkUnsafe(parent, "sequential")
+  const node = buildDom(coerceSync(value, scope), registry, scope)
+  return { node, scope }
+}
+
+const closeScope = (scope: Scope.Closeable): void => {
+  const e = Scope.closeUnsafe(scope, Exit.void)
+  if (e) Effect.runFork(e)
+}
+
 const buildDom = (view: View, registry: AtomRegistry.AtomRegistry, scope: Scope.Scope): Node => {
   switch (view._tag) {
     case "Empty":
@@ -132,15 +153,11 @@ const buildDom = (view: View, registry: AtomRegistry.AtomRegistry, scope: Scope.
         // down the OLD subtree. The reverse order would unsubscribe many
         // listeners and resubscribe many — the documented "diff, not
         // unsub-all-then-resub" hazard (see h.ts AGENTS.md) extends here.
-        const newScope = Scope.forkUnsafe(scope, "sequential")
-        const node = buildDom(coerceSync(next, newScope), registry, newScope)
+        const { node, scope: newScope } = buildScopedChild(next, scope, registry)
         if (currentNode.parentNode) {
           currentNode.parentNode.replaceChild(node, currentNode)
         }
-        if (renderChildScope) {
-          const e = Scope.closeUnsafe(renderChildScope, Exit.void)
-          if (e) Effect.runFork(e)
-        }
+        if (renderChildScope) closeScope(renderChildScope)
         renderChildScope = newScope
         currentNode = node
       }
@@ -164,57 +181,71 @@ const buildDom = (view: View, registry: AtomRegistry.AtomRegistry, scope: Scope.
       const wrapper = document.createElement("span")
       wrapper.style.display = "contents"
 
-      // Per-item: rendered DOM node + the row's own scope (which holds all
-      // finalizers registered by the row component, including
-      // `Effect.acquireRelease` releases). Keyed by AtomRef identity so
-      // reactivity is preserved across reorders/inserts.
-      type Row = { readonly node: Node; readonly rowScope: Scope.Closeable }
+      // Per-row: its DOM node, its own scope (holds every finalizer the row
+      // registered — subscriptions, user `acquireRelease` releases), and a
+      // reactive index ref the planner's `keep`/`move` ops update. Keyed by
+      // AtomRef identity so reactivity is preserved across reorders/inserts.
+      type Row = {
+        readonly node: Node
+        readonly rowScope: Scope.Closeable
+        readonly indexRef: AtomRef.AtomRef<number>
+      }
       const rendered = new Map<AtomRef.AtomRef<unknown>, Row>()
       // Snapshot the array (not just the reference!) — CollectionImpl mutates
       // its internal array in place on push/remove, so comparing references
-      // would never detect structural changes.
+      // would never detect structural changes. This is the planner's `prev`.
       let snapshot: Array<AtomRef.AtomRef<unknown>> = []
 
-      const reconcile = (next: ReadonlyArray<AtomRef.AtomRef<unknown>>): void => {
-        const nextSet = new Set(next)
+      // A plan's `before` is a row key; resolve it to the reference node.
+      const nodeBefore = (key: AtomRef.AtomRef<unknown> | null): Node | null =>
+        key === null ? null : rendered.get(key)?.node ?? null
 
-        // Drop rows whose ref is gone. Close the row scope first (firing
-        // every finalizer the row registered: subscriptions, user
-        // `acquireRelease` releases), THEN detach the DOM. Matches the prior
-        // order so user releases that observe DOM still see it.
-        for (const [ref, row] of rendered) {
-          if (!nextSet.has(ref)) {
-            const e = Scope.closeUnsafe(row.rowScope, Exit.void)
-            if (e) Effect.runFork(e)
-            if (row.node.parentNode === wrapper) wrapper.removeChild(row.node)
-            rendered.delete(ref)
+      const setIndex = (row: Row, index: number): void => {
+        if (row.indexRef.value !== index) row.indexRef.set(index)
+      }
+
+      // The diff itself lives in the pure `plan` (see reconcile.ts); this is the
+      // interpreter — it just applies the ops to real DOM + scopes.
+      const reconcile = (next: ReadonlyArray<AtomRef.AtomRef<unknown>>): void => {
+        for (const op of plan(snapshot, next)) {
+          switch (op.op) {
+            case "remove": {
+              // Close the row scope first (firing the row's finalizers) THEN
+              // detach the DOM, so user releases that observe DOM still see it.
+              const row = rendered.get(op.key)
+              if (row) {
+                closeScope(row.rowScope)
+                if (row.node.parentNode === wrapper) wrapper.removeChild(row.node)
+                rendered.delete(op.key)
+              }
+              break
+            }
+            case "insert": {
+              const indexRef = AtomRef.make(op.index)
+              const { node, scope: rowScope } = buildScopedChild(
+                view.render(op.key, indexRef),
+                scope,
+                registry,
+              )
+              rendered.set(op.key, { node, rowScope, indexRef })
+              wrapper.insertBefore(node, nodeBefore(op.before))
+              break
+            }
+            case "move": {
+              const row = rendered.get(op.key)
+              if (row) {
+                wrapper.insertBefore(row.node, nodeBefore(op.before))
+                setIndex(row, op.index)
+              }
+              break
+            }
+            case "keep": {
+              const row = rendered.get(op.key)
+              if (row) setIndex(row, op.index)
+              break
+            }
           }
         }
-
-        // Build any new rows and place each in its current position. Each new
-        // row gets its own scope, forked from the List's scope — so on full
-        // mount teardown the fork-cascade closes any rows that didn't get
-        // explicitly removed first.
-        let cursor: ChildNode | null = wrapper.firstChild
-        next.forEach((ref, i) => {
-          let row = rendered.get(ref)
-          if (!row) {
-            const rowScope = Scope.forkUnsafe(scope, "sequential")
-            const node = buildDom(
-              coerceSync(view.render(ref, i), rowScope),
-              registry,
-              rowScope,
-            )
-            row = { node, rowScope }
-            rendered.set(ref, row)
-          }
-          if (cursor !== row.node) {
-            wrapper.insertBefore(row.node, cursor)
-          } else {
-            cursor = cursor.nextSibling
-          }
-        })
-
         snapshot = Array.from(next)
       }
 

--- a/packages/core/src/runtime/mount.ts
+++ b/packages/core/src/runtime/mount.ts
@@ -253,7 +253,9 @@ const buildDom = (view: View, registry: AtomRegistry.AtomRegistry, scope: Scope.
 
       // Re-reconcile only on structural changes. CollectionImpl also notifies
       // on per-item value updates (which are handled separately by each row's
-      // own reactive bindings) — those are no-ops here.
+      // own reactive bindings) — those are no-ops here. This is a pure perf
+      // short-circuit, not a correctness gate: a redundant reconcile would just
+      // plan all-`keep`. Don't tighten it into something the diff relies on.
       subscribeRefScoped(
         view.source,
         (next) => {

--- a/packages/core/src/runtime/reconcile.test.ts
+++ b/packages/core/src/runtime/reconcile.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest"
+import { plan, type ReconcileOp } from "./reconcile.ts"
+
+// Oracle: apply a plan to a plain array of keys the same way the DOM
+// interpreter would (remove / insert-before / move-before / keep), so we can
+// assert the plan actually produces `next` from `prev` — no DOM needed.
+const applyToArray = <K>(prev: ReadonlyArray<K>, ops: ReadonlyArray<ReconcileOp<K>>): K[] => {
+  const arr = [...prev]
+  const drop = (k: K) => {
+    const i = arr.indexOf(k)
+    if (i !== -1) arr.splice(i, 1)
+  }
+  const insertBefore = (k: K, before: K | null) => {
+    drop(k)
+    if (before === null) arr.push(k)
+    else arr.splice(arr.indexOf(before), 0, k)
+  }
+  for (const op of ops) {
+    switch (op.op) {
+      case "remove":
+        drop(op.key)
+        break
+      case "insert":
+      case "move":
+        insertBefore(op.key, op.before)
+        break
+      case "keep":
+        break
+    }
+  }
+  return arr
+}
+
+// The DOM-affecting ops (everything except `keep`) are exactly the mutations
+// the old single-pass cursor loop performed. Project to them to prove parity.
+const domOps = <K>(ops: ReadonlyArray<ReconcileOp<K>>) =>
+  ops.filter((o) => o.op !== "keep")
+
+describe("plan() — produces `next` from `prev`", () => {
+  const cases: ReadonlyArray<{ name: string; prev: string[]; next: string[] }> = [
+    { name: "no-op", prev: ["a", "b", "c"], next: ["a", "b", "c"] },
+    { name: "initial mount (empty → full)", prev: [], next: ["a", "b", "c"] },
+    { name: "clear (full → empty)", prev: ["a", "b", "c"], next: [] },
+    { name: "append", prev: ["a"], next: ["a", "b"] },
+    { name: "prepend", prev: ["b", "c"], next: ["a", "b", "c"] },
+    { name: "insert middle", prev: ["a", "b"], next: ["a", "c", "b"] },
+    { name: "remove middle", prev: ["a", "b", "c"], next: ["a", "c"] },
+    { name: "reverse", prev: ["a", "b", "c"], next: ["c", "b", "a"] },
+    { name: "rotate left", prev: ["a", "b", "c"], next: ["b", "c", "a"] },
+    { name: "move tail to head", prev: ["a", "b", "c", "d"], next: ["d", "a", "b", "c"] },
+    { name: "swap ends", prev: ["a", "b", "c", "d"], next: ["d", "b", "c", "a"] },
+    { name: "interleave new + reorder", prev: ["a", "b", "c"], next: ["x", "c", "a", "y", "b"] },
+    { name: "full replace", prev: ["a", "b"], next: ["c", "d"] },
+  ]
+
+  for (const { name, prev, next } of cases) {
+    it(name, () => {
+      expect(applyToArray(prev, plan(prev, next))).toEqual(next)
+    })
+  }
+})
+
+describe("plan() — op shapes", () => {
+  it("no-op emits only keeps, no DOM mutations", () => {
+    const ops = plan(["a", "b", "c"], ["a", "b", "c"])
+    expect(domOps(ops)).toEqual([])
+    expect(ops).toEqual([
+      { op: "keep", key: "a", index: 0 },
+      { op: "keep", key: "b", index: 1 },
+      { op: "keep", key: "c", index: 2 },
+    ])
+  })
+
+  it("move tail to head is a single move (matches the old single-pass)", () => {
+    const ops = plan(["a", "b", "c", "d"], ["d", "a", "b", "c"])
+    expect(domOps(ops)).toEqual([{ op: "move", key: "d", before: "a", index: 0 }])
+  })
+
+  it("reverse is two moves before the settled tail", () => {
+    const ops = plan(["a", "b", "c"], ["c", "b", "a"])
+    expect(domOps(ops)).toEqual([
+      { op: "move", key: "c", before: "a", index: 0 },
+      { op: "move", key: "b", before: "a", index: 1 },
+    ])
+  })
+
+  it("new rows are inserts; reused rows are moves/keeps", () => {
+    const ops = plan(["a", "b"], ["a", "c", "b"])
+    expect(ops).toEqual([
+      { op: "keep", key: "a", index: 0 },
+      { op: "insert", key: "c", before: "b", index: 1 },
+      { op: "keep", key: "b", index: 2 },
+    ])
+  })
+
+  it("removals come first, then placement", () => {
+    const ops = plan(["a", "b", "c"], ["c", "a"])
+    expect(ops[0]).toEqual({ op: "remove", key: "b" })
+    expect(ops.slice(1).every((o) => o.op !== "remove")).toBe(true)
+  })
+})
+
+describe("plan() — index updates (the bug the old loop had)", () => {
+  it("a shifted-but-unmoved row gets a fresh index via keep", () => {
+    // Remove the head: b and c don't move, but their indices change 1→0, 2→1.
+    const ops = plan(["a", "b", "c"], ["b", "c"])
+    expect(ops).toEqual([
+      { op: "remove", key: "a" },
+      { op: "keep", key: "b", index: 0 },
+      { op: "keep", key: "c", index: 1 },
+    ])
+  })
+
+  it("every retained row carries its next-order index", () => {
+    const next = ["c", "a", "b"]
+    const ops = plan(["a", "b", "c"], next)
+    for (const op of ops) {
+      if (op.op !== "remove") {
+        expect(op.index).toBe(next.indexOf(op.key))
+      }
+    }
+  })
+})

--- a/packages/core/src/runtime/reconcile.ts
+++ b/packages/core/src/runtime/reconcile.ts
@@ -6,12 +6,14 @@
 // `reconcile.test.ts`) without mounting a real DOM. `mount`'s `List` case is the
 // *interpreter*: it applies the plan to real DOM nodes and per-row `Scope`s.
 //
-// The plan is a faithful port of the single-pass cursor reconcile that used to
-// live inline in `mount`: every `insert`/`move`/`remove` op corresponds 1:1 to
-// the DOM mutations the old loop performed, so behaviour (which nodes actually
-// move, and in what order) is unchanged. The added `keep` op carries the row's
-// new index so the interpreter can push it into a reactive index ref — the old
-// loop left a moved/shifted row's index stale.
+// The plan is behaviourally equivalent to the single-pass cursor reconcile that
+// used to live inline in `mount`: each `insert`/`move`/`remove` op drives
+// exactly one DOM mutation the old loop performed (`insertBefore`/`removeChild`)
+// in the same order, so the same nodes move. (The op *vocabulary* is richer —
+// the old loop conflated build-and-insert with reposition into one branch — but
+// the resulting mutations match.) The added `keep` op carries the row's new
+// index so the interpreter can push it into a reactive index ref; the old loop
+// left a moved/shifted row's index stale.
 //
 // Precondition: keys are unique within a snapshot. The `List` source is an
 // `AtomRef.Collection` whose rows are distinct `AtomRef`s, so identity is

--- a/packages/core/src/runtime/reconcile.ts
+++ b/packages/core/src/runtime/reconcile.ts
@@ -1,0 +1,82 @@
+// Pure keyed-list reconciliation planner.
+//
+// This is the single most bug-prone piece of the runtime — a keyed diff — and
+// it is deliberately pure: it operates over opaque keys `K` with NO DOM, no
+// `Scope`, no `Effect`. That makes the diff exhaustively unit-testable (see
+// `reconcile.test.ts`) without mounting a real DOM. `mount`'s `List` case is the
+// *interpreter*: it applies the plan to real DOM nodes and per-row `Scope`s.
+//
+// The plan is a faithful port of the single-pass cursor reconcile that used to
+// live inline in `mount`: every `insert`/`move`/`remove` op corresponds 1:1 to
+// the DOM mutations the old loop performed, so behaviour (which nodes actually
+// move, and in what order) is unchanged. The added `keep` op carries the row's
+// new index so the interpreter can push it into a reactive index ref — the old
+// loop left a moved/shifted row's index stale.
+//
+// Precondition: keys are unique within a snapshot. The `List` source is an
+// `AtomRef.Collection` whose rows are distinct `AtomRef`s, so identity is
+// unique; duplicate keys would make "insert before key X" ambiguous.
+
+/** One step in a reconciliation plan, over an opaque row key `K`. */
+export type ReconcileOp<K> =
+  /** Row dropped from the list — tear down its scope and detach its node. */
+  | { readonly op: "remove"; readonly key: K }
+  /** New row — build it, set its index, insert before `before` (null = append). */
+  | { readonly op: "insert"; readonly key: K; readonly before: K | null; readonly index: number }
+  /** Existing row repositioned — move its node before `before`, update its index. */
+  | { readonly op: "move"; readonly key: K; readonly before: K | null; readonly index: number }
+  /** Existing row already in place — update its index only (no DOM mutation). */
+  | { readonly op: "keep"; readonly key: K; readonly index: number }
+
+/**
+ * Compute the ops that turn the `prev` key order into the `next` key order.
+ *
+ * Removals are emitted first (every `prev` key absent from `next`), then a
+ * left-to-right placement walk over `next` emits one `insert`/`move`/`keep` per
+ * key. The walk models the post-removal DOM children in `work` and tracks a
+ * `cursor` that mirrors the live DOM cursor: it only advances past a row that is
+ * already in place, exactly like the original `cursor = cursor.nextSibling`.
+ */
+export const plan = <K>(
+  prev: ReadonlyArray<K>,
+  next: ReadonlyArray<K>,
+): ReadonlyArray<ReconcileOp<K>> => {
+  const nextSet = new Set(next)
+  const prevSet = new Set(prev)
+  const ops: Array<ReconcileOp<K>> = []
+
+  // Phase 1 — removals. Emitted first so the interpreter closes dropped rows'
+  // scopes (and detaches their nodes) before building anything new, matching
+  // the prior teardown order.
+  for (const key of prev) {
+    if (!nextSet.has(key)) ops.push({ op: "remove", key })
+  }
+
+  // Phase 2 — placement walk. `work` is the wrapper's children in DOM order
+  // after removals; `cursor` indexes the node the live DOM cursor points at.
+  const work = prev.filter((k) => nextSet.has(k))
+  let cursor = 0
+  next.forEach((key, index) => {
+    const atCursor: K | null = cursor < work.length ? work[cursor]! : null
+    if (atCursor === key) {
+      // Already in place. (DOM: cursor = cursor.nextSibling.) Still emit a
+      // `keep` so a shifted index reaches the row's index ref.
+      ops.push({ op: "keep", key, index })
+      cursor++
+      return
+    }
+    // Needs (re)placing before `atCursor` (null → append). Mirror the DOM
+    // `insertBefore(node, atCursor)`: drop any current occurrence of `key`, then
+    // splice it in at the cursor — leaving `cursor` pointed at `atCursor` again.
+    const from = work.indexOf(key)
+    if (from !== -1) {
+      work.splice(from, 1)
+      if (from < cursor) cursor-- // removal shifted the cursor target left
+    }
+    work.splice(cursor, 0, key)
+    cursor++
+    ops.push({ op: prevSet.has(key) ? "move" : "insert", key, before: atCursor, index })
+  })
+
+  return ops
+}

--- a/packages/core/src/testing/list-index.test.ts
+++ b/packages/core/src/testing/list-index.test.ts
@@ -1,0 +1,56 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from "vitest"
+import { Effect } from "effect"
+import { AtomRef } from "effect/unstable/reactivity"
+import { h, list } from "@verrex/core"
+import { render } from "./index.ts"
+
+// Each row renders "<index>: <value>". `index` is the reactive ReadonlyRef the
+// list hands the render fn; `item` is the row's value ref. Built with raw h()
+// (no .vx compiler): both refs coerce to reactive text nodes.
+const IndexedList = (coll: AtomRef.Collection<string>) =>
+  Effect.gen(function* () {
+    return yield* h(
+      "ul",
+      {},
+      list(coll, (item, index) => h("li", { class: "row" }, index, ": ", item)),
+    )
+  })
+
+describe("list() reactive index", () => {
+  it("updates shifted rows' indices on removal without rebuilding their DOM", async () => {
+    const coll = AtomRef.collection<string>(["a", "b", "c"])
+    const ui = await render(IndexedList(coll))
+
+    expect(ui.all(".row").map((r) => r.textContent)).toEqual(["0: a", "1: b", "2: c"])
+
+    // Capture the b and c row nodes so we can prove they aren't rebuilt.
+    const [, bNode, cNode] = ui.all(".row")
+
+    // Remove the head. b and c don't move, but their indices shift 1→0, 2→1.
+    coll.remove(coll.value[0]!)
+    await ui.tick()
+
+    const rows = ui.all(".row")
+    expect(rows.map((r) => r.textContent)).toEqual(["0: b", "1: c"])
+    // Same DOM objects — shifted, not re-rendered.
+    expect(rows[0]).toBe(bNode)
+    expect(rows[1]).toBe(cNode)
+  })
+
+  it("renumbers following rows when a row is inserted in the middle", async () => {
+    const coll = AtomRef.collection<string>(["a", "b", "c"])
+    const ui = await render(IndexedList(coll))
+
+    coll.insertAt(1, "x")
+    await ui.tick()
+
+    expect(ui.all(".row").map((r) => r.textContent)).toEqual([
+      "0: a",
+      "1: x",
+      "2: b",
+      "3: c",
+    ])
+    await ui.unmount()
+  })
+})

--- a/packages/core/src/testing/list-index.test.ts
+++ b/packages/core/src/testing/list-index.test.ts
@@ -2,7 +2,7 @@
 import { describe, expect, it } from "vitest"
 import { Effect } from "effect"
 import { AtomRef } from "effect/unstable/reactivity"
-import { h, list } from "@verrex/core"
+import { h, list, type View } from "@verrex/core"
 import { render } from "./index.ts"
 
 // Each row renders "<index>: <value>". `index` is the reactive ReadonlyRef the
@@ -52,5 +52,63 @@ describe("list() reactive index", () => {
       "3: c",
     ])
     await ui.unmount()
+  })
+
+  it("survives an empty → full → empty → full cycle", async () => {
+    const coll = AtomRef.collection<string>(["a", "b"])
+    const ui = await render(IndexedList(coll))
+    expect(ui.all(".row").map((r) => r.textContent)).toEqual(["0: a", "1: b"])
+
+    // Empty it — every row removed, `rendered`/`snapshot` reset.
+    for (const ref of [...coll.value]) coll.remove(ref)
+    await ui.tick()
+    expect(ui.all(".row")).toEqual([])
+
+    // Refill — fresh inserts off an empty snapshot, like an initial mount.
+    coll.push("c")
+    coll.push("d")
+    await ui.tick()
+    expect(ui.all(".row").map((r) => r.textContent)).toEqual(["0: c", "1: d"])
+    await ui.unmount()
+  })
+})
+
+describe("list() row lifecycle", () => {
+  // A row whose render returns an Effect with acquireRelease — the release
+  // registers on the row's own scope (via coerceSync providing it), so it must
+  // fire when THAT row is removed, not only on full unmount. The refactor moved
+  // this teardown into the `remove` op + closeScope, so pin it here.
+  const TrackedList = (coll: AtomRef.Collection<string>, log: string[]) =>
+    Effect.gen(function* () {
+      return yield* h(
+        "ul",
+        {},
+        list(coll, (item) =>
+          Effect.gen(function* () {
+            const id = item.value
+            yield* Effect.acquireRelease(
+              Effect.sync(() => log.push(`acquire:${id}`)),
+              () => Effect.sync(() => log.push(`release:${id}`)),
+            )
+            return yield* h("li", { class: "row" }, id)
+          })) as View,
+      )
+    })
+
+  it("fires a row's acquireRelease release when only that row is removed", async () => {
+    const log: string[] = []
+    const coll = AtomRef.collection<string>(["a", "b", "c"])
+    const ui = await render(TrackedList(coll, log))
+    expect(log).toEqual(["acquire:a", "acquire:b", "acquire:c"])
+
+    // Remove just "b": its release fires; a and c stay live.
+    coll.remove(coll.value[1]!)
+    await ui.tick()
+    expect(log).toEqual(["acquire:a", "acquire:b", "acquire:c", "release:b"])
+    expect(ui.all(".row").map((r) => r.textContent)).toEqual(["a", "c"])
+
+    // Unmount: the surviving rows' releases fire via the parent-fork cascade.
+    await ui.unmount()
+    expect(log.slice(3).sort()).toEqual(["release:a", "release:b", "release:c"])
   })
 })


### PR DESCRIPTION
## What

Lifts the `List` keyed-diff out of `mount`'s DOM/Scope interpreter into a **pure** `plan(prevKeys, nextKeys) → ReconcileOp[]` (`runtime/reconcile.ts`) — no DOM, no `Scope`, no `Effect`. `mount`'s `List` case becomes the interpreter that applies the ops to real nodes + per-row scopes.

Surfaced from an architecture review: the keyed diff is the runtime's highest-bug-density logic, yet its only test surface was a full happy-dom mount. Now it has **20 fast pure assertions**.

## Why it's safe

The `insert`/`move`/`remove` ops are a faithful **1:1 port** of the old inline single-pass cursor loop — same nodes move, same order. An adversarial review fuzzed the planner against a model of the old loop (**20k cases, 0 divergences** in final order *and* exact mutation sequence), plus leak-safety and `before`-resolution fuzzing (50k cases). No blockers.

## Also in this change

- **`buildScopedChild`** extracted and shared by the `List` and `Reactive` cases — the "child scope is parent-linked, never orphaned" invariant now has one home instead of being defended by prose in two places.
- **Reactive row index** (the bug the seam exposed): `render(item, index)` receives `index` as `AtomRef.ReadonlyRef<number>`. A moved/shifted row's `{index.value}` updates **without re-rendering** — the old `index: number` left it stale.

## ⚠️ Breaking

`list()`'s `render` receives `index` as `AtomRef.ReadonlyRef<number>` instead of `number`. Read it as `index.value` (the compiler routes that through `h.read`, so it tracks). No in-repo consumer used the index; the `.vx`-aware checker confirms 0 errors.

## Tests

- `reconcile.test.ts` (new, pure): apply-to-array oracle + exact op-sequence pins (reverse/rotate/move-tail-to-head minimality, index-on-shift).
- `list-index.test.ts` (new, happy-dom): reactive index updates end-to-end; shifted rows keep DOM identity.
- `pnpm -r test`: 178 core + 31 ts-plugin pass. `pnpm -r typecheck`: clean incl. `@verrex/core/check` (0 errors / 11 `.vx` files).
- `runtime/AGENTS.md` updated (new sub-module, the planner/interpreter seam, `buildScopedChild`, reactive index).