### PR TITLE
feat(core)!: type the error channel — View<E> + typed catchCause + mount gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,13 @@
 **Purpose:** a TypeScript UI framework where Effect's `<A, E, R>`
 channels propagate from every leaf of the view tree to the root.
 Forgetting to provide a service `Layer` becomes a *compile-time
-error that names the missing service*.
+error that names the missing service*; symmetrically, forgetting to
+handle an error with a `catchCause` boundary becomes a *compile-time
+error that names the unhandled error* (`mount` requires
+`Effect<View<never>, never, R>`). Errors live in two phases:
+construction errors ride the Effect `E`; live errors a rendered subtree
+can still produce ride the `View<E>` success — one boundary discharges
+both.
 
 **The name** is built from the channels of an `Effect<View, E, R>`:
 **V** (View — the `A`, always the `View` here), **E** (Error), **R**

--- a/apps/demo/src/channels.test-d.ts
+++ b/apps/demo/src/channels.test-d.ts
@@ -4,9 +4,9 @@
  * Each assertion either holds or produces a type error naming the
  * mismatched channel — this *is* the demonstration.
  */
-import type { Chunk, Effect, Option, Result, Scope } from "effect"
+import type { Cause, Chunk, Effect, Option, Result, Scope } from "effect"
 import type { AtomRegistry } from "effect/unstable/reactivity"
-import { h, type View } from "@verrex/core"
+import { catchCause, h, mount, type View } from "@verrex/core"
 import { AsyncUserPage } from "./AsyncUserPage.vx"
 import { Counter } from "./Counter.vx"
 import { LiveUser } from "./LiveUser.vx"
@@ -165,7 +165,37 @@ declare const chunkEff: Chunk.Chunk<Effect.Effect<View, HttpError, Http>>
 const WithChunk = h("div", {}, chunkEff)
 assertEquals<typeof WithChunk, Effect.Effect<View, HttpError, Http>>()
 
+// ─── The error-boundary thesis: discharge-or-it-won't-compile ───────────
+//     `catchCause` discharges a subtree's errors; `mount` requires a fully
+//     discharged app (`View<never>`, `never`). A forgotten boundary is a
+//     compile error that NAMES the error — the runtime counterpart of a
+//     forgotten Layer naming a service.
+
+declare const root: HTMLElement
+
+// catchCause turns a failing subtree into a fully-discharged one. The handler's
+// cause is precisely typed — `Cause<HttpError>`, not `Cause<unknown>`.
+const Caught = catchCause(UserPage({ userId: "42" }), (cause, reset) => {
+  const _typedCause: Cause.Cause<HttpError> = cause
+  void _typedCause
+  void reset
+  return h("div", {}, "failed")
+})
+// E discharged to `never`; UserPage's `Http | Theme` fold through, plus `Scope`
+// from the boundary's fork.
+assertEquals<typeof Caught, Effect.Effect<View, never, Http | Theme | Scope.Scope>>()
+
+// @ts-expect-error — UserPage's HttpError is undischarged: `mount` rejects it,
+// and the error names `HttpError` (not assignable to `never`). Forgot a boundary.
+mount(UserPage({ userId: "42" }), root)
+
+// With the boundary, the same app mounts.
+mount(Caught, root)
+
+// A pure component needs no boundary — it's already `View<never>`, `never`.
+mount(Counter(), root)
+
 // Note: the type assertions above are the **load-bearing proof** of the POC.
 // If they compile, channels are surviving the tree.
 // The `@ts-expect-error` assertions above prove props are type-checked at
-// JSX call sites.
+// JSX call sites, and that a forgotten error boundary fails to compile.

--- a/apps/demo/src/main.vx
+++ b/apps/demo/src/main.vx
@@ -1,6 +1,6 @@
 import { Cause, Effect, Exit, Fiber, Layer, Scope } from "effect"
 import { AtomRegistry } from "effect/unstable/reactivity"
-import { VerrexLive, mount, type View } from "@verrex/core"
+import { VerrexLive, catchCause, mount, type View } from "@verrex/core"
 import { Counter } from "./Counter.vx"
 import { AsyncUserPage } from "./AsyncUserPage.vx"
 import { CatchCause } from "./CatchCause.vx"
