### PR TITLE
feat(core): add catchTag / catchTags — tag-selective view boundaries

### DIFF
--- a/apps/demo/src/channels.test-d.ts
+++ b/apps/demo/src/channels.test-d.ts
@@ -6,7 +6,7 @@
  */
 import type { Cause, Chunk, Effect, Option, Result, Scope } from "effect"
 import type { AtomRegistry } from "effect/unstable/reactivity"
-import { catchCause, h, mount, type View } from "@verrex/core"
+import { catchCause, catchTag, catchTags, h, mount, type View } from "@verrex/core"
 import { AsyncUserPage } from "./AsyncUserPage.vx"
 import { Counter } from "./Counter.vx"
 import { LiveUser } from "./LiveUser.vx"
@@ -194,6 +194,55 @@ mount(Caught, root)
 
 // A pure component needs no boundary — it's already `View<never>`, `never`.
 mount(Counter(), root)
+
+// ─── catchTag / catchTags narrow the error channel by tag ───────────────
+//     Handle specific tags; the rest stay on the channel and must still be
+//     discharged before `mount`. A typo'd tag is a compile error.
+
+class ParseError {
+  readonly _tag = "ParseError" as const
+  readonly message = ""
+}
+declare const TwoErrors: Effect.Effect<View, HttpError | ParseError, Http>
+
+// catchTag handles one tag → handler gets the unwrapped error; both channels
+// narrow by `Exclude<E, { _tag }>`.
+const CaughtHttp = catchTag(TwoErrors, "HttpError", (e, reset) => {
+  const _status: number = e.status
+  void _status
+  void reset
+  return h("p", {}, "http error")
+})
+assertEquals<typeof CaughtHttp, Effect.Effect<View, ParseError, Http | Scope.Scope>>()
+
+// @ts-expect-error — "Nope" is not one of the child's error tags
+catchTag(TwoErrors, "Nope", () => h("p", {}, "x"))
+
+// @ts-expect-error — ParseError is still undischarged; mount rejects it, naming it
+mount(CaughtHttp, root)
+
+// Handle the remaining tag → fully discharged, mountable.
+const CaughtBoth = catchTag(CaughtHttp, "ParseError", (e) => {
+  const _msg: string = e.message
+  void _msg
+  return h("p", {}, "parse error")
+})
+assertEquals<typeof CaughtBoth, Effect.Effect<View, never, Http | Scope.Scope>>()
+mount(CaughtBoth, root)
+
+// catchTags handles a subset → residual narrows by the handled keys.
+const SomeTags = catchTags(TwoErrors, {
+  HttpError: (e) => h("p", {}, `${e.status}`),
+})
+assertEquals<typeof SomeTags, Effect.Effect<View, ParseError, Http | Scope.Scope>>()
+
+// catchTags handling every tag → discharged, mountable.
+const AllTags = catchTags(TwoErrors, {
+  HttpError: (e) => h("p", {}, `${e.status}`),
+  ParseError: (e) => h("p", {}, e.message),
+})
+assertEquals<typeof AllTags, Effect.Effect<View, never, Http | Scope.Scope>>()
+mount(AllTags, root)
 
 // Note: the type assertions above are the **load-bearing proof** of the POC.
 // If they compile, channels are surviving the tree.

