### PR TITLE
docs: correct release tag format (unscoped component tags)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -219,7 +219,9 @@ the publish job pushes to npm.
   only — keep a commit's edits inside one package dir to bump just that one.
 - **Versions are independent** (no linked-versions plugin) — each package
   bumps off its own commits and carries its own CHANGELOG + tag
-  (`@verrex/core-v…`, `@verrex/ts-plugin-v…`).
+  (`core-v…`, `ts-plugin-v…` — release-please's node strategy strips the
+  npm scope from tag names; a scoped tag like `@verrex/core-v0.1.0` is
+  invisible to it and breaks changelog anchoring).
 - **Still pre-1.0:** `bump-minor-pre-major` + `bump-patch-for-minor-pre-major`
   keep `feat`→minor / `fix`→patch *within* 0.x until you cut a 1.0.
 - **Tokenless publish:** OIDC trusted publishing, no `NPM_TOKEN`. Provenance is


### PR DESCRIPTION
Follow-up to the release-please anchoring fix: the root AGENTS.md claimed release tags look like `@verrex/core-v…`, but release-please's node strategy strips the npm scope — real tags are `core-v…` / `ts-plugin-v…`. The scoped bootstrap tags have been replaced with unscoped tags + GitHub Releases (`core-v0.1.0` at fb5cd72, `ts-plugin-v0.1.0` at 1eb4a8c).

Merging this also retriggers the Release workflow so release-please regenerates #56 with a correctly-anchored changelog (the spurious ts-plugin 0.1.1 section should disappear).