### PR TITLE
feat(core): add catchCause — view-level error boundary (catch-all)

### DIFF
--- a/apps/demo/src/CatchCause.vx
+++ b/apps/demo/src/CatchCause.vx
@@ -1,0 +1,48 @@
+import { Cause, Data, Effect } from "effect"
+import { catchCause } from "@verrex/core"
+
+// A local tagged error so the failure has a real shape in `Cause.pretty`.
+class BoomError extends Data.TaggedError("BoomError")<{ readonly why: string }> {}
+
+// The protected subtree. Renders fine; its button's `onclick` returns a failing
+// Effect, which — post-mount, with no E channel to land on — is routed to the
+// nearest boundary instead of being dropped.
+const Crasher = Effect.fn("Crasher")(function* (_props: {} = {}) {
+  return yield* (
+    <div class="crasher">
+      <p>This subtree works fine — until you push the button.</p>
+      <button
+        class="crash"
+        onclick={() => Effect.fail(new BoomError({ why: "you pushed the button" }))}
+      >
+        crash me
+      </button>
+    </div>
+  )
+})
+
+/**
+ * `catchCause(child, (cause, reset) => fallback)` — the view-level error
+ * boundary, mirroring `Effect.catchCause`. It recovers the *failure* side of the
+ * subtree (the child renders itself on success) and catches BOTH a failed
+ * construction Effect and a post-mount failure inside the live subtree — here the
+ * crash button's Effect. `reset` re-runs the child's construction.
+ *
+ * Inferred type: `Effect<View, never, Scope>` — `Scope` is the boundary's own
+ * contribution (it forks its reset/report loop into the enclosing scope). The
+ * caught error is `Cause<unknown>` for now; a later pass makes a *forgotten*
+ * boundary a compile error that names the unhandled error.
+ */
+export const CatchCause = Effect.fn("CatchCause")(function* (_props: {} = {}) {
+  return yield* (
+    <section class="catch-cause">
+      {catchCause(<Crasher />, (cause, reset) => (
+        <div class="boundary-fallback">
+          <p class="caught">caught a runtime failure:</p>
+          <pre class="cause">{Cause.pretty(cause)}</pre>
+          <button class="reset" onclick={reset}>reset</button>
+        </div>
+      ))}
+    </section>
+  )
+})

--- a/apps/demo/src/main.vx
+++ b/apps/demo/src/main.vx
@@ -3,6 +3,7 @@ import { AtomRegistry } from "effect/unstable/reactivity"
 import { VerrexLive, mount, type View } from "@verrex/core"
 import { Counter } from "./Counter.vx"
 import { AsyncUserPage } from "./AsyncUserPage.vx"
+import { CatchCause } from "./CatchCause.vx"
 import { flashOnUpdate } from "./flash.ts"
 import { highlight } from "./highlight.ts"
 import { Lifecycle } from "./Lifecycle.vx"