@@ -332,9 +332,22 @@ const setupDemo = <E>(id: string, make: () => Effect.Effect<View, E, DemoR>): vo
   const remount = (): void => {
     teardown?.()
     const scope = Scope.makeUnsafe()
+    // `mount` requires a discharged app. Wrap every demo in a `catchCause`
+    // boundary so any error (construction or live) becomes a visible fallback
+    // instead of a compile error here — and to discharge the `E` channel uniformly
+    // (UserPage carries HttpError). The happy paths don't fail, so they render
+    // through unchanged; this is also where the boundary itself gets exercised.
     Effect.runFork(
       Scope.provide(
-        mount(make(), container).pipe(
+        mount(
+          catchCause(make(), (cause) => (
+            <div class="demo-error">
+              <strong>this demo failed:</strong>
+              <pre>{Cause.pretty(cause)}</pre>
+            </div>
+          )),
+          container,
+        ).pipe(
           Effect.catchCause((cause) =>
             Effect.sync(() => console.error(`[verrex demo: ${id}]`, Cause.pretty(cause))),
           ),

--- a/packages/core/src/runtime/AGENTS.md
+++ b/packages/core/src/runtime/AGENTS.md
@@ -5,19 +5,25 @@ Public surface (from `index.ts`):
 
 - `h` — the view factory (the compile target for `<...>` source
   syntax) + `h.track`/`h.read` (compiler hooks)
-- `mount` — DOM renderer (returns `Effect<void, E, R | AtomRegistry | Scope>`)
+- `mount` — DOM renderer. **Requires `Effect<View<never>, never, R>`** (every
+  error discharged), returns `Effect<void, never, R | AtomRegistry | Scope>`
 - `list` — keyed reactive list helper (`View.List` IR node)
 - `Async` / `asyncRef` — async render boundary + primitive (errors-as-values; see "`asyncRef` / `Async`" below)
 - `catchCause` — view-level error boundary (catch-all; mirrors `Effect.catchCause`; see "`catchCause`" below)
 - `Fragment` — `<>...</>` compile target
 - `VerrexLive` — base Layer providing `AtomRegistry`
-- Types: `View`, `Props`, `FoldE`/`FoldR`/`TagE`/`TagR`/`TagProps`,
+- Types: `View<E>`, `Props`, `FoldE`/`FoldLiveE`/`FoldR`/`TagE`/`TagLiveE`/`TagR`/`TagProps`,
   `IntrinsicProps`, `HtmlEventHandlers`
 
 This is where the **channel propagation contract lives** —
-`h()`'s signature uses `FoldE`/`FoldR` conditional types to union
-every child's `E` and `R` into the result type. See
-[`types/Fold.ts`](./types/Fold.ts).
+`h()`'s signature uses the fold conditional types to union every child's
+channels into the result. Errors split by phase: **construction** errors
+(`FoldE`/`TagE`) ride the result Effect's `E`; **live** errors a rendered
+subtree can still produce (`FoldLiveE`/`TagLiveE`) ride the `View<E>` success.
+`R` unifies (`FoldR`/`TagR`). `mount` requires both error channels `never`;
+`catchCause` discharges them. A forgotten boundary is a compile error that
+names the error — the runtime counterpart of a forgotten Layer naming a
+service. See [`types/Fold.ts`](./types/Fold.ts).
 
 ### `h()` parameter naming — coupled to the TS plugin
 
@@ -34,13 +40,13 @@ the editor margin. If you rename them, update the regex.
 |---|---|
 | `h.ts` | `h()` factory + `track`/`read` reactivity-tracking machinery (built on `trackDeps`/`recordDep` from `coerce.ts`) |
 | `coerce.ts` | `coerceAsync` (any child shape → `Effect<View>`) and `coerceSync` (render-time emission → `View`). Internal; not re-exported from `index.ts`. Owns `isAtomRef` (brand check against `AtomRef.TypeId`) and the shared dependency tracker `trackDeps`/`recordDep` (used by both `h.track` and `Async`) |
-| `View.ts` | `View` IR (intermediate representation) — hand-written union of 6 named interfaces (`ViewText`, `ViewElement`, `ViewFragment`, `ViewReactive`, `ViewList`, `ViewEmpty`); constructors via `Data.taggedEnum<View>()`. The normalized DOM-materialization shape `mount` switches on. Plus `isView`, `VIEW_TAGS` |
+| `View.ts` | `View<E>` IR. The runtime shape is `ViewNode` — a hand-written union of 7 phantom-free named interfaces (`ViewText`…`ViewBoundary`, `ViewEmpty`); constructors via `Data.taggedEnum<ViewNode>()`. `View<E = never> = ViewNode & ViewErr<E>` layers the runtime-error channel on via a covariant phantom (`ViewErr`), so `View<HttpError>` ⊄ `View<never>` (mount can require it) while a `ViewNode` ⊂ any `View<E>` (constructors need no casts). Plus `isView`, `VIEW_TAGS` |
 | `mount.ts` | DOM renderer. `buildDom(view, ctx, scope) → Node` (`ctx: BuildCtx = { registry, context, sink }`), `mount(app, el)`. Cleanup is delegated to `Scope` — every subscription/listener/release registers a finalizer on the scope it was created in, and parent-fork cascade tears them down on close. Owns `buildScopedChild` (the one place a dynamic subtree gets a parent-linked child scope), the `List` **interpreter** that applies a `reconcile.ts` plan to real DOM + scopes, and the error **sink** (runs event-handler Effects + routes runtime failures) |
 | `reconcile.ts` | Pure keyed-list diff. `plan(prevKeys, nextKeys) → ReconcileOp[]` over opaque keys — no DOM, no `Scope`, no `Effect`. The runtime's highest-bug-density logic, made exhaustively unit-testable. `mount`'s `List` case interprets the ops |
 | `index.ts` | Public exports + `list`, `Async`, `asyncRef`, `catchCause`, `Fragment`, `VerrexLive` |
 | `coerce.test.ts` | Vitest suite for `coerceAsync` / `coerceSync` (parity + the sync/async asymmetry pin) |
 | `reconcile.test.ts` | Pure diff tests — an apply-to-array oracle (plan turns `prev` into `next`) plus exact op-sequence pins (move-minimality matches the old single-pass; index updates on shift) |
-| `types/Fold.ts` | `ChildE`/`ChildR`/`FoldE`/`FoldR`/`TagE`/`TagR`/`TagProps` — the channel-fold conditional types |
+| `types/Fold.ts` | `ChildE`/`ChildLiveE`/`ChildR` + `FoldE`/`FoldLiveE`/`FoldR` + `TagE`/`TagLiveE`/`TagR`/`TagProps` — the channel-fold conditional types. Two error families: construction (`*E`, Effect channel) vs live (`*LiveE`, `View<E>` channel) |
 | `types/Html.ts` | `IntrinsicProps`/`HtmlEventHandlers` — typed event handlers for HTML intrinsics |
 | `types/Fold.test-d.ts` | `expectTypeOf` matrix — every channel-fold shape |
 
@@ -238,8 +244,16 @@ reactive state (Counter, `list`) — just not the spine for effectful data.
 recover the **failure** side of a view subtree, let success pass through (the
 child renders itself). Contrast `Async`, which matches a data `AsyncResult` and
 renders *every* state (`initial`/`success`/`failure`) — a boundary only supplies
-the failure fallback. (Tag-selective `catchTag`/`catchTags` + the typed `Cause<E>`
-discharge come later; this is the untyped catch-all.)
+the failure fallback. (Tag-selective `catchTag`/`catchTags`, which narrow `E`
+rather than discharging all of it, come later.)
+
+**Typed discharge.** Signature `catchCause<EV, EC, R>(child: Effect<View<EV>, EC, R>,
+handler: (cause: Cause<EC | EV>, reset) => …): Effect<View<never>, never, R | Scope>`.
+The handler's `cause` is the *precise* `Cause<EC | EV>` (both the construction `EC`
+and live `EV` of the child) — not `Cause<unknown>`. It discharges both channels to
+`never`, so the result is mountable. A subtree with undischarged errors won't pass
+`mount` — that's the thesis. (The fallback's own `E`/`R` are permissive `any`/not
+folded — keep it pure markup, like `Async`'s arms.)
 
 Catches **both phases** through one fallback:
 - **construction** — `child`'s build Effect is run under `Effect.matchCause`; a
@@ -255,9 +269,8 @@ Catches **both phases** through one fallback:
 `reset()` re-runs construction. **`report` and `reset` both go through a `Queue`
 drained by a `forkScoped` loop** (like `asyncRef`) — never mutating boundary
 state synchronously inside the child's render, which would close the child scope
-mid-render (reentrant). Result type is `Effect<View, never, R | Scope>` — `E`
-discharged by `matchCause`, `R` folded, `Scope` for the fork. The fallback's own
-`E`/`R` are not folded (keep it pure markup, like `Async`'s arms).
+mid-render (reentrant). The runtime impl is untyped (`Cause<unknown>` sink); the
+precise `Cause<EC | EV>` is the public-signature contract, bridged by one cast.
 
 Unlike `Async`, this **is** a View IR variant (`Boundary`) — the sink-swap for
 the child subtree is a `buildDom`-time concern an existing `Reactive` can't
@@ -290,9 +303,10 @@ Effect — `applyProp` forks it via `Effect.runForkWith(ctx.context)` (so it get
 the app's services) and `Effect.matchCause` routes its failure to the same sink.
 Both guard with `Cause.hasInterruptsOnly` — a pure-interrupt cause is scope
 teardown, not an error, and is dropped. The root sink (`mount`) logs via
-`Effect.logError` on the captured context; a future `<Boundary>` will replace
-the sink per-subtree (the typed-discharge design). A handler that returns a
-non-Effect value runs as a plain imperative callback, unchanged.
+`Effect.logError` on the captured context; a `catchCause` boundary replaces the
+sink per-subtree (`buildDom` swaps in the boundary's `report` for the child — see
+"`catchCause`"). A handler that returns a non-Effect value runs as a plain
+imperative callback, unchanged.
 
 **`subscribeRefScoped` / `subscribeAtomScoped`** are the only two
 ways to subscribe to a reactive source from inside `mount.ts`.

--- a/packages/core/src/runtime/View.ts
+++ b/packages/core/src/runtime/View.ts
@@ -6,19 +6,44 @@ import type { AtomRef } from "effect/unstable/reactivity"
 export type Props = Readonly<Record<string, unknown>>
 
 /**
+ * Phantom carrier for a View's runtime-error channel `E` — the errors a live
+ * subtree can still produce after construction (an async refetch, a reactive
+ * re-render, an event-handler Effect), routed to the nearest `catchCause`.
+ *
+ * Covariant via `() => E`, which gives exactly the variance the thesis needs:
+ *  - `View<HttpError>` is NOT assignable to `View<never>`, so `mount` requiring
+ *    `View<never>` is a compile error until every error is discharged by a
+ *    boundary (it names the error — the runtime counterpart of a forgotten Layer);
+ *  - a phantom-free `ViewNode` (what the constructors produce) IS assignable to
+ *    any `View<E>` (the marker is optional and absent), so construction needs no
+ *    casts and `View.Empty()` stays a no-arg call.
+ *
+ * Kept off the variant interfaces (so `Data.taggedEnum` constructor args don't
+ * gain a phantom field) and mixed in only via `View<E> = ViewNode & ViewErr<E>`.
+ * The fold (`ChildE` in types/Fold.ts) reads it directly via `infer`; it does
+ * not walk a View's children, so the recursion stays shallow.
+ */
+declare const ErrorTypeId: unique symbol
+export interface ViewErr<E> {
+  readonly [ErrorTypeId]?: () => E
+}
+
+/**
  * A `ViewBoundary`'s current content: the child subtree rendered normally
  * (`ok`), or a caught failure awaiting the fallback (`error`). Driven by
  * `catchCause` — construction sets the initial value, a live failure reported
  * from the child subtree flips it to `error`, and `reset` re-runs construction.
  */
 export type BoundaryState =
-  | { readonly _tag: "ok"; readonly view: View }
+  | { readonly _tag: "ok"; readonly view: ViewNode }
   | { readonly _tag: "error"; readonly cause: Cause.Cause<unknown> }
 
 // Per-variant named interfaces — required so TS preserves the `View` alias
 // in hovers. `Data.TaggedEnum<{...}>` runs every variant through
 // `Types.Simplify`, which strips the alias and forces TS to inline the full
-// union everywhere `Effect<View, ...>` appears.
+// union everywhere `Effect<View, ...>` appears. These are the phantom-free
+// runtime shapes the `Data.taggedEnum` constructors build; the error channel is
+// mixed in only at the `View<E>` alias below.
 export interface ViewText {
   readonly _tag: "Text"
   readonly value: string
@@ -27,11 +52,11 @@ export interface ViewElement {
   readonly _tag: "Element"
   readonly tag: string
   readonly props: Props
-  readonly children: ReadonlyArray<View>
+  readonly children: ReadonlyArray<ViewNode>
 }
 export interface ViewFragment {
   readonly _tag: "Fragment"
-  readonly children: ReadonlyArray<View>
+  readonly children: ReadonlyArray<ViewNode>
 }
 export interface ViewReactive {
   readonly _tag: "Reactive"
@@ -66,7 +91,9 @@ export interface ViewBoundary {
   readonly report: (cause: Cause.Cause<unknown>) => void
 }
 
-export type View =
+/** The phantom-free runtime IR — the shape `mount` switches on and the
+ * constructors build. `View<E>` layers the error channel on top. */
+export type ViewNode =
   | ViewText
   | ViewElement
   | ViewFragment
@@ -75,12 +102,20 @@ export type View =
   | ViewBoundary
   | ViewEmpty
 
-export const View = Data.taggedEnum<View>()
+/**
+ * The public View type, carrying its runtime-error channel `E` (defaulting to
+ * `never` — a bare `View` is `View<never>`, fully discharged). `h()` stamps the
+ * folded `E` of a subtree onto its result; `catchCause` discharges it; `mount`
+ * requires `View<never>`. Structurally a `ViewNode` plus the phantom marker.
+ */
+export type View<E = never> = ViewNode & ViewErr<E>
 
-export const VIEW_TAGS: ReadonlySet<View["_tag"]> = new Set<View["_tag"]>([
+export const View = Data.taggedEnum<ViewNode>()
+
+export const VIEW_TAGS: ReadonlySet<ViewNode["_tag"]> = new Set<ViewNode["_tag"]>([
   "Text", "Element", "Fragment", "Reactive", "List", "Boundary", "Empty",
 ])
 
-export const isView = (u: unknown): u is View =>
+export const isView = (u: unknown): u is ViewNode =>
   typeof u === "object" && u !== null && "_tag" in u &&
-  VIEW_TAGS.has((u as { _tag: View["_tag"] })._tag)
+  VIEW_TAGS.has((u as { _tag: ViewNode["_tag"] })._tag)

--- a/packages/core/src/runtime/h.ts
+++ b/packages/core/src/runtime/h.ts
@@ -1,7 +1,7 @@
 import { Effect } from "effect"
 import { AtomRef } from "effect/unstable/reactivity"
 import { coerceAsync, isAtomRef, recordDep, trackDeps } from "./coerce.ts"
-import type { FoldE, FoldR, TagE, TagProps, TagR } from "./types/Fold.ts"
+import type { FoldE, FoldLiveE, FoldR, TagE, TagLiveE, TagProps, TagR } from "./types/Fold.ts"
 import { type Props, View } from "./View.ts"
 
 // ─── Tracking scope for h.track / h.read ─────────────────────────────────
@@ -71,12 +71,12 @@ function readImpl(obj: unknown): unknown {
  * normalized via `coerceAsync` in `./coerce.ts`.
  */
 const _h = (
-  tag: string | ((props: Props) => Effect.Effect<View, any, any>),
+  tag: string | ((props: Props) => Effect.Effect<View<any>, any, any>),
   props: Props,
   ...children: ReadonlyArray<unknown>
-): Effect.Effect<View, any, any> =>
+): Effect.Effect<View<any>, any, any> =>
   Effect.gen(function* () {
-    const out: View[] = []
+    const out: View<any>[] = []
     for (const c of children) {
       out.push(yield* coerceAsync(c))
     }
@@ -87,14 +87,23 @@ const _h = (
     return View.Element({ tag, props, children: out })
   })
 
+// Errors split by phase across the two channels: CONSTRUCTION errors
+// (`FoldE`/`TagE`) on the Effect `E` (a child's build failing fails this build),
+// LIVE errors (`FoldLiveE`/`TagLiveE`) on the `View<E>` success (errors the
+// rendered subtree can still produce). `mount` requires both `never`;
+// `catchCause` discharges both. The position encodes the phase.
 type HFn = <
-  T extends string | ((props: any) => Effect.Effect<View, any, any>),
+  T extends string | ((props: any) => Effect.Effect<View<any>, any, any>),
   Cs extends readonly unknown[],
 >(
   _tag: T,
   _props: TagProps<T>,
   ..._children: Cs
-) => Effect.Effect<View, FoldE<Cs> | TagE<T>, FoldR<Cs> | TagR<T>>
+) => Effect.Effect<
+  View<FoldLiveE<Cs> | TagLiveE<T>>,
+  FoldE<Cs> | TagE<T>,
+  FoldR<Cs> | TagR<T>
+>
 
 /**
  * The view factory, plus two helper methods the compiler calls into:

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -188,13 +188,14 @@ export const Async = <A, E, R>(
  * ))}
  * ```
  */
-export const catchCause = <E, R>(
-  child: Effect.Effect<View, E, R>,
-  handler: (cause: Cause.Cause<unknown>, reset: () => void) => View | Effect.Effect<View, any, any>,
-): Effect.Effect<View, never, R | Scope.Scope> =>
+export const catchCause = <EV, EC, R>(
+  child: Effect.Effect<View<EV>, EC, R>,
+  handler: (cause: Cause.Cause<EC | EV>, reset: () => void) => View | Effect.Effect<View, any, any>,
+): Effect.Effect<View<never>, never, R | Scope.Scope> =>
   Effect.gen(function* () {
     // Run `child`, folding both outcomes into a BoundaryState. `Effect.matchCause`
-    // discharges `child`'s E (catch-all) while keeping R; re-runnable for reset.
+    // discharges `child`'s construction E (`EC`) while keeping R; re-runnable for
+    // reset. Live errors riding the child's `View<EV>` are routed to `report`.
     const construct: Effect.Effect<BoundaryState, never, R> = Effect.matchCause(child, {
       onSuccess: (view): BoundaryState => ({ _tag: "ok", view }),
       onFailure: (cause): BoundaryState => ({ _tag: "error", cause }),
@@ -228,7 +229,15 @@ export const catchCause = <E, R>(
       }),
     )
 
-    return View.Boundary({ state, handler, reset, report })
+    // The node's handler slot is `Cause<unknown>` (runtime is untyped); the public
+    // signature gives the user the precise `Cause<EC | EV>`. The values flowing in
+    // are exactly those, so the cast is sound.
+    return View.Boundary({
+      state,
+      handler: handler as (cause: Cause.Cause<unknown>, reset: () => void) => unknown,
+      reset,
+      report,
+    })
   })
 
 /**

--- a/packages/core/src/runtime/mount.ts
+++ b/packages/core/src/runtime/mount.ts
@@ -2,7 +2,7 @@ import { Cause, Context, Effect, Exit, Scope } from "effect"
 import { Atom, AtomRef, AtomRegistry } from "effect/unstable/reactivity"
 import { coerceSync, type ErrorSink, isAtomRef } from "./coerce.ts"
 import { plan } from "./reconcile.ts"
-import { type BoundaryState, type Props, View } from "./View.ts"
+import { type BoundaryState, type Props, View, type ViewNode } from "./View.ts"
 
 // Stable, scope-independent dependencies threaded through the whole build path.
 // `scope` is passed separately because it changes per dynamic subtree; these
@@ -149,7 +149,7 @@ const closeScope = (scope: Scope.Closeable): void => {
   if (e) Effect.runFork(e)
 }
 
-const buildDom = (view: View, ctx: BuildCtx, scope: Scope.Scope): Node => {
+const buildDom = (view: ViewNode, ctx: BuildCtx, scope: Scope.Scope): Node => {
   switch (view._tag) {
     case "Empty":
       return document.createComment("")
@@ -345,13 +345,19 @@ const buildDom = (view: View, ctx: BuildCtx, scope: Scope.Scope): Node => {
  * cascades to every child scope and runs all finalizers.
  *
  * Post-mount failures (a reactive re-render or an event-handler Effect that
- * fails) are routed to a root error sink that logs via `Effect.logError` on the
- * captured context. A future `<Boundary>` will replace this sink per-subtree.
+ * fails) that aren't caught by a `catchCause` boundary are routed to a root
+ * error sink that logs via `Effect.logError` on the captured context.
+ *
+ * **Requires `Effect<View<never>, never, R>`** — the app must have every error
+ * discharged: construction failures off the Effect `E` channel (via
+ * `Effect.catchCause` or a `catchCause` boundary) and live failures off the
+ * `View<E>` channel (via `catchCause`). A leftover error is a compile error here
+ * that names it — the runtime counterpart of a forgotten `Layer` naming a service.
  */
-export const mount = <E, R>(
-  app: Effect.Effect<View, E, R>,
+export const mount = <R>(
+  app: Effect.Effect<View<never>, never, R>,
   el: HTMLElement,
-): Effect.Effect<void, E, R | AtomRegistry.AtomRegistry | Scope.Scope> =>
+): Effect.Effect<void, never, R | AtomRegistry.AtomRegistry | Scope.Scope> =>
   Effect.gen(function* () {
     const registry = yield* AtomRegistry.AtomRegistry
     // The real ambient context (carries the app's provided services). Typed

--- a/packages/core/src/runtime/types/Fold.test-d.ts
+++ b/packages/core/src/runtime/types/Fold.test-d.ts
@@ -7,7 +7,7 @@
  */
 import type { Effect } from "effect"
 import type { Atom, AtomRef } from "effect/unstable/reactivity"
-import type { ChildE, ChildR, FoldE, FoldR } from "./Fold.ts"
+import type { ChildE, ChildLiveE, ChildR, FoldE, FoldLiveE, FoldR, TagE, TagLiveE, TagR } from "./Fold.ts"
 import type { View } from "../View.ts"
 
 // Test fixtures
@@ -62,3 +62,33 @@ assertEquals<FoldR<readonly [CondChild]>, HttpService>()
 type EitherChild = Eff1 | Eff2
 assertEquals<FoldE<readonly [EitherChild]>, HttpError | NotFound>()
 assertEquals<FoldR<readonly [EitherChild]>, HttpService | DbService>()
+
+// ─── View<E> error channel: construction vs live split (the boundary thesis) ──
+
+// 10) A bare View<E> child: its live E rides the View; it's already built, so it
+//     contributes no construction error and no R.
+type ViewErr = View<HttpError>
+assertEquals<ChildLiveE<ViewErr>, HttpError>()
+assertEquals<ChildE<ViewErr>, never>()
+assertEquals<ChildR<ViewErr>, never>()
+
+// 11) An Effect whose SUCCESS is a View<E>: construction and live errors land on
+//     different channels — Effect's own E is construction, the View's E is live.
+type EffLive = Effect.Effect<View<HttpError>, NotFound, DbService>
+assertEquals<ChildE<EffLive>, NotFound>()
+assertEquals<ChildLiveE<EffLive>, HttpError>()
+assertEquals<ChildR<EffLive>, DbService>()
+
+// 12) Folds distribute the split over a tuple.
+assertEquals<FoldE<readonly [ViewErr, EffLive]>, NotFound>()
+assertEquals<FoldLiveE<readonly [ViewErr, EffLive]>, HttpError>()
+
+// 13) A bare View<never> contributes nothing on any channel.
+assertEquals<ChildLiveE<View>, never>()
+assertEquals<ChildE<View>, never>()
+
+// 14) Component tag: construction E vs live View<E> split, R folds.
+type Comp = (props: {}) => Effect.Effect<View<HttpError>, NotFound, DbService>
+assertEquals<TagE<Comp>, NotFound>()
+assertEquals<TagLiveE<Comp>, HttpError>()
+assertEquals<TagR<Comp>, DbService>()

--- a/packages/core/src/runtime/types/Fold.ts
+++ b/packages/core/src/runtime/types/Fold.ts
@@ -32,15 +32,24 @@ export type Child =
   | AtomRef.ReadonlyRef<unknown>
   | ReadonlyArray<unknown>
 
+// Errors live in two honest homes by phase, so the fold has two families:
+//  - ChildE / TagE → CONSTRUCTION errors, on the result Effect's `E` channel
+//    (a child's build Effect failing propagates as the parent build fails).
+//  - ChildLiveE / TagLiveE → LIVE errors, on the result `View<E>` channel
+//    (errors a rendered subtree can still produce — they ride the child's
+//    `View<E>` success). `R` unifies (one Layer set serves both phases), so
+//    there is a single `ChildR` / `TagR`.
+// A `catchCause` boundary discharges both; `mount` requires both `never`.
+
 /**
- * Walk a single child's type, peeling container layers, extracting the union
- * of every `E` channel encountered.
- *
- * Distributes over unions: if `C = A | B`, TS evaluates `ChildE<A> |
- * ChildE<B>` automatically.
+ * Walk a single child's type, extracting the union of every **construction**
+ * `E` — an Effect child's own error channel. A bare `View<E>` child is already
+ * built, so it contributes no construction error (its live `E` is `ChildLiveE`'s
+ * job). Distributes over unions automatically.
  */
 export type ChildE<C> =
   C extends Effect.Effect<any, infer E, any> ? E :
+  C extends View<any> ? never :
   C extends Option.Option<infer T> ? ChildE<T> :
   C extends Result.Result<infer A, any> ? ChildE<A> :
   C extends Chunk.Chunk<infer T> ? ChildE<T> :
@@ -50,14 +59,33 @@ export type ChildE<C> =
   never
 
 /**
- * Walk a single child's type, peeling container layers, extracting the union
- * of every `R` channel encountered.
+ * Walk a single child's type, extracting the union of every **live** `E` — the
+ * error a rendered subtree can still produce after construction. It reads the
+ * phantom `E` off a bare `View<E>` child, and recurses into an Effect's *success*
+ * (where a `View<E>` rides) — ignoring the Effect's own `E`, which is
+ * construction (`ChildE`'s job). One `infer` at the `View` leaf, no walk into the
+ * View's children, so the recursion stays shallow.
+ */
+export type ChildLiveE<C> =
+  C extends Effect.Effect<infer A, any, any> ? ChildLiveE<A> :
+  C extends View<infer VE> ? VE :
+  C extends Option.Option<infer T> ? ChildLiveE<T> :
+  C extends Result.Result<infer A, any> ? ChildLiveE<A> :
+  C extends Chunk.Chunk<infer T> ? ChildLiveE<T> :
+  C extends Atom.Atom<infer T> ? ChildLiveE<T> :
+  C extends AtomRef.ReadonlyRef<infer T> ? ChildLiveE<T> :
+  C extends ReadonlyArray<infer T> ? ChildLiveE<T> :
+  never
+
+/**
+ * Walk a single child's type, extracting the union of every `R` channel.
  *
  * Effect's `R` is encoded as a *union* type (each service is a member),
- * not an intersection — so we union here too.
+ * not an intersection — so we union here too. A `View<E>` carries no `R`.
  */
 export type ChildR<C> =
   C extends Effect.Effect<any, any, infer R> ? R :
+  C extends View<any> ? never :
   C extends Option.Option<infer T> ? ChildR<T> :
   C extends Result.Result<infer A, any> ? ChildR<A> :
   C extends Chunk.Chunk<infer T> ? ChildR<T> :
@@ -66,25 +94,29 @@ export type ChildR<C> =
   C extends ReadonlyArray<infer T> ? ChildR<T> :
   never
 
-/**
- * Fold a tuple of children to the union of their `E` channels.
- *
- * `Cs[number]` extracts the union of element types; `ChildE` distributes
- * over that union and returns the union of every E.
- */
+/** Fold a tuple of children to the union of their construction `E` channels. */
 export type FoldE<Cs extends readonly unknown[]> = ChildE<Cs[number]>
 
-/**
- * Fold a tuple of children to the union of their `R` channels.
- */
+/** Fold a tuple of children to the union of their live `E` channels (`View<E>`). */
+export type FoldLiveE<Cs extends readonly unknown[]> = ChildLiveE<Cs[number]>
+
+/** Fold a tuple of children to the union of their `R` channels. */
 export type FoldR<Cs extends readonly unknown[]> = ChildR<Cs[number]>
 
 /**
- * When the JSX tag is a component function `(props) => Effect<View, E, R>`,
- * extract its `E` channel so `h(Component, ...)` contributes it to the
- * surrounding expression's type. String tags contribute `never`.
+ * When the JSX tag is a component function `(props) => Effect<View<EV>, E, R>`,
+ * extract its **construction** `E` so `h(Component, ...)` contributes it to the
+ * result Effect's `E`. String tags contribute `never`.
  */
 export type TagE<T> = T extends (props: any) => Effect.Effect<any, infer E, any> ? E : never
+
+/**
+ * Same, for the tag's **live** `E` — the `EV` riding its `View<EV>` success,
+ * contributed to the result `View<E>` channel.
+ */
+export type TagLiveE<T> = T extends (props: any) => Effect.Effect<infer A, any, any>
+  ? ChildLiveE<A>
+  : never
 
 /**
  * Same, for the tag's `R` channel.

--- a/packages/core/src/testing/index.ts
+++ b/packages/core/src/testing/index.ts
@@ -1,4 +1,4 @@
-import { Effect, Exit, Layer, Scope } from "effect"
+import { Cause, Effect, Exit, Layer, Scope } from "effect"
 import type { AtomRegistry } from "effect/unstable/reactivity"
 import { VerrexLive, mount, type View } from "@verrex/core"
 
@@ -85,9 +85,14 @@ const renderImpl = async (
   // A Closeable scope we own: mount registers every subscription/listener/
   // release finalizer on it, and we keep it open until unmount().
   const scope = Scope.makeUnsafe()
+  // `mount` requires a discharged app (`Effect<View<never>, never, R>`). The
+  // harness discharges an undischarged construction error by turning it into a
+  // defect, so a component that fails to build (with no boundary) rejects the
+  // `render(...)` promise loudly — exactly the failure a test wants to see.
+  const discharged = Effect.catchCause(app, (cause) => Effect.die(Cause.squash(cause)))
   await Effect.runPromise(
     Scope.provide(
-      mount(app, container).pipe(Effect.provide(layer), Effect.provide(VerrexLive)),
+      mount(discharged, container).pipe(Effect.provide(layer), Effect.provide(VerrexLive)),
       scope,
     ),
   )


### PR DESCRIPTION
**Stacked on #63** (base = `pr2-catch-cause`). PR 3 — the thesis, completed for errors. Forgetting to handle an error with a `catchCause` boundary is now a **compile-time error that names the unhandled error** — the runtime counterpart of a forgotten `Layer` naming a service.

## The type mechanics (de-risked by spike first)

- **`View<E>`** carries a runtime-error channel via a covariant phantom: `View<E> = ViewNode & ViewErr<E>`, where the phantom-free `ViewNode` is what the `Data.taggedEnum` constructors build. Covariance (`() => E`) gives exactly the needed variance — `View<HttpError>` ⊄ `View<never>` (so `mount` can require it), while a `ViewNode` ⊂ *any* `View<E>` (so construction needs no casts and `View.Empty()` stays no-arg). Default `E = never` keeps a bare `View` backward-compatible.

- **The fold splits errors by phase** (the honest A1): construction errors (`ChildE`/`TagE`/`FoldE`) ride the result Effect's `E`; live errors a rendered subtree can still produce (`ChildLiveE`/`TagLiveE`/`FoldLiveE`) ride the `View<E>` success. `R` unifies. The position encodes the phase — and because every current component has construction-only errors, **the existing channel proofs pass unchanged** (`View<never>` everywhere). This avoids the asymmetry a single merged fold would create (`UserPage(...)` vs `<UserPage/>` would have disagreed on the View channel).

- **Typed `catchCause`**: `catchCause<EV, EC, R>(child: Effect<View<EV>, EC, R>, handler: (cause: Cause<EC | EV>, reset) => …): Effect<View<never>, never, R | Scope>`. The handler's `cause` is the precise `Cause<EC | EV>` (not `Cause<unknown>`); it discharges both channels. Runtime impl unchanged from #63.

## BREAKING

`mount` now requires `Effect<View<never>, never, R>` — the app must have every error discharged (construction via `Effect.catchCause`/a boundary, live via `catchCause`). The testing `render` harness discharges a leftover construction error into a defect, so a failing component rejects `render(...)` loudly. The demo's `setupDemo` wraps each demo in `catchCause` (happy paths pass through unchanged).

## Proof

- `apps/demo/src/channels.test-d.ts` gains the boundary thesis: `mount(UserPage({userId:"42"}), root)` is a **`@ts-expect-error` naming `HttpError`**; the `catchCause` handler's cause types as `Cause<HttpError>`; the discharged `Caught` mounts. All pre-existing assertions hold unchanged.
- `packages/core/src/runtime/types/Fold.test-d.ts` pins the construction/live split (`ChildE` vs `ChildLiveE`, the `View<E>` branch, `TagLiveE`).

## Verification

194 core + 31 ts-plugin tests pass; `pnpm -r typecheck` clean (demo 12 files, 0 errors); demo `vite build` passes through the real Babel→h→oxc pipeline. AGENTS.md updated (root thesis, runtime `View<E>`/fold-split/mount/`catchCause`).

## Not in this pass

- `catchTag`/`catchTags` (tag-narrowing — `Exclude<E, {_tag}>` from both channels).
- Typed event-handler errors: handlers are `(e) => void`, so a returned Effect's `E` is erased — still runtime-caught by the boundary (PR 1's sink), just not type-tracked.