--- a/packages/core/src/compiler/transform.test.ts
+++ b/packages/core/src/compiler/transform.test.ts
@@ -346,6 +346,20 @@ describe("catchCause calls are not h.track-wrapped", () => {
     `)
     expect(out).not.toContain(`h.track`)
   })
+
+  it("leaves catchTag / catchTags calls bare too (same self-tracking set)", () => {
+    const tag = compile(`
+      const x = <div>{catchTag(<Child />, "HttpError", (e) => <span>{label.value}</span>)}</div>
+    `)
+    expect(tag).toContain(`h.read(label)`)
+    expect(tag).not.toContain(`h.track`)
+
+    const tags = compile(`
+      const x = <div>{catchTags(<Child />, { HttpError: (e) => <span>{label.value}</span> })}</div>
+    `)
+    expect(tags).toContain(`h.read(label)`)
+    expect(tags).not.toContain(`h.track`)
+  })
 })
 
 describe("whole-body `.value` reads (tracking outside JSX)", () => {

--- a/packages/core/src/compiler/transform.ts
+++ b/packages/core/src/compiler/transform.ts
@@ -123,7 +123,12 @@ interface RewriteState {
  * `h.track`-wrapped and lose its channels (a loud type error at the call site).
  * Import these unaliased.
  */
-const SELF_TRACKING_HELPERS: ReadonlySet<string> = new Set(["Async", "catchCause"])
+const SELF_TRACKING_HELPERS: ReadonlySet<string> = new Set([
+  "Async",
+  "catchCause",
+  "catchTag",
+  "catchTags",
+])
 const isSelfTrackingCall = (expr: t.Expression): boolean =>
   t.isCallExpression(expr) &&
   t.isIdentifier(expr.callee) &&

--- a/packages/core/src/runtime/AGENTS.md
+++ b/packages/core/src/runtime/AGENTS.md
@@ -9,7 +9,7 @@ Public surface (from `index.ts`):
   error discharged), returns `Effect<void, never, R | AtomRegistry | Scope>`
 - `list` — keyed reactive list helper (`View.List` IR node)
 - `Async` / `asyncRef` — async render boundary + primitive (errors-as-values; see "`asyncRef` / `Async`" below)
-- `catchCause` — view-level error boundary (catch-all; mirrors `Effect.catchCause`; see "`catchCause`" below)
+- `catchCause` / `catchTag` / `catchTags` — view-level error boundaries (catch-all + tag-selective; mirror `Effect.catch*`; see "`catchCause`" below)
 - `Fragment` — `<>...</>` compile target
 - `VerrexLive` — base Layer providing `AtomRegistry`
 - Types: `View<E>`, `Props`, `FoldE`/`FoldLiveE`/`FoldR`/`TagE`/`TagLiveE`/`TagR`/`TagProps`,
@@ -43,7 +43,7 @@ the editor margin. If you rename them, update the regex.
 | `View.ts` | `View<E>` IR. The runtime shape is `ViewNode` — a hand-written union of 7 phantom-free named interfaces (`ViewText`…`ViewBoundary`, `ViewEmpty`); constructors via `Data.taggedEnum<ViewNode>()`. `View<E = never> = ViewNode & ViewErr<E>` layers the runtime-error channel on via a covariant phantom (`ViewErr`), so `View<HttpError>` ⊄ `View<never>` (mount can require it) while a `ViewNode` ⊂ any `View<E>` (constructors need no casts). Plus `isView`, `VIEW_TAGS` |
 | `mount.ts` | DOM renderer. `buildDom(view, ctx, scope) → Node` (`ctx: BuildCtx = { registry, context, sink }`), `mount(app, el)`. Cleanup is delegated to `Scope` — every subscription/listener/release registers a finalizer on the scope it was created in, and parent-fork cascade tears them down on close. Owns `buildScopedChild` (the one place a dynamic subtree gets a parent-linked child scope), the `List` **interpreter** that applies a `reconcile.ts` plan to real DOM + scopes, and the error **sink** (runs event-handler Effects + routes runtime failures) |
 | `reconcile.ts` | Pure keyed-list diff. `plan(prevKeys, nextKeys) → ReconcileOp[]` over opaque keys — no DOM, no `Scope`, no `Effect`. The runtime's highest-bug-density logic, made exhaustively unit-testable. `mount`'s `List` case interprets the ops |
-| `index.ts` | Public exports + `list`, `Async`, `asyncRef`, `catchCause`, `Fragment`, `VerrexLive` |
+| `index.ts` | Public exports + `list`, `Async`, `asyncRef`, `catchCause`/`catchTag`/`catchTags` (over a shared `makeBoundary`), `Fragment`, `VerrexLive` |
 | `coerce.test.ts` | Vitest suite for `coerceAsync` / `coerceSync` (parity + the sync/async asymmetry pin) |
 | `reconcile.test.ts` | Pure diff tests — an apply-to-array oracle (plan turns `prev` into `next`) plus exact op-sequence pins (move-minimality matches the old single-pass; index updates on shift) |
 | `types/Fold.ts` | `ChildE`/`ChildLiveE`/`ChildR` + `FoldE`/`FoldLiveE`/`FoldR` + `TagE`/`TagLiveE`/`TagR`/`TagProps` — the channel-fold conditional types. Two error families: construction (`*E`, Effect channel) vs live (`*LiveE`, `View<E>` channel) |
@@ -238,14 +238,31 @@ returns. Running the user's Effect directly on the mount fiber is what
 keeps `R` folded. `Atom`/`AtomRef` remain the right tool for *synchronous*
 reactive state (Counter, `list`) — just not the spine for effectful data.
 
-## `catchCause` — the view-level error boundary
+## `catchCause` / `catchTag` / `catchTags` — view-level error boundaries
 
 `catchCause(child, (cause, reset) => fallback)` mirrors `Effect.catchCause`:
 recover the **failure** side of a view subtree, let success pass through (the
 child renders itself). Contrast `Async`, which matches a data `AsyncResult` and
 renders *every* state (`initial`/`success`/`failure`) — a boundary only supplies
-the failure fallback. (Tag-selective `catchTag`/`catchTags`, which narrow `E`
-rather than discharging all of it, come later.)
+the failure fallback.
+
+Three combinators, all over the shared `makeBoundary(child, accepts, handler)`
+(which builds the `Boundary` node and drives `state`); they differ only in
+`accepts` and the handler arg:
+- **`catchCause(child, (cause, reset) => …)`** — catch-all (`accepts` = always);
+  discharges everything to `View<never>`/`never`.
+- **`catchTag(child, "Tag", (error, reset) => …)`** — handles one tagged error
+  (`accepts` = the cause's `_tag` matches), hands the handler the unwrapped error,
+  and **narrows** both channels by `Exclude<E, { _tag: "Tag" }>`. `Tag` is
+  constrained to the child's actual error tags (a typo is a compile error).
+- **`catchTags(child, { Tag: handler, … })`** — same, for a subset of tags.
+
+A cause a tag-boundary doesn't `accept` is **escalated**: at construction it
+re-raises on the Effect channel (its residual rides `EC`, so a parent boundary /
+`mount` still sees it); when live it goes to the ambient sink (the parent
+boundary — `mount` hands it over via the node's `setAmbient`). So a leftover tag
+must still be discharged before `mount`. (Tag-selective only catches errors in
+the *type*; an untyped event-handler/reactive error needs `catchCause`.)
 
 **Typed discharge.** Signature `catchCause<EV, EC, R>(child: Effect<View<EV>, EC, R>,
 handler: (cause: Cause<EC | EV>, reset) => …): Effect<View<never>, never, R | Scope>`.
@@ -272,10 +289,11 @@ state synchronously inside the child's render, which would close the child scope
 mid-render (reentrant). The runtime impl is untyped (`Cause<unknown>` sink); the
 precise `Cause<EC | EV>` is the public-signature contract, bridged by one cast.
 
-Unlike `Async`, this **is** a View IR variant (`Boundary`) — the sink-swap for
+Unlike `Async`, these **are** a View IR variant (`Boundary`) — the sink-swap for
 the child subtree is a `buildDom`-time concern an existing `Reactive` can't
-express. The compiler skips the `h.track` wrap for `catchCause(...)` calls (it's
-in `isSelfTrackingCall` alongside `Async`); import it unaliased.
+express. The compiler skips the `h.track` wrap for `catchCause`/`catchTag`/
+`catchTags` calls (all in `isSelfTrackingCall` alongside `Async`); import them
+unaliased.
 
 ## mount internals — invariants
 

--- a/packages/core/src/runtime/View.ts
+++ b/packages/core/src/runtime/View.ts
@@ -89,6 +89,10 @@ export interface ViewBoundary {
   readonly handler: (cause: Cause.Cause<unknown>, reset: () => void) => unknown
   readonly reset: () => void
   readonly report: (cause: Cause.Cause<unknown>) => void
+  // `mount` calls this with the ambient (parent) sink before rendering the child,
+  // so a tag-selective boundary (`catchTag`/`catchTags`) can escalate a cause it
+  // doesn't handle to the next boundary outward. A catch-all never escalates.
+  readonly setAmbient: (sink: (cause: Cause.Cause<unknown>) => void) => void
 }
 
 /** The phantom-free runtime IR — the shape `mount` switches on and the

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -1,12 +1,12 @@
-import { Cause, Effect, Fiber, Layer, Queue, Scope } from "effect"
+import { Cause, Effect, Fiber, Layer, Option, Queue, Scope } from "effect"
 import { AsyncResult, AtomRef, AtomRegistry } from "effect/unstable/reactivity"
-import { trackDeps } from "./coerce.ts"
+import { type ErrorSink, trackDeps } from "./coerce.ts"
 import { type BoundaryState, type Props, View } from "./View.ts"
 
 export { h } from "./h.ts"
 export { mount } from "./mount.ts"
 export { type Props, View } from "./View.ts"
-// `Async`, `asyncRef`, `catchCause`, `list`, `Fragment`, `VerrexLive` are declared + exported below.
+// `Async`, `asyncRef`, `catchCause`, `catchTag`, `catchTags`, `list`, `Fragment`, `VerrexLive` are declared + exported below.
 export type { Child, ChildE, ChildR, FoldE, FoldR, TagE, TagProps, TagR } from "./types/Fold.ts"
 export type { HtmlEventHandlers, IntrinsicProps } from "./types/Html.ts"
 
@@ -162,25 +162,113 @@ export const Async = <A, E, R>(
     ),
   )
 
+// ─── Error boundaries (catchCause / catchTag / catchTags) ────────────────
+
+type Tagged = { readonly _tag: string }
+type TagsOf<E> = E extends Tagged ? E["_tag"] : never
+type WithoutTag<E, Tag extends string> = Exclude<E, { readonly _tag: Tag }>
+
+/** The `_tag` of a cause's first error, if it's a tagged error. */
+const errorTagOf = (cause: Cause.Cause<unknown>): string | undefined => {
+  const err = Option.getOrUndefined(Cause.findErrorOption(cause))
+  return typeof err === "object" && err !== null && "_tag" in err
+    ? (err as Tagged)._tag
+    : undefined
+}
+
 /**
- * View-level error boundary — the catch-all. Mirrors `Effect.catchCause`: it
+ * Shared boundary machinery for `catchCause`/`catchTag`/`catchTags`. `accepts`
+ * decides which causes THIS boundary handles; a non-accepted cause re-raises at
+ * construction (its residual rides the Effect channel → a parent boundary / fails
+ * mount) and escalates to the ambient sink when live. The typed public wrappers
+ * below cast the residual to its precise shape.
+ */
+const makeBoundary = <R>(
+  child: Effect.Effect<View<any>, any, R>,
+  accepts: (cause: Cause.Cause<unknown>) => boolean,
+  handler: (cause: Cause.Cause<unknown>, reset: () => void) => unknown,
+): Effect.Effect<View<never>, unknown, R | Scope.Scope> =>
+  Effect.gen(function* () {
+    // Ambient (parent) sink — set by mount via the node's `setAmbient`. A cause
+    // this boundary doesn't `accept` escalates here. A catch-all never escalates.
+    let ambient: ErrorSink = () => {}
+    const setAmbient = (sink: ErrorSink): void => { ambient = sink }
+
+    // Build the child into a BoundaryState. An ACCEPTED construction failure
+    // becomes the `error` state; a non-accepted one re-raises (its residual rides
+    // this Effect's error channel → propagates to a parent boundary / fails mount).
+    const construct: Effect.Effect<BoundaryState, unknown, R> = child.pipe(
+      Effect.map((view): BoundaryState => ({ _tag: "ok", view })),
+      Effect.catchCause((cause) =>
+        accepts(cause)
+          ? Effect.succeed<BoundaryState>({ _tag: "error", cause })
+          : Effect.failCause(cause)
+      ),
+    )
+
+    // Initial construction inline (folds R; no first-paint flash). A non-accepted
+    // failure here propagates on this Effect's error channel.
+    const state = AtomRef.make<BoundaryState>(yield* construct)
+    const runs = yield* Queue.unbounded<{ readonly _tag: "reset" } | {
+      readonly _tag: "error"
+      readonly cause: Cause.Cause<unknown>
+    }>()
+
+    // Live failures: accepted → error state (via the queue, off the render stack —
+    // a synchronous mutation would close the child scope mid-render); non-accepted
+    // → escalate to the ambient sink. Interrupts (teardown) dropped.
+    const report = (cause: Cause.Cause<unknown>): void => {
+      if (Cause.hasInterruptsOnly(cause)) return
+      if (accepts(cause)) Queue.offerUnsafe(runs, { _tag: "error", cause })
+      else ambient(cause)
+    }
+    const reset = (): void => {
+      Queue.offerUnsafe(runs, { _tag: "reset" })
+    }
+
+    yield* Effect.forkScoped(
+      Effect.gen(function* () {
+        while (true) {
+          const msg = yield* Queue.take(runs)
+          if (msg._tag === "error") {
+            state.set({ _tag: "error", cause: msg.cause })
+          } else {
+            // reset: re-run. Accepted failure → error state; non-accepted →
+            // escalate and keep the current content (can't re-raise post-mount).
+            const next = yield* child.pipe(
+              Effect.map((view): BoundaryState => ({ _tag: "ok", view })),
+              Effect.catchCause((cause) => {
+                if (accepts(cause)) return Effect.succeed<BoundaryState>({ _tag: "error", cause })
+                ambient(cause)
+                return Effect.succeed(state.value)
+              }),
+            )
+            state.set(next)
+          }
+        }
+      }),
+    )
+
+    return View.Boundary({ state, handler, reset, report, setAmbient })
+  })
+
+/**
+ * View-level error boundary — the **catch-all**. Mirrors `Effect.catchCause`: it
  * recovers the FAILURE side of a view subtree and lets success pass through (the
  * child renders itself). Contrast `Async`, which matches a data `AsyncResult`
  * and renders *every* state — a boundary supplies only the failure fallback.
  *
- * `catchCause(child, (cause, reset) => fallback)` catches both phases of failure:
- *  - **construction** — `child`'s build Effect fails (run under `Effect.catchCause`);
- *  - **live** — a post-mount failure inside the rendered subtree (a reactive
- *    re-render or an event-handler Effect) routed to this boundary's sink.
- * Either swaps the subtree for `fallback(cause, reset)`; `reset()` re-runs the
- * child's construction. Pure-interrupt causes (scope teardown) are ignored.
+ * Catches both phases: **construction** (`child`'s build Effect fails) and
+ * **live** (a post-mount failure inside the rendered subtree — a reactive
+ * re-render or an event-handler Effect — routed to this boundary's sink). Either
+ * swaps the subtree for `fallback(cause, reset)`; `reset()` re-runs construction.
+ * Pure-interrupt causes (scope teardown) are ignored.
  *
- * `child`'s `R` folds into the component (construction + every `reset` run on the
- * mount fiber, like `asyncRef`), so a forgotten `Layer` is still a compile error
- * at `mount`. `cause` is `Cause<unknown>` for now — the typed `View<E>` discharge
- * (where a forgotten boundary becomes a compile error naming the error) lands in
- * a later pass. The fallback's own `E`/`R` are not folded — keep it pure markup,
- * like `Async`'s arms.
+ * The handler's `cause` is the precise `Cause<EC | EV>` (construction + live
+ * errors of the child). Discharges both channels to `never`, so the result is
+ * mountable — a subtree with undischarged errors won't pass `mount`. `child`'s
+ * `R` folds (construction + every `reset` run on the mount fiber); the fallback's
+ * own `E`/`R` are not folded — keep it pure markup, like `Async`'s arms.
  *
  * ```tsx
  * {catchCause(<UserCard id={id} />, (cause, reset) => (
@@ -192,53 +280,91 @@ export const catchCause = <EV, EC, R>(
   child: Effect.Effect<View<EV>, EC, R>,
   handler: (cause: Cause.Cause<EC | EV>, reset: () => void) => View | Effect.Effect<View, any, any>,
 ): Effect.Effect<View<never>, never, R | Scope.Scope> =>
-  Effect.gen(function* () {
-    // Run `child`, folding both outcomes into a BoundaryState. `Effect.matchCause`
-    // discharges `child`'s construction E (`EC`) while keeping R; re-runnable for
-    // reset. Live errors riding the child's `View<EV>` are routed to `report`.
-    const construct: Effect.Effect<BoundaryState, never, R> = Effect.matchCause(child, {
-      onSuccess: (view): BoundaryState => ({ _tag: "ok", view }),
-      onFailure: (cause): BoundaryState => ({ _tag: "error", cause }),
-    })
+  makeBoundary(
+    child,
+    () => true,
+    handler as (cause: Cause.Cause<unknown>, reset: () => void) => unknown,
+  ) as Effect.Effect<View<never>, never, R | Scope.Scope>
 
-    // Initial construction inline (folds R; no first-paint flash before the
-    // child appears — unlike a forked run, which mount would race).
-    const state = AtomRef.make<BoundaryState>(yield* construct)
-    const runs = yield* Queue.unbounded<{ readonly _tag: "reset" } | {
-      readonly _tag: "error"
-      readonly cause: Cause.Cause<unknown>
-    }>()
+/**
+ * Tag-selective error boundary — mirrors `Effect.catchTag`. Handles only the one
+ * tagged error `tag` (from either channel of `child`); every other error flows
+ * through unchanged. `tag` is constrained to the child's actual error tags (a
+ * typo is a compile error), the handler gets the unwrapped tagged error, and the
+ * result **narrows** both channels by `Exclude<E, { _tag: Tag }>` — so a leftover
+ * tag still has to be discharged (by another `catchTag`/`catchCause`) before
+ * `mount`. A non-matching live error escalates to the parent boundary.
+ *
+ * ```tsx
+ * {catchTag(<UserCard id={id} />, "HttpError", (e, reset) =>
+ *   <Banner status={e.status} onRetry={reset} />)}
+ * ```
+ */
+export const catchTag = <EV, EC, R, Tag extends TagsOf<EC | EV>>(
+  child: Effect.Effect<View<EV>, EC, R>,
+  tag: Tag,
+  handler: (
+    error: Extract<EC | EV, { readonly _tag: Tag }>,
+    reset: () => void,
+  ) => View | Effect.Effect<View, any, any>,
+): Effect.Effect<View<WithoutTag<EV, Tag>>, WithoutTag<EC, Tag>, R | Scope.Scope> =>
+  makeBoundary(
+    child,
+    (cause) => errorTagOf(cause) === tag,
+    (cause, reset) =>
+      handler(
+        Option.getOrUndefined(Cause.findErrorOption(cause)) as Extract<EC | EV, { readonly _tag: Tag }>,
+        reset,
+      ),
+  ) as Effect.Effect<View<WithoutTag<EV, Tag>>, WithoutTag<EC, Tag>, R | Scope.Scope>
 
-    // report/reset both go through the queue → applied on the forked fiber, never
-    // synchronously inside the child's render (which would close the child scope
-    // mid-render — reentrant). This is also why `report` is safe as a sink.
-    const report = (cause: Cause.Cause<unknown>): void => {
-      if (!Cause.hasInterruptsOnly(cause)) Queue.offerUnsafe(runs, { _tag: "error", cause })
-    }
-    const reset = (): void => {
-      Queue.offerUnsafe(runs, { _tag: "reset" })
-    }
-
-    yield* Effect.forkScoped(
-      Effect.gen(function* () {
-        while (true) {
-          const msg = yield* Queue.take(runs)
-          if (msg._tag === "error") state.set({ _tag: "error", cause: msg.cause })
-          else state.set(yield* construct)
-        }
-      }),
-    )
-
-    // The node's handler slot is `Cause<unknown>` (runtime is untyped); the public
-    // signature gives the user the precise `Cause<EC | EV>`. The values flowing in
-    // are exactly those, so the cast is sound.
-    return View.Boundary({
-      state,
-      handler: handler as (cause: Cause.Cause<unknown>, reset: () => void) => unknown,
-      reset,
-      report,
-    })
-  })
+/**
+ * Multi-tag error boundary — mirrors `Effect.catchTags`. `handlers` maps tag →
+ * fallback for any subset of the child's error tags; each is type-checked against
+ * its tag's error, and the result narrows both channels by the handled tags. A
+ * non-matching live error escalates to the parent boundary.
+ *
+ * ```tsx
+ * {catchTags(<UserCard id={id} />, {
+ *   HttpError: (e, reset) => <Banner status={e.status} onRetry={reset} />,
+ *   ParseError: (e) => <p>bad data: {e.message}</p>,
+ * })}
+ * ```
+ */
+export const catchTags = <
+  EV,
+  EC,
+  R,
+  Handlers extends {
+    readonly [K in TagsOf<EC | EV>]?: (
+      error: Extract<EC | EV, { readonly _tag: K }>,
+      reset: () => void,
+    ) => View | Effect.Effect<View, any, any>
+  },
+>(
+  child: Effect.Effect<View<EV>, EC, R>,
+  handlers: Handlers,
+): Effect.Effect<
+  View<WithoutTag<EV, keyof Handlers & string>>,
+  WithoutTag<EC, keyof Handlers & string>,
+  R | Scope.Scope
+> =>
+  makeBoundary(
+    child,
+    (cause) => {
+      const t = errorTagOf(cause)
+      return t !== undefined && t in handlers
+    },
+    (cause, reset) => {
+      const t = errorTagOf(cause)!
+      const fn = (handlers as Record<string, (e: any, r: () => void) => unknown>)[t]!
+      return fn(Option.getOrUndefined(Cause.findErrorOption(cause)), reset)
+    },
+  ) as Effect.Effect<
+    View<WithoutTag<EV, keyof Handlers & string>>,
+    WithoutTag<EC, keyof Handlers & string>,
+    R | Scope.Scope
+  >
 
 /**
  * Fragment component — the compile target for JSX `<>...</>` syntax.

--- a/packages/core/src/runtime/mount.ts
+++ b/packages/core/src/runtime/mount.ts
@@ -311,7 +311,10 @@ const buildDom = (view: ViewNode, ctx: BuildCtx, scope: Scope.Scope): Node => {
       // The child subtree renders with a sink that reports into THIS boundary
       // (live failures flip its state to `error`); the fallback renders with the
       // ambient `ctx` sink, so a failure in the fallback bubbles to the next
-      // boundary outward. Same build-NEW → swap → close-OLD ordering as Reactive.
+      // boundary outward. `setAmbient` hands the boundary the parent sink so a
+      // tag-selective boundary can escalate a cause it doesn't handle.
+      // Same build-NEW → swap → close-OLD ordering as Reactive.
+      view.setAmbient(ctx.sink)
       const childCtx: BuildCtx = { ...ctx, sink: view.report }
       let currentNode: Node = document.createComment("boundary-pending")
       let contentScope: Scope.Closeable | null = null

--- a/packages/core/src/testing/catch-tag.test.ts
+++ b/packages/core/src/testing/catch-tag.test.ts
@@ -1,0 +1,109 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from "vitest"
+import { Cause, Data, Effect } from "effect"
+import { catchCause, catchTag, catchTags, h } from "@verrex/core"
+import { render } from "./index.ts"
+
+// PR4: tag-selective boundaries. `catchTag`/`catchTags` mirror Effect's — handle
+// specific tagged errors, NARROW the channels by the handled tags, and pass the
+// rest through to an outer boundary. `tag`/keys are constrained to the child's
+// actual error tags (a typo is a compile error). These exercise construction
+// errors (the typed ones); event-handler/reactive errors stay untyped and use
+// `catchCause`.
+
+class HttpError extends Data.TaggedError("HttpError")<{ readonly status: number }> {}
+class ParseError extends Data.TaggedError("ParseError")<{ readonly message: string }> {}
+
+// A child that fails (at construction) with one of two tagged errors.
+const Child = Effect.fn("Child")(function* (props: { readonly fail: "http" | "parse" }) {
+  if (props.fail === "http") yield* Effect.fail(new HttpError({ status: 503 }))
+  else yield* Effect.fail(new ParseError({ message: "bad json" }))
+  return yield* h("p", { class: "child" }, "ok")
+})
+
+describe("catchTag", () => {
+  it("catches the matching tag and hands the handler the unwrapped error", async () => {
+    const App = Effect.fn("App")(function* (_props: {} = {}) {
+      return yield* catchTag(Child({ fail: "http" }), "HttpError", (e) =>
+        h("p", { class: "http-fallback" }, `http ${e.status}`),
+      )
+    })
+    const ui = await render(App())
+    expect(ui.text(".http-fallback")).toBe("http 503")
+    expect(ui.query(".child")).toBeNull()
+    await ui.unmount()
+  })
+
+  it("passes a non-matching tag through to an outer catchCause", async () => {
+    const App = Effect.fn("App")(function* (_props: {} = {}) {
+      // inner handles HttpError only; the child fails with ParseError → re-raised
+      // (residual) and caught by the outer catch-all.
+      return yield* catchCause(
+        catchTag(Child({ fail: "parse" }), "HttpError", () => h("p", { class: "http" }, "http")),
+        (cause) => h("p", { class: "outer" }, Cause.pretty(cause)),
+      )
+    })
+    const ui = await render(App())
+    expect(ui.query(".http")).toBeNull()
+    expect(ui.text(".outer")).toContain("ParseError")
+    await ui.unmount()
+  })
+
+  it("reset() re-runs construction", async () => {
+    let attempt = 0
+    const Flaky = Effect.fn("Flaky")(function* (_props: {} = {}) {
+      attempt++
+      if (attempt === 1) yield* Effect.fail(new HttpError({ status: 500 }))
+      return yield* h("p", { class: "child" }, "recovered")
+    })
+    const App = Effect.fn("App")(function* (_props: {} = {}) {
+      return yield* catchTag(Flaky(), "HttpError", (_e, reset) =>
+        h("button", { class: "retry", onClick: reset }, "retry"),
+      )
+    })
+    const ui = await render(App())
+    expect(ui.query(".retry")).not.toBeNull()
+    ui.click(".retry")
+    await ui.waitFor(".child")
+    expect(ui.text(".child")).toBe("recovered")
+    await ui.unmount()
+  })
+})
+
+describe("catchTags", () => {
+  it("dispatches to the handler for the failing tag", async () => {
+    const make = (fail: "http" | "parse") =>
+      Effect.fn("App")(function* (_props: {} = {}) {
+        return yield* catchTags(Child({ fail }), {
+          HttpError: (e) => h("p", { class: "http" }, `http ${e.status}`),
+          ParseError: (e) => h("p", { class: "parse" }, `parse ${e.message}`),
+        })
+      })()
+
+    const httpUi = await render(make("http"))
+    expect(httpUi.text(".http")).toBe("http 503")
+    expect(httpUi.query(".parse")).toBeNull()
+    await httpUi.unmount()
+
+    const parseUi = await render(make("parse"))
+    expect(parseUi.text(".parse")).toBe("parse bad json")
+    expect(parseUi.query(".http")).toBeNull()
+    await parseUi.unmount()
+  })
+
+  it("passes an unhandled tag through to an outer boundary", async () => {
+    const App = Effect.fn("App")(function* (_props: {} = {}) {
+      // handles only HttpError; the child fails with ParseError → outer catches.
+      return yield* catchCause(
+        catchTags(Child({ fail: "parse" }), {
+          HttpError: (e) => h("p", { class: "http" }, `http ${e.status}`),
+        }),
+        (cause) => h("p", { class: "outer" }, Cause.pretty(cause)),
+      )
+    })
+    const ui = await render(App())
+    expect(ui.query(".http")).toBeNull()
+    expect(ui.text(".outer")).toContain("ParseError")
+    await ui.unmount()
+  })
+})


### PR DESCRIPTION
**Stacked on #64** (base = `pr3-typed-boundary`). PR 4 — the tag-selective boundaries, completing the `catch*` family. Mirrors `Effect.catchTag`/`catchTags`.

## API

```tsx
// handle one tag; the rest pass through to an outer boundary
{catchTag(<UserCard id={id} />, "HttpError", (e, reset) =>
  <Banner status={e.status} onRetry={reset} />)}

// handle a subset of tags
{catchTags(<UserCard id={id} />, {
  HttpError: (e, reset) => <Banner status={e.status} onRetry={reset} />,
  ParseError: (e) => <p>bad data: {e.message}</p>,
})}
```

- **`catchTag`** — `tag` is constrained to the child's *actual* error tags (a typo is a compile error); the handler gets the **unwrapped** tagged error; the result **narrows** both channels by `Exclude<E, { _tag }>`. A leftover tag still has to be discharged before `mount`.
- **`catchTags`** — same, for a subset, via a partial map type-checked per tag.

## One shared machine

All three boundaries (`catchCause`/`catchTag`/`catchTags`) now go through one `makeBoundary(child, accepts, handler)`. `accepts` decides which causes this boundary handles; a non-accepted cause **escalates**:
- at **construction** → re-raises on the Effect channel (its residual rides `EC`, so a parent boundary / `mount` still sees it — that's the type-level narrowing made real);
- when **live** → to the ambient (parent) sink, which `mount` hands the boundary via the new `ViewBoundary.setAmbient`.

`catchCause` is just `accepts = () => true` (never escalates). Tag-selective only catches errors that are in the *type* (construction errors); an untyped event-handler/reactive error needs `catchCause`.

## Proof & tests

- `channels.test-d.ts`: `catchTag(TwoErrors, "HttpError", …)` narrows to `Effect<View, ParseError, …>`; a typo'd tag is a `@ts-expect-error`; `mount` on the residual is a `@ts-expect-error` naming `ParseError`; handling both tags → mountable. Same for `catchTags`.
- Integration (`catch-tag.test.ts`, 5): catchTag catches + unwraps (`e.status`), passes a non-matching tag through to an outer `catchCause`, reset; catchTags dispatches by tag and passes unhandled tags through.
- Compiler skip-wrap extended to `catchTag`/`catchTags`.

200 core + 31 ts-plugin tests pass; `pnpm -r typecheck` clean (demo 12 files, 0 errors); demo `vite build` passes.

## Stack

#61 (Await→Async) → #62 (error sink) → #63 (catchCause runtime) → #64 (typed `View<E>` + mount gate) → **#65 (catchTag/catchTags)**. The error-handling model is now complete: catch-all + tag-selective, both compile-time-enforced.