@@ -262,6 +263,36 @@ const App = (
       {demoSlot("lifecycle")}
     </section>
 
+    <section class="tour">
+      {copy({
+        step: "07",
+        title: "Error boundary (catch the failure side)",
+        concept:
+          "catchCause mirrors Effect.catchCause: recover the failure side of a view subtree, let success pass through. It catches BOTH a failed construction Effect and a post-mount failure inside the live subtree — here the crash button's Effect, which has no E channel to land on and is routed to the boundary instead of dropped. reset re-runs the child's construction. Scope is the boundary's own contribution (it forks its reset/report loop into the enclosing scope). The cause is Cause<unknown> for now; a later pass makes a forgotten boundary a compile error that names the unhandled error.",
+        type: "Effect<View, never, Scope>",
+        code: `const Crasher = Effect.fn("Crasher")(function* () {
+  return yield* (
+    <button onclick={() => Effect.fail(new BoomError())}>
+      crash me
+    </button>
+  )
+})
+
+export const CatchCause = Effect.fn("CatchCause")(function* () {
+  return yield* (
+    {catchCause(<Crasher />, (cause, reset) => (
+      <div class="fallback">
+        <pre>{Cause.pretty(cause)}</pre>
+        <button onclick={reset}>reset</button>
+      </div>
+    ))}
+  )
+})`,
+        file: "CatchCause.vx",
+      })}
+      {demoSlot("boundary")}
+    </section>
+
     <footer class="site-footer">
       <p>
         verrex is an experimental proof-of-concept.{" "}
@@ -332,6 +363,7 @@ const program = Effect.gen(function* () {
     setupDemo("live", () => LiveUser())
     setupDemo("todos", () => Todos())
     setupDemo("lifecycle", () => Lifecycle())
+    setupDemo("boundary", () => CatchCause())
   })
   // Start the reactivity flash once the initial mounts settle (incl. the
   // simulated fetch latency), so only interactions and resets flash — not page

--- a/packages/core/src/compiler/AGENTS.md
+++ b/packages/core/src/compiler/AGENTS.md
@@ -50,7 +50,9 @@ Every JSX expression `{...}` triggers up to three local rewrites:
    `<Row item={item} />` (where `item` is a generic `T`). Static
    passes through with no wrap. The `.value.map → list(...)` rewrite
    (#3) also does **not** trigger a wrap — `list()` subscribes inside
-   `mount`, so wrapping in `h.track` would be a redundant layer.
+   `mount`, so wrapping in `h.track` would be a redundant layer. Same
+   for `Async(...)` and `catchCause(...)` calls (`isSelfTrackingCall`):
+   they self-track and must reach the `h()` fold un-erased.
 
 2. **`x.value` → `h.read(x)`** inside the wrapped expression. Tracks
    AtomRef reads. (The *same* read rewrite also runs over the whole

--- a/packages/core/src/compiler/transform.test.ts
+++ b/packages/core/src/compiler/transform.test.ts
@@ -328,6 +328,26 @@ describe("Async calls are not h.track-wrapped", () => {
   })
 })
 
+describe("catchCause calls are not h.track-wrapped", () => {
+  // Same reason as Async: catchCause returns Effect<View, never, R | Scope> that
+  // must reach the h() fold; h.track would erase it to `unknown`. A `.value` read
+  // inside the fallback is still rewritten to h.read, but the outer call is bare.
+  it("leaves a `.value`-reading catchCause(...) bare, keeping h.read", () => {
+    const out = compile(`
+      const x = <div>{catchCause(<Child />, (cause, reset) => <span>{label.value}</span>)}</div>
+    `)
+    expect(out).toContain(`h.read(label)`) // dep rewrite kept inside the fallback
+    expect(out).not.toMatch(/h\.track\(\(\)\s*=>\s*catchCause\(/) // not wrapped
+  })
+
+  it("does not introduce h.track when catchCause is the only `.value` reader", () => {
+    const out = compile(`
+      const x = <div>{catchCause(<Child />, (cause) => <span>{label.value}</span>)}</div>
+    `)
+    expect(out).not.toContain(`h.track`)
+  })
+})
+
 describe("whole-body `.value` reads (tracking outside JSX)", () => {
   // The JSX pass only rewrites `.value` inside JSX expressions. A third pass
   // rewrites `.value` reads that survive in *statements* — extracted Async

--- a/packages/core/src/compiler/transform.ts
+++ b/packages/core/src/compiler/transform.ts
@@ -108,22 +108,26 @@ interface RewriteState {
 }
 
 /**
- * True when `expr` is a top-level `Async(...)` call. The `Async` boundary does
- * its OWN dependency tracking (it runs its `from` thunk under the same tracker
- * as `h.track`), so wrapping it in `h.track` is redundant *and* harmful:
- * `h.track` is typed `(thunk) => unknown`, which erases `Async`'s
- * `Effect<View, never, R | Scope>` to `unknown` and drops its channels from the
- * `h()` fold. Same reason `.value.map(...)` → `list(...)` is left unwrapped. The
- * inner `.value` reads are still rewritten to `h.read` (Async's tracker needs
- * them).
+ * True when `expr` is a top-level call to a self-tracking boundary helper —
+ * `Async(...)` or `catchCause(...)`. Both return an `Effect<View, never, R | …>`
+ * that must reach the `h()` fold intact, and both manage their own reactivity
+ * (`Async` tracks its `from` thunk; `catchCause` drives its state from a forked
+ * loop). Wrapping either in `h.track` is redundant *and* harmful: `h.track` is
+ * typed `(thunk) => unknown`, which erases the channels and drops them from the
+ * fold. Same reason `.value.map(...)` → `list(...)` is left unwrapped. The inner
+ * `.value` reads are still rewritten to `h.read` (e.g. a `.value` read in a
+ * `catchCause` fallback or an `Async` thunk).
  *
  * Matched purely by callee name (the compiler has no types). So
  * `import { Async as A }` defeats the skip — `A(...)` would be wrongly
  * `h.track`-wrapped and lose its channels (a loud type error at the call site).
- * Import `Async` unaliased.
+ * Import these unaliased.
  */
-const isAsyncCall = (expr: t.Expression): boolean =>
-  t.isCallExpression(expr) && t.isIdentifier(expr.callee, { name: "Async" })
+const SELF_TRACKING_HELPERS: ReadonlySet<string> = new Set(["Async", "catchCause"])
+const isSelfTrackingCall = (expr: t.Expression): boolean =>
+  t.isCallExpression(expr) &&
+  t.isIdentifier(expr.callee) &&
+  SELF_TRACKING_HELPERS.has(expr.callee.name)
 
 /**
  * Wrap a JSX-expression's value in a `h.track(() => expr)` call **only when
@@ -136,15 +140,15 @@ const isAsyncCall = (expr: t.Expression): boolean =>
  * wrapping would erase their channels:
  *   - `.value.map(arrow → JSX)` → `list(...)` (flips `state.wroteList` for the
  *     `list` auto-import; subscribes inside `mount`).
- *   - `Async(() => …, arms)` calls — the boundary tracks its own deps (see
- *     `isAsyncCall`).
+ *   - `Async(() => …, arms)` and `catchCause(child, fallback)` calls — these
+ *     self-track (see `isSelfTrackingCall`).
  */
 const wrapTracked = (expr: t.Expression, state: RewriteState): t.Expression => {
   const { expr: rewritten, rewroteRead } = rewriteTrackedExpression(expr, state)
   if (!rewroteRead) return rewritten
-  // Async self-tracks; the `.value`→`h.read` rewrite inside it is kept, but the
-  // outer `h.track` wrap is skipped so Async's channels survive the fold.
-  if (isAsyncCall(rewritten)) return rewritten
+  // Async / catchCause self-track; the `.value`→`h.read` rewrite inside them is
+  // kept, but the outer `h.track` wrap is skipped so their channels survive the fold.
+  if (isSelfTrackingCall(rewritten)) return rewritten
   return t.callExpression(
     t.memberExpression(t.identifier("h"), t.identifier("track")),
     [t.arrowFunctionExpression([], rewritten)],

--- a/packages/core/src/runtime/AGENTS.md
+++ b/packages/core/src/runtime/AGENTS.md
@@ -8,6 +8,7 @@ Public surface (from `index.ts`):
 - `mount` — DOM renderer (returns `Effect<void, E, R | AtomRegistry | Scope>`)
 - `list` — keyed reactive list helper (`View.List` IR node)
 - `Async` / `asyncRef` — async render boundary + primitive (errors-as-values; see "`asyncRef` / `Async`" below)
+- `catchCause` — view-level error boundary (catch-all; mirrors `Effect.catchCause`; see "`catchCause`" below)
 - `Fragment` — `<>...</>` compile target
 - `VerrexLive` — base Layer providing `AtomRegistry`
 - Types: `View`, `Props`, `FoldE`/`FoldR`/`TagE`/`TagR`/`TagProps`,
@@ -36,7 +37,7 @@ the editor margin. If you rename them, update the regex.
 | `View.ts` | `View` IR (intermediate representation) — hand-written union of 6 named interfaces (`ViewText`, `ViewElement`, `ViewFragment`, `ViewReactive`, `ViewList`, `ViewEmpty`); constructors via `Data.taggedEnum<View>()`. The normalized DOM-materialization shape `mount` switches on. Plus `isView`, `VIEW_TAGS` |
 | `mount.ts` | DOM renderer. `buildDom(view, ctx, scope) → Node` (`ctx: BuildCtx = { registry, context, sink }`), `mount(app, el)`. Cleanup is delegated to `Scope` — every subscription/listener/release registers a finalizer on the scope it was created in, and parent-fork cascade tears them down on close. Owns `buildScopedChild` (the one place a dynamic subtree gets a parent-linked child scope), the `List` **interpreter** that applies a `reconcile.ts` plan to real DOM + scopes, and the error **sink** (runs event-handler Effects + routes runtime failures) |
 | `reconcile.ts` | Pure keyed-list diff. `plan(prevKeys, nextKeys) → ReconcileOp[]` over opaque keys — no DOM, no `Scope`, no `Effect`. The runtime's highest-bug-density logic, made exhaustively unit-testable. `mount`'s `List` case interprets the ops |
-| `index.ts` | Public exports + `list`, `Async`, `asyncRef`, `Fragment`, `VerrexLive` |
+| `index.ts` | Public exports + `list`, `Async`, `asyncRef`, `catchCause`, `Fragment`, `VerrexLive` |
 | `coerce.test.ts` | Vitest suite for `coerceAsync` / `coerceSync` (parity + the sync/async asymmetry pin) |
 | `reconcile.test.ts` | Pure diff tests — an apply-to-array oracle (plan turns `prev` into `next`) plus exact op-sequence pins (move-minimality matches the old single-pass; index updates on shift) |
 | `types/Fold.ts` | `ChildE`/`ChildR`/`FoldE`/`FoldR`/`TagE`/`TagR`/`TagProps` — the channel-fold conditional types |
@@ -95,7 +96,7 @@ and "DOM nodes." `coerceAsync` (in `coerce.ts`) coerces inputs to
 View at `h()` call time; `coerceSync` (also in `coerce.ts`) coerces
 render-time emissions from Reactive sources; `buildDom` (in
 `mount.ts`) switches on the variant tag and produces DOM. Closed-
-for-now at 6 variants:
+for-now at 7 variants:
 
 - `Text { value }` — plain text node
 - `Element { tag, props, children }` — DOM element
@@ -103,6 +104,10 @@ for-now at 6 variants:
 - `Reactive { source: Atom | AtomRef.ReadonlyRef }` — subscribe to
   source, swap rendered child on emit
 - `List { source: AtomRef.Collection, render }` — keyed reactive list
+- `Boundary { state, handler, reset, report }` — error boundary; renders the
+  child subtree (with `report` swapped in as the subtree's error sink) or, on a
+  caught failure, `handler(cause, reset)`. Built by `catchCause` (see below).
+  The one variant that carries behavior, not just data.
 - `Empty {}` — comment placeholder (used for `false`/`null` children)
 
 ### Why hand-written interfaces (not `Data.TaggedEnum<{...}>`)
@@ -122,7 +127,7 @@ inline form.
 
 ### Closed-for-now, not closed-forever
 
-The current 6 variants cover everything we need to render. Adding
+The current 7 variants cover everything we need to render. Adding
 a variant is a coordinated edit across two files:
 
   - `buildDom` (mount.ts) — exhaustive `switch (view._tag)` forces
@@ -142,8 +147,11 @@ hoisted into the surrounding Effect.
 
 Good candidates if a need arises: `Portal` (render children to a
 different DOM root). Note an async boundary did **not** need a new
-variant — see `Async` below. Anti-pattern: convenience wrappers like
-`Card`/`Heading` — those are components, not IR.
+variant (`Async` builds a `Reactive` — see below), but the *error*
+boundary **did** (`Boundary`): it has to redirect the error sink for its
+child subtree, which only `buildDom` can do when it descends into the
+node — not expressible by `Reactive`-over-a-ref alone. Anti-pattern:
+convenience wrappers like `Card`/`Heading` — those are components, not IR.
 
 ## `asyncRef` / `Async` — the async data primitive + render boundary
 
@@ -223,6 +231,38 @@ from a captured context dies "registry disposed" once the creating program
 returns. Running the user's Effect directly on the mount fiber is what
 keeps `R` folded. `Atom`/`AtomRef` remain the right tool for *synchronous*
 reactive state (Counter, `list`) — just not the spine for effectful data.
+
+## `catchCause` — the view-level error boundary
+
+`catchCause(child, (cause, reset) => fallback)` mirrors `Effect.catchCause`:
+recover the **failure** side of a view subtree, let success pass through (the
+child renders itself). Contrast `Async`, which matches a data `AsyncResult` and
+renders *every* state (`initial`/`success`/`failure`) — a boundary only supplies
+the failure fallback. (Tag-selective `catchTag`/`catchTags` + the typed `Cause<E>`
+discharge come later; this is the untyped catch-all.)
+
+Catches **both phases** through one fallback:
+- **construction** — `child`'s build Effect is run under `Effect.matchCause`; a
+  failure becomes the initial `error` state. Run **inline** in `catchCause`'s gen
+  (folds `R`, no first-paint flash), so a forgotten `Layer` is still a compile
+  error at `mount`.
+- **live** — a post-mount failure inside the rendered subtree (a reactive
+  re-render via `coerceSync`, or an event-handler Effect) is routed to the
+  boundary's `report` sink, which `buildDom` swaps in as `ctx.sink` for the child
+  subtree (see "Runtime error routing"). The fallback itself renders with the
+  *ambient* sink, so a failure in the fallback bubbles to the next boundary out.
+
+`reset()` re-runs construction. **`report` and `reset` both go through a `Queue`
+drained by a `forkScoped` loop** (like `asyncRef`) — never mutating boundary
+state synchronously inside the child's render, which would close the child scope
+mid-render (reentrant). Result type is `Effect<View, never, R | Scope>` — `E`
+discharged by `matchCause`, `R` folded, `Scope` for the fork. The fallback's own
+`E`/`R` are not folded (keep it pure markup, like `Async`'s arms).
+
+Unlike `Async`, this **is** a View IR variant (`Boundary`) — the sink-swap for
+the child subtree is a `buildDom`-time concern an existing `Reactive` can't
+express. The compiler skips the `h.track` wrap for `catchCause(...)` calls (it's
+in `isSelfTrackingCall` alongside `Async`); import it unaliased.
 
 ## mount internals — invariants
 

--- a/packages/core/src/runtime/View.ts
+++ b/packages/core/src/runtime/View.ts
@@ -1,8 +1,19 @@
 import { Data } from "effect"
+import type { Cause } from "effect"
 import type { Atom } from "effect/unstable/reactivity"
 import type { AtomRef } from "effect/unstable/reactivity"
 
 export type Props = Readonly<Record<string, unknown>>
+
+/**
+ * A `ViewBoundary`'s current content: the child subtree rendered normally
+ * (`ok`), or a caught failure awaiting the fallback (`error`). Driven by
+ * `catchCause` — construction sets the initial value, a live failure reported
+ * from the child subtree flips it to `error`, and `reset` re-runs construction.
+ */
+export type BoundaryState =
+  | { readonly _tag: "ok"; readonly view: View }
+  | { readonly _tag: "error"; readonly cause: Cause.Cause<unknown> }
 
 // Per-variant named interfaces — required so TS preserves the `View` alias
 // in hovers. `Data.TaggedEnum<{...}>` runs every variant through
@@ -41,6 +52,19 @@ export interface ViewList {
 export interface ViewEmpty {
   readonly _tag: "Empty"
 }
+// Error boundary. Renders `state.ok.view` (child subtree) or, on a caught
+// failure, `handler(cause, reset)` (fallback). Unlike other variants this
+// carries behavior, not just data: `handler` produces the fallback, `reset`
+// re-runs the child construction, and `report` is the sink the child subtree's
+// LIVE failures route to (mount swaps `ctx.sink` to it when descending). See
+// `catchCause` (index.ts) which builds it and drives `state`.
+export interface ViewBoundary {
+  readonly _tag: "Boundary"
+  readonly state: AtomRef.ReadonlyRef<BoundaryState>
+  readonly handler: (cause: Cause.Cause<unknown>, reset: () => void) => unknown
+  readonly reset: () => void
+  readonly report: (cause: Cause.Cause<unknown>) => void
+}
 
 export type View =
   | ViewText
@@ -48,12 +72,13 @@ export type View =
   | ViewFragment
   | ViewReactive
   | ViewList
+  | ViewBoundary
   | ViewEmpty
 
 export const View = Data.taggedEnum<View>()
 
 export const VIEW_TAGS: ReadonlySet<View["_tag"]> = new Set<View["_tag"]>([
-  "Text", "Element", "Fragment", "Reactive", "List", "Empty",
+  "Text", "Element", "Fragment", "Reactive", "List", "Boundary", "Empty",
 ])
 
 export const isView = (u: unknown): u is View =>

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -1,12 +1,12 @@
 import { Cause, Effect, Fiber, Layer, Queue, Scope } from "effect"
 import { AsyncResult, AtomRef, AtomRegistry } from "effect/unstable/reactivity"
 import { trackDeps } from "./coerce.ts"
-import { type Props, View } from "./View.ts"
+import { type BoundaryState, type Props, View } from "./View.ts"
 
 export { h } from "./h.ts"
 export { mount } from "./mount.ts"
 export { type Props, View } from "./View.ts"
-// `Async`, `asyncRef`, `list`, `Fragment`, `VerrexLive` are declared + exported below.
+// `Async`, `asyncRef`, `catchCause`, `list`, `Fragment`, `VerrexLive` are declared + exported below.
 export type { Child, ChildE, ChildR, FoldE, FoldR, TagE, TagProps, TagR } from "./types/Fold.ts"
 export type { HtmlEventHandlers, IntrinsicProps } from "./types/Html.ts"
 
@@ -161,6 +161,75 @@ export const Async = <A, E, R>(
       }),
     ),
   )
+
+/**
+ * View-level error boundary — the catch-all. Mirrors `Effect.catchCause`: it
+ * recovers the FAILURE side of a view subtree and lets success pass through (the
+ * child renders itself). Contrast `Async`, which matches a data `AsyncResult`
+ * and renders *every* state — a boundary supplies only the failure fallback.
+ *
+ * `catchCause(child, (cause, reset) => fallback)` catches both phases of failure:
+ *  - **construction** — `child`'s build Effect fails (run under `Effect.catchCause`);
+ *  - **live** — a post-mount failure inside the rendered subtree (a reactive
+ *    re-render or an event-handler Effect) routed to this boundary's sink.
+ * Either swaps the subtree for `fallback(cause, reset)`; `reset()` re-runs the
+ * child's construction. Pure-interrupt causes (scope teardown) are ignored.
+ *
+ * `child`'s `R` folds into the component (construction + every `reset` run on the
+ * mount fiber, like `asyncRef`), so a forgotten `Layer` is still a compile error
+ * at `mount`. `cause` is `Cause<unknown>` for now — the typed `View<E>` discharge
+ * (where a forgotten boundary becomes a compile error naming the error) lands in
+ * a later pass. The fallback's own `E`/`R` are not folded — keep it pure markup,
+ * like `Async`'s arms.
+ *
+ * ```tsx
+ * {catchCause(<UserCard id={id} />, (cause, reset) => (
+ *   <div class="err">{Cause.pretty(cause)}<button onClick={reset}>retry</button></div>
+ * ))}
+ * ```
+ */
+export const catchCause = <E, R>(
+  child: Effect.Effect<View, E, R>,
+  handler: (cause: Cause.Cause<unknown>, reset: () => void) => View | Effect.Effect<View, any, any>,
+): Effect.Effect<View, never, R | Scope.Scope> =>
+  Effect.gen(function* () {
+    // Run `child`, folding both outcomes into a BoundaryState. `Effect.matchCause`
+    // discharges `child`'s E (catch-all) while keeping R; re-runnable for reset.
+    const construct: Effect.Effect<BoundaryState, never, R> = Effect.matchCause(child, {
+      onSuccess: (view): BoundaryState => ({ _tag: "ok", view }),
+      onFailure: (cause): BoundaryState => ({ _tag: "error", cause }),
+    })
+
+    // Initial construction inline (folds R; no first-paint flash before the
+    // child appears — unlike a forked run, which mount would race).
+    const state = AtomRef.make<BoundaryState>(yield* construct)
+    const runs = yield* Queue.unbounded<{ readonly _tag: "reset" } | {
+      readonly _tag: "error"
+      readonly cause: Cause.Cause<unknown>
+    }>()
+
+    // report/reset both go through the queue → applied on the forked fiber, never
+    // synchronously inside the child's render (which would close the child scope
+    // mid-render — reentrant). This is also why `report` is safe as a sink.
+    const report = (cause: Cause.Cause<unknown>): void => {
+      if (!Cause.hasInterruptsOnly(cause)) Queue.offerUnsafe(runs, { _tag: "error", cause })
+    }
+    const reset = (): void => {
+      Queue.offerUnsafe(runs, { _tag: "reset" })
+    }
+
+    yield* Effect.forkScoped(
+      Effect.gen(function* () {
+        while (true) {
+          const msg = yield* Queue.take(runs)
+          if (msg._tag === "error") state.set({ _tag: "error", cause: msg.cause })
+          else state.set(yield* construct)
+        }
+      }),
+    )
+
+    return View.Boundary({ state, handler, reset, report })
+  })
 
 /**
  * Fragment component — the compile target for JSX `<>...</>` syntax.

--- a/packages/core/src/runtime/mount.ts
+++ b/packages/core/src/runtime/mount.ts
@@ -2,7 +2,7 @@ import { Cause, Context, Effect, Exit, Scope } from "effect"
 import { Atom, AtomRef, AtomRegistry } from "effect/unstable/reactivity"
 import { coerceSync, type ErrorSink, isAtomRef } from "./coerce.ts"
 import { plan } from "./reconcile.ts"
-import { type Props, View } from "./View.ts"
+import { type BoundaryState, type Props, View } from "./View.ts"
 
 // Stable, scope-independent dependencies threaded through the whole build path.
 // `scope` is passed separately because it changes per dynamic subtree; these
@@ -305,6 +305,33 @@ const buildDom = (view: View, ctx: BuildCtx, scope: Scope.Scope): Node => {
       )
 
       return wrapper
+    }
+
+    case "Boundary": {
+      // The child subtree renders with a sink that reports into THIS boundary
+      // (live failures flip its state to `error`); the fallback renders with the
+      // ambient `ctx` sink, so a failure in the fallback bubbles to the next
+      // boundary outward. Same build-NEW → swap → close-OLD ordering as Reactive.
+      const childCtx: BuildCtx = { ...ctx, sink: view.report }
+      let currentNode: Node = document.createComment("boundary-pending")
+      let contentScope: Scope.Closeable | null = null
+
+      const render = (st: BoundaryState): void => {
+        const built =
+          st._tag === "ok"
+            ? buildScopedChild(st.view, scope, childCtx)
+            : buildScopedChild(view.handler(st.cause, view.reset), scope, ctx)
+        if (currentNode.parentNode) {
+          currentNode.parentNode.replaceChild(built.node, currentNode)
+        }
+        if (contentScope) closeScope(contentScope)
+        contentScope = built.scope
+        currentNode = built.node
+      }
+
+      render(view.state.value)
+      subscribeRefScoped(view.state, render, scope)
+      return currentNode
     }
   }
 }

--- a/packages/core/src/testing/catch-cause.test.ts
+++ b/packages/core/src/testing/catch-cause.test.ts
@@ -1,0 +1,170 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from "vitest"
+import { Cause, Data, Effect } from "effect"
+import { AtomRef } from "effect/unstable/reactivity"
+import { catchCause, h } from "@verrex/core"
+import { render } from "./index.ts"
+
+// PR2: `catchCause(child, (cause, reset) => fallback)` — the catch-all view
+// boundary. Mirrors `Effect.catchCause`: recover the failure side of a subtree,
+// pass success through. Catches BOTH phases (construction + live) and offers a
+// `reset` that re-runs construction. Cause is `Cause<unknown>` (typed discharge
+// is a later pass).
+
+class BoomError extends Data.TaggedError("BoomError")<{ readonly why: string }> {}
+
+describe("catchCause — success", () => {
+  it("renders the child and never calls the handler", async () => {
+    let handlerCalls = 0
+    const Child = Effect.fn("Child")(function* (_props: {} = {}) {
+      return yield* h("p", { class: "child" }, "hello")
+    })
+    const App = Effect.fn("App")(function* (_props: {} = {}) {
+      return yield* catchCause(Child(), (cause) => {
+        handlerCalls++
+        return h("p", { class: "fallback" }, Cause.pretty(cause))
+      })
+    })
+
+    const ui = await render(App())
+    expect(ui.text(".child")).toBe("hello")
+    expect(ui.query(".fallback")).toBeNull()
+    expect(handlerCalls).toBe(0)
+    await ui.unmount()
+  })
+})
+
+describe("catchCause — construction failure", () => {
+  it("renders the fallback with the cause when the child build Effect fails", async () => {
+    const Child = Effect.fn("Child")(function* (_props: {} = {}) {
+      yield* Effect.fail(new BoomError({ why: "construction" }))
+      return yield* h("p", { class: "child" }, "unreachable")
+    })
+    const App = Effect.fn("App")(function* (_props: {} = {}) {
+      return yield* catchCause(Child(), (cause) =>
+        h("div", { class: "fallback" }, Cause.pretty(cause)),
+      )
+    })
+
+    const ui = await render(App())
+    expect(ui.query(".child")).toBeNull()
+    expect(ui.query(".fallback")).not.toBeNull()
+    expect(ui.text(".fallback")).toContain("BoomError")
+    await ui.unmount()
+  })
+})
+
+describe("catchCause — live failures", () => {
+  it("swaps to the fallback when an event-handler Effect in the child fails", async () => {
+    const Child = Effect.fn("Child")(function* (_props: {} = {}) {
+      return yield* h(
+        "div",
+        { class: "child" },
+        h("button", { class: "boom", onClick: () => Effect.fail(new BoomError({ why: "click" })) }, "explode"),
+      )
+    })
+    const App = Effect.fn("App")(function* (_props: {} = {}) {
+      return yield* catchCause(Child(), (cause) =>
+        h("div", { class: "fallback" }, Cause.pretty(cause)),
+      )
+    })
+
+    const ui = await render(App())
+    expect(ui.query(".child")).not.toBeNull()
+
+    ui.click(".boom")
+    await ui.waitFor(".fallback")
+    expect(ui.query(".child")).toBeNull()
+    expect(ui.text(".fallback")).toContain("BoomError")
+    await ui.unmount()
+  })
+
+  it("swaps to the fallback when a reactive re-render Effect fails", async () => {
+    const trigger = AtomRef.make(false)
+    const Child = Effect.fn("Child")(function* (_props: {} = {}) {
+      return yield* h(
+        "div",
+        { class: "child" },
+        // Reactive child: emits "ok" until `trigger` flips, then emits a failing
+        // Effect — coerceSync runs it, the failure routes to the boundary sink.
+        trigger.map((t) => (t ? Effect.fail(new BoomError({ why: "reactive" })) : "ok")),
+      )
+    })
+    const App = Effect.fn("App")(function* (_props: {} = {}) {
+      return yield* catchCause(Child(), (cause) =>
+        h("div", { class: "fallback" }, Cause.pretty(cause)),
+      )
+    })
+
+    const ui = await render(App())
+    expect(ui.text(".child")).toBe("ok")
+
+    trigger.set(true)
+    await ui.waitFor(".fallback")
+    expect(ui.query(".child")).toBeNull()
+    expect(ui.text(".fallback")).toContain("BoomError")
+    await ui.unmount()
+  })
+})
+
+describe("catchCause — reset", () => {
+  it("reset() re-runs construction and brings the child back", async () => {
+    let shouldFail = true
+    const Child = Effect.fn("Child")(function* (_props: {} = {}) {
+      if (shouldFail) {
+        shouldFail = false
+        yield* Effect.fail(new BoomError({ why: "first build" }))
+      }
+      return yield* h("p", { class: "child" }, "recovered")
+    })
+    const App = Effect.fn("App")(function* (_props: {} = {}) {
+      return yield* catchCause(Child(), (cause, reset) =>
+        h(
+          "div",
+          { class: "fallback" },
+          Cause.pretty(cause),
+          h("button", { class: "retry", onClick: reset }, "retry"),
+        ),
+      )
+    })
+
+    const ui = await render(App())
+    // First construction failed → fallback.
+    expect(ui.query(".fallback")).not.toBeNull()
+    expect(ui.query(".child")).toBeNull()
+
+    // reset → re-run construction (now succeeds) → child returns.
+    ui.click(".retry")
+    await ui.waitFor(".child")
+    expect(ui.text(".child")).toBe("recovered")
+    expect(ui.query(".fallback")).toBeNull()
+    await ui.unmount()
+  })
+
+  it("reset() after a live failure rebuilds a fresh child subtree", async () => {
+    const Child = Effect.fn("Child")(function* (_props: {} = {}) {
+      return yield* h(
+        "div",
+        { class: "child" },
+        h("button", { class: "boom", onClick: () => Effect.fail(new BoomError({ why: "click" })) }, "explode"),
+      )
+    })
+    const App = Effect.fn("App")(function* (_props: {} = {}) {
+      return yield* catchCause(Child(), (cause, reset) =>
+        h("div", { class: "fallback" }, h("button", { class: "retry", onClick: reset }, "retry")),
+      )
+    })
+
+    const ui = await render(App())
+    ui.click(".boom")
+    await ui.waitFor(".fallback")
+
+    ui.click(".retry")
+    await ui.waitFor(".child")
+    expect(ui.query(".fallback")).toBeNull()
+    // The fresh child still works (its button is wired again).
+    ui.click(".boom")
+    await ui.waitFor(".fallback")
+    await ui.unmount()
+  })
+})


### PR DESCRIPTION
**Stacked on #62** (base = `pr1-runtime-error-routing`). PR 2 of the unified error-model build order — the runtime boundary. Still untyped `Cause<unknown>`; the typed `View<E>` discharge is PR 3.

## API — a function, named after Effect

`catchCause(child, (cause, reset) => fallback)` mirrors **`Effect.catchCause`** (the only catch-all in v4 — there's no `catchAll`). It's a positional function like `Async`/`list` (inference: `child` fixes before the handler types), *not* a JSX component. It recovers the **failure** side of a subtree and lets success pass through — contrast `Async`, which matches a data `AsyncResult` and renders *every* state. (`catchTag`/`catchTags` + typed discharge follow in PR 3.)

```tsx
{catchCause(<UserCard id={id} />, (cause, reset) => (
  <div class="err">{Cause.pretty(cause)}<button onclick={reset}>retry</button></div>
))}
```

## What it catches — both phases, one fallback

- **construction** — `child`'s build Effect runs under `Effect.matchCause` (inline → `R` folds, no first-paint flash); a failure is the initial `error` state.
- **live** — a post-mount failure inside the subtree (a reactive re-render, or an event-handler Effect from PR 1) routes to the boundary's sink, which `buildDom` swaps in as `ctx.sink` for the child subtree. The fallback renders with the **ambient** sink, so a failure in the fallback bubbles outward to the next boundary.

`reset()` re-runs construction. `report` + `reset` both go through a `Queue` drained by a `forkScoped` loop (like `asyncRef`) — so boundary state never mutates **synchronously inside the child's render**, which would close the child scope mid-render (reentrant).

## New View IR variant

Unlike `Async` (a pure helper over `Reactive`), this needs a `Boundary` IR variant — redirecting the child subtree's error sink is a `buildDom`-time concern `Reactive`-over-a-ref can't express. Variant count 6 → 7. The compiler adds `catchCause` to `isSelfTrackingCall` (skip the `h.track` wrap, same as `Async`).

Result type: `Effect<View, never, R | Scope>` — `E` discharged by `matchCause`, `R` folded, `Scope` for the fork. The fallback's own `E`/`R` aren't folded (pure markup, like `Async` arms).

## Tests & coverage

- **Integration** (`testing/catch-cause.test.ts`, 6): success-passthrough (handler never called), construction failure → fallback with cause, live **event-handler** failure → swap, live **reactive-render** failure → swap, `reset` after construction failure → child recovers, `reset` after live failure → fresh child. All via the real `mount`/`buildDom`/`catchCause` (the "did the click re-render" check the project flags for UI changes).
- **Compiler** (`transform.test.ts`, +2): `catchCause(...)` left un-`h.track`-wrapped, inner `.value`→`h.read` kept.
- **Demo** (`CatchCause.vx`, step 07): exercises it end-to-end — `pnpm --filter verrex-demo typecheck` (12 files, 0 errors) and `vite build` (268 modules) both pass through the real Babel→h→oxc pipeline.

`pnpm -r test` (core 194 + ts-plugin 31) and `pnpm -r typecheck` all green. AGENTS.md updated (runtime: the `Boundary` variant + a `catchCause` section + the sink-redirect rationale; compiler: `isSelfTrackingCall`).

## Next (PR 3)

`View<E>` + typed `catchCause`/`catchTag`/`catchTags` discharging both the Effect-E and View-E channels + `mount` requiring `View<never>`, gated on promoting the proven A1 spike into `channels.test-d.ts`.