### PR TITLE
feat(runtime): Async without failure arm puts E on the live channel (#73)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,15 +11,17 @@ errors ride the Effect `E`; live errors a rendered subtree can still
 produce ride the `View<E>` success — one `Catch` boundary discharges both.
 
 **Honest scope today:** the *construction* channel is fully type-tracked —
-a forgotten boundary on a failing build is a compile error. The live channel
-has its first stamping primitive: `Async` *without* a `failure` arm is
-`Effect<View<E>, never, R | Scope>` — the failure (initial fetch or refetch)
-rides `View<E>` to the nearest `Catch`, and `mount`'s `View<never>` gate makes
+a forgotten boundary on a failing build is a compile error. The *live*
+channel is only partially tracked: exactly one leaf primitive stamps
+`View<E≠never>` — `Async` *without* a `failure` arm, typed
+`Effect<View<E>, never, R | Scope>`. Its failures (initial fetch or refetch)
+ride `View<E>` to the nearest `Catch`, and `mount`'s `View<never>` gate makes
 a missing boundary a compile error naming `E` (with the arm, the failure is
-handled at the leaf and discharges to `View<never>`). Event-handler/reactive
-errors are still erased to `(e) => void` / `unknown` — those live failures are
-caught at *runtime* by `Catch`'s sink, not tracked by the type. Closing that
-(typed event handlers, #72) is the remaining thesis work.
+handled at the leaf and discharges to `View<never>`). Everything else that
+can fail live — event handlers, reactive re-renders — is still erased to
+`(e) => void` / `unknown` and caught only at *runtime* by `Catch`'s sink, not
+tracked by the type. Closing that (typed event handlers, #72) is the
+remaining thesis work.
 
 **The name** is built from the channels of an `Effect<View, E, R>`:
 **V** (View — the `A`, always the `View` here), **E** (Error), **R**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,13 +11,15 @@ errors ride the Effect `E`; live errors a rendered subtree can still
 produce ride the `View<E>` success — one `Catch` boundary discharges both.
 
 **Honest scope today:** the *construction* channel is fully type-tracked —
-a forgotten boundary on a failing build is a compile error. The `View<E>`
-machinery for *live* errors is built and gated by `mount`, but no leaf
-primitive yet stamps `View<E≠never>` (`Async` discharges to `View<never>`;
-event-handler/reactive errors are erased to `(e) => void` / `unknown`), so
-in compiled `.vx` the live channel is effectively `never` — live failures
-are caught at *runtime* by `Catch`'s sink, not tracked by the type. Closing
-that (a primitive that types live errors) is the remaining thesis work.
+a forgotten boundary on a failing build is a compile error. The live channel
+has its first stamping primitive: `Async` *without* a `failure` arm is
+`Effect<View<E>, never, R | Scope>` — the failure (initial fetch or refetch)
+rides `View<E>` to the nearest `Catch`, and `mount`'s `View<never>` gate makes
+a missing boundary a compile error naming `E` (with the arm, the failure is
+handled at the leaf and discharges to `View<never>`). Event-handler/reactive
+errors are still erased to `(e) => void` / `unknown` — those live failures are
+caught at *runtime* by `Catch`'s sink, not tracked by the type. Closing that
+(typed event handlers, #72) is the remaining thesis work.
 
 **The name** is built from the channels of an `Effect<View, E, R>`:
 **V** (View — the `A`, always the `View` here), **E** (Error), **R**

--- a/apps/demo/AGENTS.md
+++ b/apps/demo/AGENTS.md
@@ -19,6 +19,7 @@ they can be exercised in a browser side-by-side.
 | `Todos.vx` | Keyed reactive list (`{coll.value.map(item => <Row item={item}/>)}` compiles to `list(coll, render)`). Per-row reactivity: toggling one row doesn't tear down others. |
 | `Lifecycle.vx` | `Effect.acquireRelease` inside a row — release fires when the row is removed (per-row Scope in mount). |
 | `CatchDemo.vx` | The `Catch` error boundary (step 07), both forms: a function handler (catch-all over a `Crasher` whose click fails) and an object tag-map (`{ HttpError }` over a flaky `BadRequest` that ~50% of the time fails construction with a random typed error, routed + unwrapped — `retry` re-rolls and may recover). Discharges to `Effect<View, never, Scope>`; `reset`/`retry` re-run construction. Exercised end-to-end by `scripts/probe-catch.mjs`. |
+| `AsyncEscalate.vx` | `Async`, open form (step 08): the same auto-tracking fetch as `LiveUser`, **without** a `failure` arm — the failure rides the live channel (`View<HttpError>`) to a page-level `Catch` whose banner offers `retry` (re-runs construction → fresh fetch). The id buttons live outside the boundary so they survive the fallback swap. Deleting the `Catch` is a compile error at the demo mount naming `HttpError`. Exercised end-to-end by `scripts/probe-escalate.mjs`. |
 | `main.vx` | Wires Layers (`VerrexLive`, `HttpLive`, `ThemeLive`) + `Effect.scoped` + `Effect.never` (keep scope alive for page lifetime). |
 | `services.ts` | Mock Http + Theme services. `Data.TaggedError` for `HttpError`. |
 

--- a/apps/demo/src/AsyncEscalate.vx
+++ b/apps/demo/src/AsyncEscalate.vx
@@ -1,0 +1,58 @@
+import { Cause, Effect } from "effect"
+import { AtomRef } from "effect/unstable/reactivity"
+import { Async, Catch } from "@verrex/core"
+import { Http } from "./services.ts"
+
+/**
+ * `Async`, open form — **omit the `failure` arm and the failure escalates**.
+ *
+ * Without a `failure` arm the failure is not handled at the leaf: it rides the
+ * `View<E>` live channel to the nearest `Catch` — here, a page-level boundary
+ * wrapping the content section. Both phases route there: the initial fetch and
+ * any auto-tracked refetch (the thunk reads `userId.value`, so "Bad id"
+ * triggers a failing refetch *after* content already rendered). The boundary's
+ * `reset` re-runs construction → a fresh fetch with the current id.
+ *
+ * Deleting the `Catch` below is a compile error at the demo's mount, naming
+ * `HttpError` — `mount` requires `View<never>`, and the open `Async` is the
+ * leaf primitive that stamps `View<E≠never>`.
+ *
+ * The id buttons live *outside* the boundary so they survive the fallback swap
+ * (pick a good id, then retry, to recover).
+ *
+ * Inferred type: `Effect<View, never, Http | Scope>`
+ */
+export const AsyncEscalate = Effect.fn("AsyncEscalate")(function* (_props: {} = {}) {
+  const userId = AtomRef.make("42")
+  const http = yield* Http
+
+  return yield* (
+    <div class="async-escalate">
+      <div class="controls">
+        <button onclick={() => userId.set("42")}>Ada (42)</button>
+        <button onclick={() => userId.set("7")}>Grace (7)</button>
+        <button onclick={() => userId.set("999")}>Bad id</button>
+      </div>
+      {Catch(
+        <section class="content">
+          {Async(() => http.getUser(userId.value), {
+            initial: <span class="loading">  loading…</span>,
+            success: (user) => (
+              <div class="user-card">
+                <strong>{user.name}</strong>
+                {user.bio && <p class="bio">{user.bio}</p>}
+              </div>
+            ),
+          })}
+        </section>,
+        (cause, reset) => (
+          <div class="boundary-fallback">
+            <p class="caught">page boundary caught:</p>
+            <pre class="cause">{Cause.pretty(cause)}</pre>
+            <button class="retry" onclick={reset}>retry</button>
+          </div>
+        ),
+      )}
+    </div>
+  )
+})

--- a/apps/demo/src/channels.test-d.ts
+++ b/apps/demo/src/channels.test-d.ts
@@ -6,11 +6,11 @@
  */
 import type { Cause, Chunk, Effect, Option, Result, Scope } from "effect"
 import type { AtomRegistry } from "effect/unstable/reactivity"
-import { Catch, h, mount, type View } from "@verrex/core"
+import { Async, Catch, h, mount, type View } from "@verrex/core"
 import { AsyncUserPage } from "./AsyncUserPage.vx"
 import { Counter } from "./Counter.vx"
 import { LiveUser } from "./LiveUser.vx"
-import { HttpError, Http, Theme } from "./services.ts"
+import { HttpError, Http, Theme, type User } from "./services.ts"
 import { UserPage } from "./UserPage.vx"
 
 type Equals<A, B> = (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false
@@ -245,8 +245,7 @@ mount(AllTags, root)
 // ─── The LIVE half of the mount gate ────────────────────────────────────
 //     A View carrying a live error (`View<E≠never>`) is also rejected by `mount`,
 //     and `Catch` discharges it — the symmetric counterpart of the construction
-//     (Effect-E) gate above. (No leaf primitive stamps `View<E≠never>` today, so
-//     this is the type-level guarantee in isolation.)
+//     (Effect-E) gate above.
 
 declare const liveOnly: Effect.Effect<View<HttpError>, never, never>
 
@@ -258,6 +257,44 @@ mount(Catch(liveOnly, (_cause) => h("p", {}, "live error")), root)
 
 // tag-map discharges it too, narrowing to View<never>.
 mount(Catch(liveOnly, { HttpError: (e) => h("p", {}, `${e.status}`) }), root)
+
+// ─── Async: the failure arm picks the error's home ──────────────────────
+//     Providing `failure` handles the failure at the leaf — `View<never>`,
+//     nothing for a boundary to see. Omitting it puts `E` on the LIVE channel
+//     (`View<E>`) — the leaf primitive that stamps `View<E≠never>` — and the
+//     failure (initial fetch or refetch) routes to the nearest `Catch`.
+
+declare const getUser42: () => Effect.Effect<User, HttpError, Http>
+
+// Open form: HttpError rides the View channel; Http still folds into R.
+const OpenAsync = Async(getUser42, { success: (u) => h("p", {}, u.name) })
+assertEquals<typeof OpenAsync, Effect.Effect<View<HttpError>, never, Http | Scope.Scope>>()
+
+// Handled form: discharged to View<never>; the cause is precisely typed.
+const HandledAsync = Async(getUser42, {
+  success: (u) => h("p", {}, u.name),
+  failure: (cause) => {
+    const _typed: Cause.Cause<HttpError> = cause
+    void _typed
+    return h("p", {}, "failed")
+  },
+})
+assertEquals<typeof HandledAsync, Effect.Effect<View, never, Http | Scope.Scope>>()
+
+// The live E folds through enclosing elements (FoldLiveE picks it off the
+// child Effect's View<E> success).
+const OpenInTree = h("main", {}, OpenAsync)
+assertEquals<typeof OpenInTree, Effect.Effect<View<HttpError>, never, Http | Scope.Scope>>()
+
+// @ts-expect-error — the open Async's HttpError is undischarged: mount rejects
+// it, naming HttpError. Add a Catch boundary (or a failure arm at the leaf).
+mount(OpenInTree, root)
+
+// A page-level Catch discharges the live failure → mountable.
+mount(Catch(OpenInTree, (_cause) => h("p", {}, "failed")), root)
+
+// Tag-map form discharges it too, narrowing to View<never>.
+mount(Catch(OpenInTree, { HttpError: (e) => h("p", {}, `${e.status}`) }), root)
 
 // Note: the type assertions above are the **load-bearing proof** of the POC.
 // If they compile, channels are surviving the tree.

--- a/apps/demo/src/main.vx
+++ b/apps/demo/src/main.vx
@@ -3,6 +3,7 @@ import { AtomRegistry } from "effect/unstable/reactivity"
 import { VerrexLive, Catch, mount, type View } from "@verrex/core"
 import { Counter } from "./Counter.vx"
 import { AsyncUserPage } from "./AsyncUserPage.vx"
+import { AsyncEscalate } from "./AsyncEscalate.vx"
 import { CatchDemo } from "./CatchDemo.vx"
 import { flashOnUpdate } from "./flash.ts"
 import { highlight } from "./highlight.ts"
@@ -294,6 +295,44 @@ const App = (
       {demoSlot("boundary")}
     </section>
 
+    <section class="tour">
+      {copy({
+        step: "08",
+        title: "Async escalation (failure rides the live channel)",
+        concept:
+          "The same Async as step 03 — minus the failure arm. Omitting it puts the error on the View<E> live channel instead of handling it at the leaf: the result is Effect<View<HttpError>, …>, and the failure — initial fetch or auto-tracked refetch — routes to the nearest Catch. mount requires View<never>, so deleting the boundary is a compile error naming HttpError. Click \"Bad id\" after content renders: the refetch fails and the page-level banner swaps in. reset re-runs construction with the current id — pick a good one and retry to recover. Handle-at-the-leaf (step 03) vs escalate-to-the-page is now a per-call-site choice.",
+        type: "Effect<View, never, Http | Scope>",
+        code: `export const AsyncEscalate = Effect.fn("AsyncEscalate")(function* () {
+  const userId = AtomRef.make("42")
+  const http = yield* Http
+
+  return yield* (
+    <div>
+      <button onclick={() => userId.set("999")}>Bad id</button>
+
+      {Catch(
+        <section>
+          {/* no failure arm → HttpError rides View<E> to the Catch */}
+          {Async(() => http.getUser(userId.value), {
+            initial: <span>loading…</span>,
+            success: user => <strong>{user.name}</strong>,
+          })}
+        </section>,
+        (cause, reset) => (
+          <div class="banner">
+            <pre>{Cause.pretty(cause)}</pre>
+            <button onclick={reset}>retry</button>
+          </div>
+        ),
+      )}
+    </div>
+  )
+})`,
+        file: "AsyncEscalate.vx",
+      })}
+      {demoSlot("escalate")}
+    </section>
+
     <footer class="site-footer">
       <p>
         verrex is an experimental proof-of-concept.{" "}
@@ -378,6 +417,7 @@ const program = Effect.gen(function* () {
     setupDemo("todos", () => Todos())
     setupDemo("lifecycle", () => Lifecycle())
     setupDemo("boundary", () => CatchDemo())
+    setupDemo("escalate", () => AsyncEscalate())
   })
   // Start the reactivity flash once the initial mounts settle (incl. the
   // simulated fetch latency), so only interactions and resets flash — not page

--- a/packages/core/src/runtime/AGENTS.md
+++ b/packages/core/src/runtime/AGENTS.md
@@ -189,6 +189,28 @@ Solid's Resource — **not** React Suspense). Two exports, both in `index.ts`:
   object passed through `h(Async, props)` defeats inference (`success`'s value
   collapses to `unknown`), the same reason `list` is positional.
 
+**The `failure` arm is an overload pair — it picks the error's home.** Two
+public overloads (the with-`failure` one declared first, the open form's arms
+typed `failure?: never` so resolution can't fall through):
+
+- **provide `failure`** → the failure is handled at the leaf, rendered by the
+  arm: `Effect<View<never>, never, R | Scope>` — discharged, nothing for a
+  boundary to see.
+- **omit `failure`** → the failure **rides the live channel**:
+  `Effect<View<E>, never, R | Scope>`. This is the leaf primitive that stamps
+  `View<E≠never>`. Both an initial-fetch failure and a refetch failure route to
+  the nearest enclosing `Catch` (whose `reset` re-runs construction → a fresh
+  fetch), and `mount`'s `View<never>` gate makes a missing boundary a compile
+  error naming `E`. Mechanism: on `AsyncResult.failure` the matched source
+  emits `Effect.failCause(cause)`; the Reactive render path (`coerceSync`)
+  runs it, routes the cause to `ctx.sink` — the boundary's `report` — and
+  renders `Empty`. No new runtime machinery: it reuses the reactive-re-render
+  producer of "Runtime error routing" below. The interrupt-only guard already
+  ran in `asyncRef` (teardown never reaches the `Failure` state), and the
+  boundary queues the report off the render stack. Pinned by
+  `testing/async-escalate.test.ts` and the `Async` section of
+  `apps/demo/src/channels.test-d.ts`.
+
 The `from`/thunk runs under the **same dependency tracker as `h.track`**
 (`trackDeps`/`recordDep`, from `coerce.ts`): any reactive ref it reads via
 `.value`/`h.read` becomes a dependency, and the effect **re-runs when one
@@ -229,9 +251,11 @@ Reactive node does the DOM work. The design that makes this fit verrex:
 - **Channels:** because `forkScoped` forks the thunk's effect, the result folds
   its `R` — `asyncRef`/`Async` are `Effect<…, never, R | Scope>` with **no cast**.
   Extract services with `yield* Service` before the thunk so they fold into the
-  *component's* `R` (a missing Layer is a compile error at `mount`). `E` is
-  `never`: failure is a `Failure` value (matched / rendered via `failure`), not
-  propagated. Contrast in-component fetching (UserPage), where `E`+`R` fold to
+  *component's* `R` (a missing Layer is a compile error at `mount`). The
+  construction `E` is always `never` — the fetch never fails the build. The
+  failure's home is the `failure`-arm choice above: rendered at the leaf
+  (`View<never>`), or riding the live channel (`View<E>`) to the nearest
+  `Catch`. Contrast in-component fetching (UserPage), where `E`+`R` fold to
   the root.
 
 Why NOT `Atom`/`Atom.runtime` for this: an `Atom.runtime(layer)` bakes the

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -136,10 +136,17 @@ export const asyncRef = <A, E, R>(
  * Channels are accepted permissively (`any`) — the arms render at the node scope
  * and their E/R are NOT folded; only `from`'s `R` is (the thesis-bearing one).
  */
-interface AsyncArms<A, E> {
+interface AsyncArmsBase<A> {
   readonly initial?: View | Effect.Effect<View, any, any>
-  readonly failure?: (cause: Cause.Cause<E>) => View | Effect.Effect<View, any, any>
   readonly success: (value: A) => View | Effect.Effect<View, any, any>
+}
+/** Handled form: `failure` renders the failure locally → `E` discharged. */
+interface AsyncArmsHandled<A, E> extends AsyncArmsBase<A> {
+  readonly failure: (cause: Cause.Cause<E>) => View | Effect.Effect<View, any, any>
+}
+/** Open form: no `failure` arm — the failure rides the live channel (`View<E>`). */
+interface AsyncArmsOpen<A> extends AsyncArmsBase<A> {
+  readonly failure?: never
 }
 
 /**
@@ -162,27 +169,52 @@ interface AsyncArms<A, E> {
  * ```
  *
  * Sugar over `asyncRef` + `AsyncResult.match`: `from` runs on the mount fiber so
- * its `R` folds into the component (forgotten Layer = compile error); result is
- * `Effect<View, never, R | Scope>`. Failure renders via `failure` (omit → renders
- * nothing) — never thrown, never folded to `E`.
+ * its `R` folds into the component (forgotten Layer = compile error). The
+ * `failure` arm is a per-call-site choice between the two error homes:
+ *
+ *  - **provide it** → the failure is handled here as a value (rendered by the
+ *    arm) and the result is `Effect<View<never>, never, R | Scope>` — fully
+ *    discharged, nothing for a boundary to see.
+ *  - **omit it** → the failure **rides the live channel**: the result is
+ *    `Effect<View<E>, never, R | Scope>`, the failure (initial fetch *or* any
+ *    refetch) routes to the nearest enclosing `Catch`, and `mount`'s
+ *    `View<never>` gate makes a missing boundary a compile error naming `E`.
+ *    The boundary's `reset` re-runs construction → a fresh fetch.
  */
-export const Async = <A, E, R>(
+export function Async<A, E, R>(
   from: () => Effect.Effect<A, E, R>,
-  arms: AsyncArms<A, E>,
-): Effect.Effect<View, never, R | Scope.Scope> =>
-  asyncRef(from).pipe(
+  arms: AsyncArmsHandled<A, E>,
+): Effect.Effect<View, never, R | Scope.Scope>
+export function Async<A, E, R>(
+  from: () => Effect.Effect<A, E, R>,
+  arms: AsyncArmsOpen<A>,
+): Effect.Effect<View<E>, never, R | Scope.Scope>
+export function Async<A, E, R>(
+  from: () => Effect.Effect<A, E, R>,
+  arms: AsyncArmsBase<A> & {
+    readonly failure?: (cause: Cause.Cause<E>) => View | Effect.Effect<View, any, any>
+  },
+): Effect.Effect<View<E>, never, R | Scope.Scope> {
+  return asyncRef(from).pipe(
     Effect.map((state) =>
       View.Reactive({
         source: state.map((r) =>
           AsyncResult.match(r, {
             onInitial: () => arms.initial ?? null,
-            onFailure: (f) => (arms.failure ? arms.failure(f.cause) : null),
+            // No failure arm: emit the cause as a failing Effect. The Reactive
+            // render path (`coerceSync`) runs it, routes the cause to the
+            // subtree's error sink — the nearest `Catch`'s `report` — and
+            // renders nothing. The interrupt-only guard already ran in
+            // `asyncRef` (teardown never reaches the Failure state).
+            onFailure: (f) =>
+              arms.failure ? arms.failure(f.cause) : Effect.failCause(f.cause),
             onSuccess: (s) => arms.success(s.value),
           }),
         ) as AtomRef.ReadonlyRef<unknown>,
       }),
     ),
   )
+}
 
 // ─── Error boundary (Catch) ────────────────
 

--- a/packages/core/src/testing/async-autotrack.test.ts
+++ b/packages/core/src/testing/async-autotrack.test.ts
@@ -20,11 +20,12 @@ const UsersLive = Layer.succeed(Users, {
 })
 const read = (h as unknown as { read: (r: unknown) => string }).read
 
-// folding: a thunk whose effect has no R → Async is Effect<View, never, Scope>.
+// folding: a thunk whose effect has no R → Async is Effect<View<E>, never, Scope>;
+// with no failure arm, GetErr rides the live channel instead of being discharged.
 const _folds = (userId: AtomRef.AtomRef<string>, get: (id: string) => Effect.Effect<string, GetErr>) =>
   Async(() => get(read(userId)), {
     success: (n) => h("span", {}, n),
-  }) satisfies Effect.Effect<View, never, Scope.Scope>
+  }) satisfies Effect.Effect<View<GetErr>, never, Scope.Scope>
 void _folds
 
 const Page = (userId: AtomRef.AtomRef<string>) =>

--- a/packages/core/src/testing/async-escalate.test.ts
+++ b/packages/core/src/testing/async-escalate.test.ts
@@ -1,0 +1,116 @@
+// @vitest-environment happy-dom
+/**
+ * Async without a `failure` arm — the open form. The failure is not handled at
+ * the leaf; it rides the live channel (`View<E>`) to the nearest `Catch`: both
+ * an initial-fetch failure and a refetch failure flip the boundary to its
+ * fallback, and the boundary's `reset` re-runs construction → a fresh fetch.
+ * (The handled form — `failure` provided — is covered by async-boundary.test.ts.)
+ */
+import { describe, it, expect } from "vitest"
+import { Cause, Context, Effect, Layer, type Scope } from "effect"
+import { AtomRef } from "effect/unstable/reactivity"
+import { Async, Catch, h, type View } from "@verrex/core"
+import { render } from "./index.ts"
+
+class Users extends Context.Service<Users, {
+  readonly get: (id: string) => Effect.Effect<string, FetchError>
+}>()("esc/Users") {}
+class FetchError {
+  readonly _tag = "FetchError"
+  constructor(readonly id: string) {}
+}
+const db: Record<string, string> = { "42": "Ada", "7": "Grace" }
+const UsersLive = Layer.succeed(Users, {
+  get: (id) => (db[id] ? Effect.succeed(db[id]) : Effect.fail(new FetchError(id))),
+})
+const read = (h as unknown as { read: (r: unknown) => string }).read
+
+// A page-level catch-all boundary around content that fetches via the open
+// form. The id-switching button lives OUTSIDE the boundary so it survives the
+// fallback swap.
+const Page = (userId: AtomRef.AtomRef<string>) =>
+  Effect.fn(function* () {
+    const client = yield* Users
+    return yield* h("div", { class: "page" },
+      h("button", { class: "bad", onclick: () => userId.set("999") }, "bad"),
+      yield* Catch(
+        h("section", { class: "content" },
+          Async(() => client.get(read(userId)), {
+            initial: h("span", { class: "loading" }, "…"),
+            success: (n) => h("span", { class: "ok" }, n),
+          }),
+        ),
+        (cause, reset) =>
+          h("div", { class: "fallback" },
+            h("pre", { class: "caught" }, Cause.pretty(cause)),
+            h("button", { class: "retry", onclick: reset }, "retry"),
+          ),
+      ),
+    )
+  })()
+
+describe("Async without failure arm → nearest Catch", () => {
+  it("routes an initial-fetch failure to the boundary fallback (cause included)", async () => {
+    const ui = await render(Page(AtomRef.make("999")), UsersLive)
+    const fallback = await ui.waitFor(".fallback")
+    expect(fallback.querySelector(".caught")?.textContent).toContain("FetchError")
+    expect(ui.query(".ok")).toBeNull()
+    await ui.unmount()
+  })
+
+  it("routes a REFETCH failure to the boundary — content already rendered", async () => {
+    const userId = AtomRef.make("42")
+    const ui = await render(Page(userId), UsersLive)
+    expect((await ui.waitFor(".ok")).textContent?.trim()).toBe("Ada")
+    ui.click(".bad") // userId → "999": tracked refetch fails post-mount
+    await ui.waitFor(".fallback")
+    expect(ui.query(".ok")).toBeNull()
+    await ui.unmount()
+  })
+
+  it("reset re-runs construction → a fresh fetch that can succeed", async () => {
+    const userId = AtomRef.make("999")
+    const ui = await render(Page(userId), UsersLive)
+    await ui.waitFor(".fallback")
+    userId.set("42") // fix the input, then retry
+    ui.click(".retry")
+    expect((await ui.waitFor(".ok")).textContent?.trim()).toBe("Ada")
+    expect(ui.query(".fallback")).toBeNull()
+    await ui.unmount()
+  })
+
+  it("a tag-map Catch routes on the failure's tag and unwraps it", async () => {
+    const TagPage = Effect.fn(function* () {
+      const client = yield* Users
+      return yield* Catch(
+        h("section", {},
+          Async(() => client.get("999"), {
+            success: (n) => h("span", { class: "ok" }, n),
+          }),
+        ),
+        {
+          FetchError: (e, _reset) => h("p", { class: "tagged" }, `missing user ${e.id}`),
+        },
+      )
+    })()
+    const ui = await render(TagPage, UsersLive)
+    expect((await ui.waitFor(".tagged")).textContent?.trim()).toBe("missing user 999")
+    await ui.unmount()
+  })
+
+  it("the open form still types R (service folds) and stamps View<E>", () => {
+    // Compile-time pin, kept next to the runtime proof: omitting `failure`
+    // stamps E on the View channel; providing it discharges to View<never>.
+    const open = (get: (id: string) => Effect.Effect<string, FetchError>) =>
+      Async(() => get("42"), {
+        success: (n) => h("span", {}, n),
+      }) satisfies Effect.Effect<View<FetchError>, never, Scope.Scope>
+    const handled = (get: (id: string) => Effect.Effect<string, FetchError>) =>
+      Async(() => get("42"), {
+        success: (n) => h("span", {}, n),
+        failure: () => h("span", {}, "nope"),
+      }) satisfies Effect.Effect<View, never, Scope.Scope>
+    expect(typeof open).toBe("function")
+    expect(typeof handled).toBe("function")
+  })
+})

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -15,6 +15,7 @@ re-renders when you click +".
 | `probe-liveuser.mjs` | Keyed `asyncRef`: clicking the LiveUser buttons changes the trigger `AtomRef`, refetching through Initial → Success → Failure → recovery. |
 | `probe-async-userpage.mjs` | Once-form `Async`: the boundary renders a pending placeholder then swaps in the success arm (`.async-user-page .user-body`). Non-blocking counterpart to `probe.mjs`'s in-component UserPage check. |
 | `probe-catch.mjs` | Both `Catch` forms in the browser: the catch-all (function) form catching a failing event-handler Effect and recovering on reset; the object tag-map (`{ HttpError }`) form routing a flaky construction failure **and** a live (post-construction) error, with retry re-rolling the request. Prints PASS/FAIL, sets `process.exitCode`. |
+| `probe-escalate.mjs` | `Async` open form (no `failure` arm): a failing auto-tracked refetch escalates past the leaf to the page-level `Catch` banner; the controls outside the boundary survive the swap; `retry` after fixing the id recovers. Prints PASS/FAIL, sets `process.exitCode`. |
 | `probe-todos.mjs` | Keyed reactive list: add/remove/toggle a row leaves sibling DOM nodes untouched (tagged-node identity check). |
 | `probe-lifecycle.mjs` | Per-component lifecycle scope, three phases: (1) initial mount-event count, (2) removing a row fires its matching unmount via `Scope.closeUnsafe`, (3) full teardown via `__teardown` cascades through every row scope so every outstanding mount has a matching unmount. |
 | `probe-hmr.mjs` | Vite HMR on a `.vx` edit propagates without a full reload. |

--- a/scripts/probe-catch.mjs
+++ b/scripts/probe-catch.mjs
@@ -1,7 +1,7 @@
 // Probe for step 07 — the `Catch` boundary demo (both forms).
 // Verifies the tag-map caught a typed HttpError on load, and the catch-all
 // catches a live event-handler failure on click + recovers on reset.
-import { runProbe } from "./probe-harness.mjs"
+import { runProbe, waitForText as waitForTextIn } from "./probe-harness.mjs"
 
 const errors = []
 
@@ -17,15 +17,7 @@ await runProbe({
     const sel = '[data-demo="boundary"]'
     const demo = page.locator(sel)
     await demo.waitFor({ state: "attached" })
-    // Poll for content rather than fixed sleeps (a cold dev server compiles .vx on
-    // first request, so timings vary). Case-insensitive — the fallback label is
-    // upper-cased by CSS (text-transform), which `innerText` reflects.
-    const waitForText = (re) =>
-      page.waitForFunction(
-        ({ s, src, fl }) => new RegExp(src, fl).test(document.querySelector(s)?.innerText ?? ""),
-        { s: sel, src: re.source, fl: re.flags },
-        { timeout: 5000 },
-      )
+    const waitForText = (re) => waitForTextIn(page, sel, re)
     const demoText = async () => (await demo.innerText()).replace(/\s+/g, " ").trim()
 
     // 1) tag-map (object form): the flaky request ~50% fails at construction with a

--- a/scripts/probe-escalate.mjs
+++ b/scripts/probe-escalate.mjs
@@ -1,0 +1,52 @@
+// Probe for step 08 — `Async` open form (no failure arm) escalating to the
+// page-level `Catch`. Verifies: content renders on load; a failing auto-tracked
+// REFETCH (Bad id) swaps in the boundary banner naming HttpError; the id
+// buttons outside the boundary survive the swap; retry after picking a good id
+// re-runs construction and recovers.
+import { runProbe } from "./probe-harness.mjs"
+
+const errors = []
+
+await runProbe({
+  onConsole: (msg) => {
+    if (msg.type() === "error" && !/Failed to load resource/.test(msg.text())) {
+      errors.push(msg.text())
+    }
+  },
+  run: async (page) => {
+    const sel = '[data-demo="escalate"]'
+    const demo = page.locator(sel)
+    await demo.waitFor({ state: "attached" })
+    const waitForText = (re) =>
+      page.waitForFunction(
+        ({ s, src, fl }) => new RegExp(src, fl).test(document.querySelector(s)?.innerText ?? ""),
+        { s: sel, src: re.source, fl: re.flags },
+        { timeout: 5000 },
+      )
+
+    // 1. Happy path renders through the boundary untouched.
+    await waitForText(/Ada Lovelace/)
+    console.log("PASS: content rendered (Ada Lovelace)")
+
+    // 2. Bad id → the refetch fails post-mount; the failure rides the live
+    //    channel to the page boundary, which swaps in the banner.
+    await demo.locator("button", { hasText: "Bad id" }).click()
+    await waitForText(/page boundary caught/i)
+    await waitForText(/HttpError/)
+    console.log("PASS: refetch failure escalated to the boundary banner")
+
+    // 3. The controls outside the boundary survived the swap; pick a good id
+    //    and retry → reset re-runs construction → fresh fetch succeeds.
+    await demo.locator("button", { hasText: "Grace (7)" }).click()
+    await demo.locator("button.retry", { hasText: "retry" }).click()
+    await waitForText(/Grace Hopper/)
+    console.log("PASS: retry after fixing the id recovered (Grace Hopper)")
+
+    if (errors.length > 0) {
+      console.error("FAIL: console errors:", errors)
+      process.exitCode = 1
+    } else {
+      console.log("PASS: no console errors")
+    }
+  },
+})

--- a/scripts/probe-escalate.mjs
+++ b/scripts/probe-escalate.mjs
@@ -3,7 +3,7 @@
 // REFETCH (Bad id) swaps in the boundary banner naming HttpError; the id
 // buttons outside the boundary survive the swap; retry after picking a good id
 // re-runs construction and recovers.
-import { runProbe } from "./probe-harness.mjs"
+import { runProbe, waitForText as waitForTextIn } from "./probe-harness.mjs"
 
 const errors = []
 
@@ -17,12 +17,7 @@ await runProbe({
     const sel = '[data-demo="escalate"]'
     const demo = page.locator(sel)
     await demo.waitFor({ state: "attached" })
-    const waitForText = (re) =>
-      page.waitForFunction(
-        ({ s, src, fl }) => new RegExp(src, fl).test(document.querySelector(s)?.innerText ?? ""),
-        { s: sel, src: re.source, fl: re.flags },
-        { timeout: 5000 },
-      )
+    const waitForText = (re) => waitForTextIn(page, sel, re)
 
     // 1. Happy path renders through the boundary untouched.
     await waitForText(/Ada Lovelace/)

--- a/scripts/probe-harness.mjs
+++ b/scripts/probe-harness.mjs
@@ -1,6 +1,19 @@
 // Shared Playwright harness for probe-*.mjs specs.
 import { chromium } from "playwright-core"
 
+/**
+ * Poll until `sel`'s innerText matches `re` (or `timeout` ms elapse). Poll for
+ * content rather than fixed sleeps — a cold dev server compiles .vx on first
+ * request, so timings vary. Match against `innerText` (it reflects CSS
+ * `text-transform`, so pass a case-insensitive regex for upper-cased labels).
+ */
+export const waitForText = (page, sel, re, timeout = 5000) =>
+  page.waitForFunction(
+    ({ s, src, fl }) => new RegExp(src, fl).test(document.querySelector(s)?.innerText ?? ""),
+    { s: sel, src: re.source, fl: re.flags },
+    { timeout },
+  )
+
 export async function runProbe({
   url = "http://localhost:5173/",
   viewport = { width: 900, height: 1100 },


### PR DESCRIPTION
Closes #73.

## What

`Async` grows an overload pair, picked by the `failure` arm — the per-call-site choice between the two error homes:

```ts
Async(thunk, { success, failure })   // : Effect<View<never>, never, R | Scope>  (unchanged)
Async(thunk, { success })            // : Effect<View<E>,     never, R | Scope>  (new: E rides the live channel)
```

Omitting `failure` makes `Async` the first leaf primitive that stamps `View<E≠never>`: the failure — initial fetch *or* auto-tracked refetch — routes to the nearest enclosing `Catch` (whose `reset` re-runs construction → a fresh fetch), and `mount`'s `View<never>` gate turns a missing boundary into a compile error naming `E`. This closes the "no primitive stamps `View<E≠never>`" gap in the honest-scope note for the `Async` leaf (typed event handlers, #72, remain).

## How

Minimal runtime change, as anticipated in the issue: with no `failure` arm, the matched `Reactive` source emits `Effect.failCause(cause)` on `AsyncResult.failure`. The existing render path does the rest — `coerceSync` runs the effect, routes the cause to the subtree's error sink (the boundary's `report`, queued off the render stack), and renders `Empty`. The interrupt-only guard already ran in `asyncRef`, so teardown never reaches the failure state. Stale-content semantics follow existing `Catch` swap behavior.

Previously an omitted `failure` arm silently rendered nothing on failure; that case now escalates instead (and is a type-level change from `View<never>` to `View<E>`, surfaced at the `mount` gate).

## Acceptance (from #73)

- [x] **Demo:** step 08 (`AsyncEscalate.vx`) — a page-level `Catch` catches a child refetch failure and offers retry; verified in real Chromium via `scripts/probe-escalate.mjs` (content renders → "Bad id" refetch failure swaps in the banner → fix id + retry recovers; no console errors). Existing `probe-catch` / `probe-async-userpage` / `probe-liveuser` still pass.
- [x] **Type-test pins** (`channels.test-d.ts`): omitting `failure` puts `E` on the View channel; providing it discharges to `never`; the live `E` folds through enclosing elements.
- [x] An `Async` without `failure` and without an enclosing `Catch` fails `mount`'s gate naming the error (`@ts-expect-error` pin).
- [x] Runtime AGENTS.md `Async`/`asyncRef` section updated; root honest-scope note updated.

## Tests

- New `testing/async-escalate.test.ts` (5 tests): initial-fetch failure → fallback with cause; refetch failure after content rendered → fallback; reset → fresh fetch recovers; tag-map `Catch` routes on the tag and unwraps; `satisfies` pins for both overloads.
- Full suite: 206 + 31 tests pass, `pnpm -r typecheck` clean (the one pre-existing no-failure-arm pin in `async-autotrack.test.ts` updated from `View` to `View<GetErr>` — the type now tells the truth).

## Inference/perf check

`verrex-check` over the demo (13 files): **5.66s** on this branch vs **5.65s** on main — no measurable inference regression. Hovers on `Async` call sites resolve to the concise `Effect<View<E>, never, R | Scope>` form (the overload pair adds no conditional types; `E` comes straight from the thunk).