### PR TITLE
feat(runtime): tag-selective failure arm for Async (mirrors Catch's tag map)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,8 +16,11 @@ channel is only partially tracked: exactly one leaf primitive stamps
 `View<E≠never>` — `Async` *without* a `failure` arm, typed
 `Effect<View<E>, never, R | Scope>`. Its failures (initial fetch or refetch)
 ride `View<E>` to the nearest `Catch`, and `mount`'s `View<never>` gate makes
-a missing boundary a compile error naming `E` (with the arm, the failure is
-handled at the leaf and discharges to `View<never>`). Everything else that
+a missing boundary a compile error naming `E`. The `failure` arm mirrors
+`Catch`'s two forms: a function handles everything at the leaf
+(`View<never>`); a tag map handles matched tags at the leaf — keeping the
+fetch loop live, so a dep change can recover the view — while the residual
+rides `View<Exclude<E, { _tag }>>`. Everything else that
 can fail live — event handlers, reactive re-renders — is still erased to
 `(e) => void` / `unknown` and caught only at *runtime* by `Catch`'s sink, not
 tracked by the type. Closing that (typed event handlers, #72) is the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,8 @@ produce ride the `View<E>` success — one `Catch` boundary discharges both.
 **Honest scope today:** the *construction* channel is fully type-tracked —
 a forgotten boundary on a failing build is a compile error. The *live*
 channel is only partially tracked: exactly one leaf primitive stamps
-`View<E≠never>` — `Async` *without* a `failure` arm, typed
+`View<E≠never>` — `Async` *without* a `failure` arm (or with a *partial* tag
+map, whose residual rides), typed
 `Effect<View<E>, never, R | Scope>`. Its failures (initial fetch or refetch)
 ride `View<E>` to the nearest `Catch`, and `mount`'s `View<never>` gate makes
 a missing boundary a compile error naming `E`. The `failure` arm mirrors

--- a/apps/demo/src/channels.test-d.ts
+++ b/apps/demo/src/channels.test-d.ts
@@ -327,6 +327,13 @@ mount(TagMapAsync, root)
 // A boundary discharges the residual → mountable.
 mount(Catch(TagMapAsync, { ParseError: (e) => h("p", {}, e.message) }), root)
 
+// A tag map needs an E with at least one tagged member: with TagsOf<E> = never
+// the Handlers constraint collapses to `never` (not the empty mapped type, which
+// would accept ANY map as a silently-dead handler set).
+declare const getUntagged: () => Effect.Effect<string, string, never>
+// @ts-expect-error — E = string has no tags; the tag-map overload is rejected
+Async(getUntagged, { success: (s) => h("p", {}, s), failure: { Oops: () => h("p", {}, "x") } })
+
 // Handle every tag at the leaf → View<never>, mountable with no boundary.
 const TagMapAll = Async(getUserTwo, {
   success: (u) => h("p", {}, u.name),

--- a/apps/demo/src/channels.test-d.ts
+++ b/apps/demo/src/channels.test-d.ts
@@ -296,6 +296,48 @@ mount(Catch(OpenInTree, (_cause) => h("p", {}, "failed")), root)
 // Tag-map form discharges it too, narrowing to View<never>.
 mount(Catch(OpenInTree, { HttpError: (e) => h("p", {}, `${e.status}`) }), root)
 
+// ─── Async tag-map failure arm: per-tag leaf handling, residual rides ───
+//     `failure` as a `_tag → handler` map mirrors Catch's tag-selective form:
+//     matched tags are handled at the leaf (the fetch loop stays live), the
+//     residual rides the live channel by `Exclude<E, { _tag }>` and must still
+//     meet a `Catch` before `mount`.
+
+declare const getUserTwo: () => Effect.Effect<User, HttpError | ParseError, Http>
+
+// Handle one tag → its handler gets the unwrapped error; the residual stays
+// on the live channel: View<ParseError>.
+const TagMapAsync = Async(getUserTwo, {
+  success: (u) => h("p", {}, u.name),
+  failure: {
+    HttpError: (e) => {
+      const _status: number = e.status
+      void _status
+      return h("p", {}, "http error")
+    },
+  },
+})
+assertEquals<typeof TagMapAsync, Effect.Effect<View<ParseError>, never, Http | Scope.Scope>>()
+
+// @ts-expect-error — "Nope" is not one of the thunk's error tags
+Async(getUserTwo, { success: (u) => h("p", {}, u.name), failure: { Nope: () => h("p", {}, "x") } })
+
+// @ts-expect-error — ParseError still rides the live channel; mount rejects it, naming it
+mount(TagMapAsync, root)
+
+// A boundary discharges the residual → mountable.
+mount(Catch(TagMapAsync, { ParseError: (e) => h("p", {}, e.message) }), root)
+
+// Handle every tag at the leaf → View<never>, mountable with no boundary.
+const TagMapAll = Async(getUserTwo, {
+  success: (u) => h("p", {}, u.name),
+  failure: {
+    HttpError: (e) => h("p", {}, `${e.status}`),
+    ParseError: (e) => h("p", {}, e.message),
+  },
+})
+assertEquals<typeof TagMapAll, Effect.Effect<View, never, Http | Scope.Scope>>()
+mount(TagMapAll, root)
+
 // Note: the type assertions above are the **load-bearing proof** of the POC.
 // If they compile, channels are surviving the tree.
 // The `@ts-expect-error` assertions above prove props are type-checked at

--- a/packages/core/src/runtime/AGENTS.md
+++ b/packages/core/src/runtime/AGENTS.md
@@ -189,13 +189,31 @@ Solid's Resource — **not** React Suspense). Two exports, both in `index.ts`:
   object passed through `h(Async, props)` defeats inference (`success`'s value
   collapses to `unknown`), the same reason `list` is positional.
 
-**The `failure` arm is an overload pair — it picks the error's home.** Two
-public overloads (the with-`failure` one declared first, the open form's arms
-typed `failure?: never` so resolution can't fall through):
+**The `failure` arm picks the error's home — function, tag map, or absent.**
+Three public overloads (catch-all function first, tag map second, the open
+form's arms typed `failure?: never` so resolution can't fall through),
+mirroring `Catch`'s function-vs-object convention:
 
-- **provide `failure`** → the failure is handled at the leaf, rendered by the
-  arm: `Effect<View<never>, never, R | Scope>` — discharged, nothing for a
+- **`failure` as a function** → catch-all: every failure is handled at the
+  leaf, rendered by the arm (which gets the full `Cause<E>`):
+  `Effect<View<never>, never, R | Scope>` — discharged, nothing for a
   boundary to see.
+- **`failure` as a tag map** — `failure: { NotFound: (e) => … }` → a matched
+  tag is handled at the leaf (the handler gets the unwrapped error) while the
+  **fetch loop stays live**: a dep change still refetches, so the view
+  recovers with no boundary `reset`. That semantic is why this isn't sugar
+  for `Catch(Async(open), tagMap)` — a leaf `Catch` that accepts a failure
+  swaps the subtree and closes its build scope, tearing down the `asyncRef`
+  supervisor. The residual rides the live channel:
+  `Effect<View<Exclude<E, { _tag }>>, never, R | Scope>`. Dispatch is shared
+  with `Catch` (`taggedHandlerFor`: own function-valued key, first tagged
+  error) and inherits its caveats — first-error routing on multi-tagged
+  causes, and a typo'd key mixed with ≥1 valid key is silently dead (its tag
+  stays on the channel, so nothing is wrongly discharged; a typo as the
+  *only* key is a compile error). Tag handlers get no retry callback yet
+  (TODO — `Catch`'s `reset` is the boundary-side analog). Pinned by
+  `testing/async-tagmap.test.ts` (incl. the recover-without-reset semantic)
+  and the tag-map `Async` section of `apps/demo/src/channels.test-d.ts`.
 - **omit `failure`** → the failure **rides the live channel**:
   `Effect<View<E>, never, R | Scope>`. This is the leaf primitive that stamps
   `View<E≠never>`. Both an initial-fetch failure and a refetch failure route to

--- a/packages/core/src/runtime/AGENTS.md
+++ b/packages/core/src/runtime/AGENTS.md
@@ -206,14 +206,23 @@ mirroring `Catch`'s function-vs-object convention:
   swaps the subtree and closes its build scope, tearing down the `asyncRef`
   supervisor. The residual rides the live channel:
   `Effect<View<Exclude<E, { _tag }>>, never, R | Scope>`. Dispatch is shared
-  with `Catch` (`taggedHandlerFor`: own function-valued key, first tagged
-  error) and inherits its caveats — first-error routing on multi-tagged
-  causes, and a typo'd key mixed with ≥1 valid key is silently dead (its tag
-  stays on the channel, so nothing is wrongly discharged; a typo as the
-  *only* key is a compile error). Tag handlers get no retry callback yet
-  (TODO — `Catch`'s `reset` is the boundary-side analog). Pinned by
-  `testing/async-tagmap.test.ts` (incl. the recover-without-reset semantic)
-  and the tag-map `Async` section of `apps/demo/src/channels.test-d.ts`.
+  with `Catch` (`taggedMatch`: own function-valued key, routed on the cause's
+  *first* error when it is tagged; the helper returns the matched
+  `{ handler, error }` pair so dispatch tag and handler argument can't drift)
+  and inherits its caveats: a typo'd key mixed with ≥1 valid key is silently
+  dead (its tag stays on the channel — for *inline literals* the type never
+  lies; a typo as the only key is a compile error), and a tag map on an `E`
+  with no tagged members is rejected outright (the overload's constraint
+  collapses to `never`, not the accept-anything empty mapped type). Known
+  type/runtime gaps — pre-built/widened maps, prototype-keyed objects,
+  explicit-`undefined` slots without `exactOptionalPropertyTypes` — can
+  over-discharge and are tracked in #91; both tag-map surfaces share them.
+  The handler-map shape itself is the shared `TagHandlers<E, Extra>` alias
+  (Catch instantiates `Extra = [reset]`), so the planned Async retry callback
+  (TODO — `Catch`'s `reset` is the boundary-side analog) is a one-place
+  change. Pinned by `testing/async-tagmap.test.ts` (incl. the
+  recover-without-reset semantic and nullish-arm degradation) and the tag-map
+  `Async` section of `apps/demo/src/channels.test-d.ts`.
 - **omit `failure`** → the failure **rides the live channel**:
   `Effect<View<E>, never, R | Scope>`. This is the leaf primitive that stamps
   `View<E≠never>`. Both an initial-fetch failure and a refetch failure route to

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -137,29 +137,49 @@ type Tagged = { readonly _tag: string }
 type TagsOf<E> = E extends Tagged ? E["_tag"] : never
 type WithoutTag<E, Tag extends string> = Exclude<E, { readonly _tag: Tag }>
 
-/** The `_tag` of a cause's first error, if it's a tagged error. */
-const errorTagOf = (cause: Cause.Cause<unknown>): string | undefined => {
-  const err = Option.getOrUndefined(Cause.findErrorOption(cause))
-  return typeof err === "object" && err !== null && "_tag" in err
-    ? (err as Tagged)._tag
-    : undefined
+/**
+ * Tag-selective handler map over `E`'s tagged members; `Extra` appends the
+ * surface-specific trailing params (Catch's `reset`; Async's planned retry).
+ * Both tag-map surfaces instantiate THIS alias so the deliberate trade-offs
+ * live once: keys are constrained to the child's tags for per-handler `error`
+ * inference, and the exactness guard is omitted on purpose — a typo'd key
+ * beside ≥1 valid key is silently dead (its tag stays on the channel, so the
+ * type never lies for inline literals), while a typo as the only key is a
+ * compile error. Pre-built/widened maps, prototype-keyed objects, and (for
+ * consumers without `exactOptionalPropertyTypes`) explicit-`undefined` slots
+ * can over-discharge — the type/runtime gap is tracked in #91.
+ */
+type TagHandlers<E, Extra extends ReadonlyArray<unknown> = []> = {
+  readonly [K in TagsOf<E>]?: (
+    error: Extract<E, { readonly _tag: K }>,
+    ...rest: Extra
+  ) => View | Effect.Effect<View, any, any>
 }
 
 /**
- * The OWN, function-valued handler for the cause's first tagged error (not a
- * prototype-chain hit, not an explicit `undefined` slot). Dispatches on the
- * FIRST tagged error of the cause (`Cause.findErrorOption`); the design assumes
- * a single tagged failure per cause — a multi-tagged cause routes on its first
- * error. One lookup for both tag-map surfaces so their dispatch can't drift.
+ * The handler matching the cause's first error, when that error is tagged and
+ * `handlers` carries an OWN, function-valued key for it (not a prototype-chain
+ * hit, not an explicit `undefined` slot — the gaps this leaves are #91).
+ * Dispatch is on the cause's FIRST error — if it is untagged, no handler
+ * matches even when a later error's tag is mapped; the design assumes a single
+ * failure per cause. Returns the handler together with the error it matched
+ * on, so dispatch tag and handler argument can't drift apart across the two
+ * tag-map surfaces.
  */
-const taggedHandlerFor = (
+const taggedMatch = (
   handlers: Record<string, unknown>,
   cause: Cause.Cause<unknown>,
-): ((error: any, ...rest: Array<any>) => unknown) | undefined => {
-  const t = errorTagOf(cause)
+):
+  | { readonly handler: (error: any, reset?: () => void) => unknown; readonly error: unknown }
+  | undefined => {
+  const err = Option.getOrUndefined(Cause.findErrorOption(cause))
+  const t =
+    typeof err === "object" && err !== null && "_tag" in err ? (err as Tagged)._tag : undefined
   if (t === undefined || !Object.hasOwn(handlers, t)) return undefined
   const fn = handlers[t]
-  return typeof fn === "function" ? (fn as (error: any, ...rest: Array<any>) => unknown) : undefined
+  return typeof fn === "function"
+    ? { handler: fn as (error: any, reset?: () => void) => unknown, error: err }
+    : undefined
 }
 
 /**
@@ -213,10 +233,12 @@ interface AsyncArmsOpen<A> extends AsyncArmsBase<A> {
  *    LIVE — a dep change still refetches, so the view can recover with no
  *    boundary `reset`. The residual rides the live channel:
  *    `Effect<View<Exclude<E, { _tag }>>, never, R | Scope>`. Dispatch is
- *    `Catch`'s tag-map dispatch (first tagged error; own, function-valued
- *    keys; a typo'd key mixed with ≥1 valid key is silently dead — its tag
- *    stays on the channel, nothing is wrongly discharged). Handlers get no
- *    retry callback yet (TODO; `Catch`'s `reset` is the boundary-side analog).
+ *    `Catch`'s tag-map dispatch (the cause's first error, when tagged; own,
+ *    function-valued keys — prefer inline literals: pre-built/widened maps
+ *    can over-discharge, see #91). A typo'd key mixed with ≥1 valid key is
+ *    silently dead — its tag stays on the channel. A tag map on an `E` with
+ *    no tagged members is rejected at compile time. Handlers get no retry
+ *    callback yet (TODO; `Catch`'s `reset` is the boundary-side analog).
  *  - **omitted** — the failure **rides the live channel**: the result is
  *    `Effect<View<E>, never, R | Scope>`, the failure (initial fetch *or* any
  *    refetch) routes to the nearest enclosing `Catch`, and `mount`'s
@@ -231,11 +253,9 @@ export function Async<
   A,
   E,
   R,
-  Handlers extends {
-    readonly [K in TagsOf<E>]?: (
-      error: Extract<E, { readonly _tag: K }>,
-    ) => View | Effect.Effect<View, any, any>
-  },
+  // `never` when E has no tagged members: without it, TagsOf<E> = never makes
+  // the constraint the empty mapped type and ANY map compiles, silently dead.
+  Handlers extends [TagsOf<E>] extends [never] ? never : TagHandlers<E>,
 >(
   from: () => Effect.Effect<A, E, R>,
   arms: AsyncArmsBase<A> & { readonly failure: Handlers },
@@ -249,7 +269,7 @@ export function Async<A, E, R>(
   arms: AsyncArmsBase<A> & {
     readonly failure?:
       | ((cause: Cause.Cause<E>) => View | Effect.Effect<View, any, any>)
-      | Record<string, (error: any) => View | Effect.Effect<View, any, any>>
+      | Record<string, unknown>
   },
 ): Effect.Effect<View<E>, never, R | Scope.Scope> {
   return asyncRef(from).pipe(
@@ -269,10 +289,11 @@ export function Async<A, E, R>(
             onFailure: (f) => {
               const { failure } = arms
               if (typeof failure === "function") return failure(f.cause)
-              const handler = failure === undefined ? undefined : taggedHandlerFor(failure, f.cause)
-              return handler !== undefined
-                ? handler(Option.getOrUndefined(Cause.findErrorOption(f.cause)))
-                : Effect.failCause(f.cause)
+              // Truthiness (not === undefined): a nullish `failure` smuggled
+              // past the types degrades to the open form instead of crashing
+              // `Object.hasOwn` — matching the pre-tag-map behavior.
+              const match = failure ? taggedMatch(failure, f.cause) : undefined
+              return match ? match.handler(match.error) : Effect.failCause(f.cause)
             },
             onSuccess: (s) => arms.success(s.value),
           }),
@@ -454,12 +475,7 @@ export function Catch<
   EV,
   EC,
   R,
-  Handlers extends {
-    readonly [K in TagsOf<EC | EV>]?: (
-      error: Extract<EC | EV, { readonly _tag: K }>,
-      reset: () => void,
-    ) => View | Effect.Effect<View, any, any>
-  },
+  Handlers extends TagHandlers<EC | EV, [reset: () => void]>,
 >(
   child: Effect.Effect<View<EV>, EC, R>,
   handlers: Handlers,
@@ -478,12 +494,15 @@ export function Catch(
     return makeBoundary(child, () => true, handlerOrMap)
   }
   const handlers = handlerOrMap
-  // Dispatch rules (own function-valued key, first tagged error) live in
-  // `taggedHandlerFor`, shared with Async's tag-map `failure` arm.
+  // Dispatch rules (own function-valued key, first-error routing) live in
+  // `taggedMatch`, shared with Async's tag-map `failure` arm.
   return makeBoundary(
     child,
-    (cause) => taggedHandlerFor(handlers, cause) !== undefined,
-    (cause, reset) => taggedHandlerFor(handlers, cause)!(Option.getOrUndefined(Cause.findErrorOption(cause)), reset),
+    (cause) => taggedMatch(handlers, cause) !== undefined,
+    (cause, reset) => {
+      const m = taggedMatch(handlers, cause)!
+      return m.handler(m.error, reset)
+    },
   )
 }
 

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -131,6 +131,37 @@ export const asyncRef = <A, E, R>(
     return state as AtomRef.ReadonlyRef<AsyncResult.AsyncResult<A, E>>
   })
 
+// ─── Tagged-error dispatch (shared by Async's tag-map `failure` arm and Catch) ─
+
+type Tagged = { readonly _tag: string }
+type TagsOf<E> = E extends Tagged ? E["_tag"] : never
+type WithoutTag<E, Tag extends string> = Exclude<E, { readonly _tag: Tag }>
+
+/** The `_tag` of a cause's first error, if it's a tagged error. */
+const errorTagOf = (cause: Cause.Cause<unknown>): string | undefined => {
+  const err = Option.getOrUndefined(Cause.findErrorOption(cause))
+  return typeof err === "object" && err !== null && "_tag" in err
+    ? (err as Tagged)._tag
+    : undefined
+}
+
+/**
+ * The OWN, function-valued handler for the cause's first tagged error (not a
+ * prototype-chain hit, not an explicit `undefined` slot). Dispatches on the
+ * FIRST tagged error of the cause (`Cause.findErrorOption`); the design assumes
+ * a single tagged failure per cause — a multi-tagged cause routes on its first
+ * error. One lookup for both tag-map surfaces so their dispatch can't drift.
+ */
+const taggedHandlerFor = (
+  handlers: Record<string, unknown>,
+  cause: Cause.Cause<unknown>,
+): ((error: any, ...rest: Array<any>) => unknown) | undefined => {
+  const t = errorTagOf(cause)
+  if (t === undefined || !Object.hasOwn(handlers, t)) return undefined
+  const fn = handlers[t]
+  return typeof fn === "function" ? (fn as (error: any, ...rest: Array<any>) => unknown) : undefined
+}
+
 /**
  * The arms for `Async` / `<Async>`. Each maps to an `AsyncResult` variant.
  * Channels are accepted permissively (`any`) — the arms render at the node scope
@@ -170,12 +201,23 @@ interface AsyncArmsOpen<A> extends AsyncArmsBase<A> {
  *
  * Sugar over `asyncRef` + `AsyncResult.match`: `from` runs on the mount fiber so
  * its `R` folds into the component (forgotten Layer = compile error). The
- * `failure` arm is a per-call-site choice between the two error homes:
+ * `failure` arm picks the error's home, per call site (mirroring `Catch`'s
+ * function-vs-object forms):
  *
- *  - **provide it** → the failure is handled here as a value (rendered by the
- *    arm) and the result is `Effect<View<never>, never, R | Scope>` — fully
- *    discharged, nothing for a boundary to see.
- *  - **omit it** → the failure **rides the live channel**: the result is
+ *  - **function** — catch-all: every failure is handled here as a value (the
+ *    arm gets the full `Cause<E>`) and the result is
+ *    `Effect<View<never>, never, R | Scope>` — fully discharged, nothing for a
+ *    boundary to see.
+ *  - **tag map** — `failure: { NotFound: (e) => … }`: a matched tag is handled
+ *    here (the handler gets the unwrapped error) and the fetch loop STAYS
+ *    LIVE — a dep change still refetches, so the view can recover with no
+ *    boundary `reset`. The residual rides the live channel:
+ *    `Effect<View<Exclude<E, { _tag }>>, never, R | Scope>`. Dispatch is
+ *    `Catch`'s tag-map dispatch (first tagged error; own, function-valued
+ *    keys; a typo'd key mixed with ≥1 valid key is silently dead — its tag
+ *    stays on the channel, nothing is wrongly discharged). Handlers get no
+ *    retry callback yet (TODO; `Catch`'s `reset` is the boundary-side analog).
+ *  - **omitted** — the failure **rides the live channel**: the result is
  *    `Effect<View<E>, never, R | Scope>`, the failure (initial fetch *or* any
  *    refetch) routes to the nearest enclosing `Catch`, and `mount`'s
  *    `View<never>` gate makes a missing boundary a compile error naming `E`.
@@ -185,6 +227,19 @@ export function Async<A, E, R>(
   from: () => Effect.Effect<A, E, R>,
   arms: AsyncArmsHandled<A, E>,
 ): Effect.Effect<View, never, R | Scope.Scope>
+export function Async<
+  A,
+  E,
+  R,
+  Handlers extends {
+    readonly [K in TagsOf<E>]?: (
+      error: Extract<E, { readonly _tag: K }>,
+    ) => View | Effect.Effect<View, any, any>
+  },
+>(
+  from: () => Effect.Effect<A, E, R>,
+  arms: AsyncArmsBase<A> & { readonly failure: Handlers },
+): Effect.Effect<View<WithoutTag<E, keyof Handlers & string>>, never, R | Scope.Scope>
 export function Async<A, E, R>(
   from: () => Effect.Effect<A, E, R>,
   arms: AsyncArmsOpen<A>,
@@ -192,7 +247,9 @@ export function Async<A, E, R>(
 export function Async<A, E, R>(
   from: () => Effect.Effect<A, E, R>,
   arms: AsyncArmsBase<A> & {
-    readonly failure?: (cause: Cause.Cause<E>) => View | Effect.Effect<View, any, any>
+    readonly failure?:
+      | ((cause: Cause.Cause<E>) => View | Effect.Effect<View, any, any>)
+      | Record<string, (error: any) => View | Effect.Effect<View, any, any>>
   },
 ): Effect.Effect<View<E>, never, R | Scope.Scope> {
   return asyncRef(from).pipe(
@@ -201,13 +258,22 @@ export function Async<A, E, R>(
         source: state.map((r) =>
           AsyncResult.match(r, {
             onInitial: () => arms.initial ?? null,
-            // No failure arm: emit the cause as a failing Effect. The Reactive
-            // render path (`coerceSync`) runs it, routes the cause to the
-            // subtree's error sink — the nearest `Catch`'s `report` — and
-            // renders nothing. The interrupt-only guard already ran in
-            // `asyncRef` (teardown never reaches the Failure state).
-            onFailure: (f) =>
-              arms.failure ? arms.failure(f.cause) : Effect.failCause(f.cause),
+            // Function arm: catch-all, renders the full Cause. Tag map: a
+            // matched tag renders locally — the asyncRef stays live, so a dep
+            // change still refetches and can recover. Unmatched/absent: emit
+            // the cause as a failing Effect; the Reactive render path
+            // (`coerceSync`) runs it, routes the cause to the subtree's error
+            // sink — the nearest `Catch`'s `report` — and renders nothing. The
+            // interrupt-only guard already ran in `asyncRef` (teardown never
+            // reaches the Failure state).
+            onFailure: (f) => {
+              const { failure } = arms
+              if (typeof failure === "function") return failure(f.cause)
+              const handler = failure === undefined ? undefined : taggedHandlerFor(failure, f.cause)
+              return handler !== undefined
+                ? handler(Option.getOrUndefined(Cause.findErrorOption(f.cause)))
+                : Effect.failCause(f.cause)
+            },
             onSuccess: (s) => arms.success(s.value),
           }),
         ) as AtomRef.ReadonlyRef<unknown>,
@@ -217,18 +283,6 @@ export function Async<A, E, R>(
 }
 
 // ─── Error boundary (Catch) ────────────────
-
-type Tagged = { readonly _tag: string }
-type TagsOf<E> = E extends Tagged ? E["_tag"] : never
-type WithoutTag<E, Tag extends string> = Exclude<E, { readonly _tag: Tag }>
-
-/** The `_tag` of a cause's first error, if it's a tagged error. */
-const errorTagOf = (cause: Cause.Cause<unknown>): string | undefined => {
-  const err = Option.getOrUndefined(Cause.findErrorOption(cause))
-  return typeof err === "object" && err !== null && "_tag" in err
-    ? (err as Tagged)._tag
-    : undefined
-}
 
 /**
  * Shared boundary machinery for `Catch` (both forms). `accepts`
@@ -424,20 +478,12 @@ export function Catch(
     return makeBoundary(child, () => true, handlerOrMap)
   }
   const handlers = handlerOrMap
-  // `accepts` checks for an OWN function-valued handler (not a prototype-chain hit,
-  // not an explicit `undefined` slot). `accepts` dispatches on the FIRST tagged
-  // error of the cause (`Cause.findErrorOption`); the design assumes a single
-  // tagged failure per cause — a multi-tagged cause routes on its first error.
-  const handlerFor = (cause: Cause.Cause<unknown>): ((e: any, r: () => void) => unknown) | undefined => {
-    const t = errorTagOf(cause)
-    if (t === undefined || !Object.hasOwn(handlers, t)) return undefined
-    const fn = handlers[t]
-    return typeof fn === "function" ? fn : undefined
-  }
+  // Dispatch rules (own function-valued key, first tagged error) live in
+  // `taggedHandlerFor`, shared with Async's tag-map `failure` arm.
   return makeBoundary(
     child,
-    (cause) => handlerFor(cause) !== undefined,
-    (cause, reset) => handlerFor(cause)!(Option.getOrUndefined(Cause.findErrorOption(cause)), reset),
+    (cause) => taggedHandlerFor(handlers, cause) !== undefined,
+    (cause, reset) => taggedHandlerFor(handlers, cause)!(Option.getOrUndefined(Cause.findErrorOption(cause)), reset),
   )
 }
 

--- a/packages/core/src/testing/async-tagmap.test.ts
+++ b/packages/core/src/testing/async-tagmap.test.ts
@@ -98,6 +98,28 @@ describe("Async tag-map failure arm", () => {
     await ui.unmount()
   })
 
+  it("a nullish failure arm smuggled past the types degrades to the open form, not a crash", async () => {
+    // Regression pin: the impl guards with truthiness, so `failure: null`
+    // (reachable only via JS or a cast) behaves like the omitted arm —
+    // the cause rides to the boundary instead of throwing in Object.hasOwn.
+    const NullPage = Effect.fn(function* () {
+      const client = yield* Users
+      return yield* Catch(
+        h("section", {},
+          Async(() => client.get("999"), {
+            success: (n) => h("span", { class: "ok" }, n),
+            failure: null as never,
+          }),
+        ),
+        () => h("div", { class: "fallback" }, "caught"),
+      )
+    })()
+    const ui = await render(NullPage, UsersLive)
+    await ui.waitFor(".fallback")
+    expect(ui.query(".ok")).toBeNull()
+    await ui.unmount()
+  })
+
   it("types: matched tags are excluded from the live channel", () => {
     // Compile-time pin, kept next to the runtime proof: a partial tag map
     // narrows by Exclude; a full map discharges to View<never>.

--- a/packages/core/src/testing/async-tagmap.test.ts
+++ b/packages/core/src/testing/async-tagmap.test.ts
@@ -1,0 +1,120 @@
+// @vitest-environment happy-dom
+/**
+ * Async with a tag-map `failure` arm — `failure: { Tag: handler }`. A matched
+ * tag renders locally while the asyncRef STAYS LIVE: a dep change still
+ * refetches, so the view recovers with no boundary `reset` — the semantic a
+ * leaf `Catch` can't express (an accepted failure swaps the subtree and closes
+ * its build scope, tearing down the supervisor). An unmatched tag rides the
+ * live channel to the nearest `Catch`, exactly like the open form
+ * (async-escalate.test.ts).
+ */
+import { describe, it, expect } from "vitest"
+import { Context, Effect, Layer, type Scope } from "effect"
+import { AtomRef } from "effect/unstable/reactivity"
+import { Async, Catch, h, type View } from "@verrex/core"
+import { render } from "./index.ts"
+
+class Users extends Context.Service<Users, {
+  readonly get: (id: string) => Effect.Effect<string, NotFound | Timeout>
+}>()("tagmap/Users") {}
+class NotFound {
+  readonly _tag = "NotFound"
+  constructor(readonly id: string) {}
+}
+class Timeout {
+  readonly _tag = "Timeout"
+}
+const db: Record<string, string> = { "42": "Ada", "7": "Grace" }
+const UsersLive = Layer.succeed(Users, {
+  get: (id) =>
+    id === "slow"
+      ? Effect.fail(new Timeout())
+      : db[id]
+        ? Effect.succeed(db[id])
+        : Effect.fail(new NotFound(id)),
+})
+const read = (h as unknown as { read: (r: unknown) => string }).read
+
+// NotFound is handled at the leaf; Timeout is not — it escalates to the
+// page-level catch-all.
+const Page = (userId: AtomRef.AtomRef<string>) =>
+  Effect.fn(function* () {
+    const client = yield* Users
+    return yield* h("div", { class: "page" },
+      yield* Catch(
+        h("section", { class: "content" },
+          Async(() => client.get(read(userId)), {
+            initial: h("span", { class: "loading" }, "…"),
+            success: (n) => h("span", { class: "ok" }, n),
+            failure: {
+              NotFound: (e) => h("span", { class: "missing" }, `no user ${e.id}`),
+            },
+          }),
+        ),
+        (_cause, reset) =>
+          h("div", { class: "fallback" },
+            h("button", { class: "retry", onclick: reset }, "retry"),
+          ),
+      ),
+    )
+  })()
+
+describe("Async tag-map failure arm", () => {
+  it("renders a matched tag's handler in place (unwrapped error), boundary untouched", async () => {
+    const ui = await render(Page(AtomRef.make("999")), UsersLive)
+    expect((await ui.waitFor(".missing")).textContent?.trim()).toBe("no user 999")
+    expect(ui.query(".fallback")).toBeNull()
+    expect(ui.query(".content")).not.toBeNull()
+    await ui.unmount()
+  })
+
+  it("matched failure keeps the fetch loop live: a dep change refetches and recovers, no reset", async () => {
+    const userId = AtomRef.make("999")
+    const ui = await render(Page(userId), UsersLive)
+    await ui.waitFor(".missing")
+    userId.set("42") // fix the input — the tracked thunk re-runs by itself
+    expect((await ui.waitFor(".ok")).textContent?.trim()).toBe("Ada")
+    expect(ui.query(".missing")).toBeNull()
+    expect(ui.query(".fallback")).toBeNull()
+    await ui.unmount()
+  })
+
+  it("a REFETCH failure after success renders the matched handler in place", async () => {
+    const userId = AtomRef.make("42")
+    const ui = await render(Page(userId), UsersLive)
+    expect((await ui.waitFor(".ok")).textContent?.trim()).toBe("Ada")
+    userId.set("999")
+    await ui.waitFor(".missing")
+    expect(ui.query(".ok")).toBeNull()
+    expect(ui.query(".fallback")).toBeNull()
+    await ui.unmount()
+  })
+
+  it("an UNMATCHED tag escalates to the nearest Catch, like the open form", async () => {
+    const ui = await render(Page(AtomRef.make("slow")), UsersLive)
+    await ui.waitFor(".fallback")
+    expect(ui.query(".missing")).toBeNull()
+    expect(ui.query(".content")).toBeNull()
+    await ui.unmount()
+  })
+
+  it("types: matched tags are excluded from the live channel", () => {
+    // Compile-time pin, kept next to the runtime proof: a partial tag map
+    // narrows by Exclude; a full map discharges to View<never>.
+    const partial = (get: (id: string) => Effect.Effect<string, NotFound | Timeout>) =>
+      Async(() => get("42"), {
+        success: (n) => h("span", {}, n),
+        failure: { NotFound: (e) => h("span", {}, e.id) },
+      }) satisfies Effect.Effect<View<Timeout>, never, Scope.Scope>
+    const full = (get: (id: string) => Effect.Effect<string, NotFound | Timeout>) =>
+      Async(() => get("42"), {
+        success: (n) => h("span", {}, n),
+        failure: {
+          NotFound: (e) => h("span", {}, e.id),
+          Timeout: () => h("span", {}, "slow"),
+        },
+      }) satisfies Effect.Effect<View, never, Scope.Scope>
+    expect(typeof partial).toBe("function")
+    expect(typeof full).toBe("function")
+  })
+})


### PR DESCRIPTION
Closes the leaf-side half of the tag-selective convention started by #86.

## What

`Async`'s `failure` arm now picks the error's home in **three** forms, completing the framework-wide convention — *function = catch-all over `Cause`, object = tag-selective with the residual riding onward* — so the convention means the same thing at both error homes (leaf and boundary):

- **function** → catch-all, handled at the leaf: `Effect<View<never>, never, R | Scope>` (unchanged)
- **tag map** → `failure: { NotFound: (e) => … }`: matched tags render locally and the residual rides the live channel: `Effect<View<Exclude<E, { _tag }>>, never, R | Scope>`. A tag map on an `E` with **no tagged members is a compile error** (the overload's constraint collapses to `never`, not the accept-anything empty mapped type).
- **omitted** → open form, `E` rides `View<E>` to the nearest `Catch` (unchanged, from #86)

## Why this isn't sugar for `Catch(Async(open), tagMap)`

Same type, different runtime semantics: a leaf `Catch` that accepts a failure swaps the subtree and closes its build scope — tearing down the `asyncRef` supervisor, so auto-refetch is dead until `reset`. With the tag-map **arm**, the fetch loop stays live: a dep change refetches and the view recovers with no boundary involved. Pinned by the recover-without-reset test.

## How

- One shared `TagHandlers<E, Extra>` mapped type backs both tag-map surfaces (Catch instantiates `Extra = [reset: () => void]`), so the exactness/inference trade-offs — and the future retry param — live in one place.
- One shared dispatcher, `taggedMatch(handlers, cause)`, returns the matched `{ handler, error }` pair from a single cause walk: dispatch tag and handler argument can't drift, and the two surfaces can't diverge. Dispatch is on the cause's **first error, when tagged** (own, function-valued keys; the design assumes a single failure per cause).
- An unmatched tag reuses the open-form emission (`Effect.failCause` → sink) — no new runtime machinery.
- A nullish `failure` smuggled past the types degrades to the open form (truthiness guard), never a mid-render `Object.hasOwn` TypeError.
- Caveats inherited from Catch by design: a typo'd key beside ≥1 valid key is a dead handler (its tag stays on the channel; for inline literals the type never lies — a lone typo'd key is a compile error). Known type/runtime gaps for non-literal maps are tracked in #91, not silently shipped as claims.

## Follow-ups (filed, deliberately out of scope)

- [ ] #72-adjacent retry callback param for `failure` handlers (catch-all + tag-map) — the leaf-side analog of `Catch`'s `reset`; now a one-place change via `TagHandlers`.
- [ ] #91 — keyof-based discharge vs own-function-valued runtime dispatch (pre-built/widened maps, prototype-keyed objects, `undefined` slots without `exactOptionalPropertyTypes`); pre-existing in Catch, shared decision for both surfaces.
- [ ] #92 — replace local `TagsOf`/`WithoutTag` with effect's identical `Types.Tags`/`ExcludeTag`.

## Tests

- `testing/async-tagmap.test.ts` (6) — matched tag renders in place (unwrapped error); **recovers on dep change without reset**; refetch failure after success renders the arm; unmatched tag escalates to the nearest `Catch`; nullish-arm degradation; narrowing satisfies-pins
- `channels.test-d.ts` — `Exclude` narrowing, typo'd-key rejection, **untagged-`E` tag-map rejection**, mount gate naming the residual, full-map discharge
- `pnpm -r test` + `pnpm -r typecheck` green; CI green

## Review

A 7-angle / 10-finding review ran against this branch (transcript in session); everything introduced by this PR was fixed in `1be0aac`, pre-existing findings became #91/#92.
