### PR TITLE
fix(runtime): reject undispatched tag-map shapes at construction

### DIFF
--- a/packages/core/src/runtime/AGENTS.md
+++ b/packages/core/src/runtime/AGENTS.md
@@ -213,10 +213,15 @@ mirroring `Catch`'s function-vs-object convention:
   dead (its tag stays on the channel — for *inline literals* the type never
   lies; a typo as the only key is a compile error), and a tag map on an `E`
   with no tagged members is rejected outright (the overload's constraint
-  collapses to `never`, not the accept-anything empty mapped type). Known
-  type/runtime gaps — pre-built/widened maps, prototype-keyed objects,
-  explicit-`undefined` slots without `exactOptionalPropertyTypes` — can
-  over-discharge and are tracked in #91; both tag-map surfaces share them.
+  collapses to `never`, not the accept-anything empty mapped type). The two
+  runtime-detectable type/runtime gaps — prototype-keyed handler objects and
+  non-function slots (compilable without `exactOptionalPropertyTypes`) — are
+  rejected at the `Async()`/`Catch()` call site by `assertHandlerMap`
+  (TypeError naming the surface and key; pinned by
+  `testing/tagmap-validation.test.ts`). The remaining gap — a pre-built map
+  whose *type* declares keys the value doesn't carry — is invisible at
+  runtime (erasure) and stays a documented limitation (#91): prefer inline
+  handler literals.
   The handler-map shape itself is the shared `TagHandlers<E, Extra>` alias
   (Catch instantiates `Extra = [reset]`), so the planned Async retry callback
   (TODO — `Catch`'s `reset` is the boundary-side analog) is a one-place

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -143,9 +143,10 @@ type Tagged = { readonly _tag: string }
  * inference, and the exactness guard is omitted on purpose — a typo'd key
  * beside ≥1 valid key is silently dead (its tag stays on the channel, so the
  * type never lies for inline literals), while a typo as the only key is a
- * compile error. Pre-built/widened maps, prototype-keyed objects, and (for
- * consumers without `exactOptionalPropertyTypes`) explicit-`undefined` slots
- * can over-discharge — the type/runtime gap is tracked in #91.
+ * compile error. Prototype-keyed objects and explicit-`undefined` slots are
+ * rejected at construction by `assertHandlerMap`; pre-built maps whose TYPE
+ * declares keys the value doesn't carry can still over-discharge — invisible
+ * at runtime (erasure), documented limitation (#91).
  */
 type TagHandlers<E, Extra extends ReadonlyArray<unknown> = []> = {
   readonly [K in Types.Tags<E>]?: (
@@ -155,9 +156,37 @@ type TagHandlers<E, Extra extends ReadonlyArray<unknown> = []> = {
 }
 
 /**
+ * Construction-time guard for tag-map handler objects (#91): the type level
+ * discharges every `keyof Handlers`, but dispatch only honors OWN,
+ * function-valued keys — so reject, loudly and at the call site, the two
+ * shapes that would silently over-discharge: prototype-keyed objects (class
+ * instances, whose methods never dispatch) and non-function slots
+ * (`Tag: undefined`, which compiles for consumers without
+ * `exactOptionalPropertyTypes`). The third gap — pre-built maps whose TYPE
+ * declares keys the value doesn't carry — is invisible at runtime (erasure)
+ * and stays a documented limitation.
+ */
+const assertHandlerMap = (handlers: Record<string, unknown>, surface: string): void => {
+  const proto = Object.getPrototypeOf(handlers)
+  if (proto !== Object.prototype && proto !== null) {
+    throw new TypeError(
+      `${surface}: a tag-map of handlers must be a plain object — handlers on a prototype (class instance) never dispatch (#91)`,
+    )
+  }
+  for (const key of Object.keys(handlers)) {
+    if (typeof handlers[key] !== "function") {
+      throw new TypeError(
+        `${surface}: tag-map handler "${key}" is not a function — its tag was discharged from the type but would never dispatch (#91)`,
+      )
+    }
+  }
+}
+
+/**
  * The handler matching the cause's first error, when that error is tagged and
- * `handlers` carries an OWN, function-valued key for it (not a prototype-chain
- * hit, not an explicit `undefined` slot — the gaps this leaves are #91).
+ * `handlers` carries an OWN, function-valued key for it (non-plain maps and
+ * non-function slots are rejected up front by `assertHandlerMap`; the
+ * remaining erasure gap is #91).
  * Dispatch is on the cause's FIRST error — if it is untagged, no handler
  * matches even when a later error's tag is mapped; the design assumes a single
  * failure per cause. Returns the handler together with the error it matched
@@ -270,6 +299,10 @@ export function Async<A, E, R>(
       | Record<string, unknown>
   },
 ): Effect.Effect<View<E>, never, R | Scope.Scope> {
+  const { failure } = arms
+  // Fail fast at the call site: a tag map that can't dispatch is a
+  // programming error, not a renderable failure.
+  if (failure && typeof failure === "object") assertHandlerMap(failure, "Async")
   return asyncRef(from).pipe(
     Effect.map((state) =>
       View.Reactive({
@@ -285,7 +318,6 @@ export function Async<A, E, R>(
             // interrupt-only guard already ran in `asyncRef` (teardown never
             // reaches the Failure state).
             onFailure: (f) => {
-              const { failure } = arms
               if (typeof failure === "function") return failure(f.cause)
               // Truthiness (not === undefined): a nullish `failure` smuggled
               // past the types degrades to the open form instead of crashing
@@ -492,6 +524,7 @@ export function Catch(
     return makeBoundary(child, () => true, handlerOrMap)
   }
   const handlers = handlerOrMap
+  assertHandlerMap(handlers, "Catch")
   // Dispatch rules (own function-valued key, first-error routing) live in
   // `taggedMatch`, shared with Async's tag-map `failure` arm.
   return makeBoundary(

--- a/packages/core/src/testing/tagmap-validation.test.ts
+++ b/packages/core/src/testing/tagmap-validation.test.ts
@@ -1,0 +1,76 @@
+// @vitest-environment happy-dom
+/**
+ * Construction-time validation of tag-map handler objects (#91). The type
+ * level discharges every `keyof Handlers` but dispatch honors only OWN,
+ * function-valued keys — `assertHandlerMap` turns the two runtime-detectable
+ * mismatches (prototype-keyed objects, non-function slots) into a TypeError
+ * at the `Async()`/`Catch()` call site instead of a silently-dead handler.
+ * (The third gap — a pre-built map whose TYPE declares keys the value doesn't
+ * carry — is invisible at runtime and stays documented in #91.)
+ */
+import { describe, it, expect } from "vitest"
+import { Effect } from "effect"
+import { Async, Catch, h } from "@verrex/core"
+
+class NotFound {
+  readonly _tag = "NotFound"
+  constructor(readonly id: string) {}
+}
+class Timeout {
+  readonly _tag = "Timeout"
+}
+const get = (): Effect.Effect<string, NotFound | Timeout> => Effect.fail(new NotFound("x"))
+const child = h("div", {}, Async(get, { success: (n) => h("span", {}, n) }))
+
+// Satisfies TagHandlers at the type level (methods match the constraint), but
+// the handlers live on the prototype — exactly the shape that never dispatches.
+class ProtoHandlers {
+  NotFound(e: NotFound) {
+    return h("p", {}, e.id)
+  }
+}
+
+describe("tag-map construction validation (#91)", () => {
+  it("Async rejects a prototype-keyed handler object at the call site", () => {
+    expect(() =>
+      Async(get, { success: (n) => h("span", {}, n), failure: new ProtoHandlers() }),
+    ).toThrow(/Async: a tag-map of handlers must be a plain object/)
+  })
+
+  it("Async rejects a non-function handler slot, naming the key", () => {
+    // `Timeout: undefined` is a compile error in-repo (exactOptionalPropertyTypes)
+    // but compiles for default-tsconfig consumers — simulate them with a cast.
+    expect(() =>
+      Async(get, {
+        success: (n) => h("span", {}, n),
+        failure: { NotFound: (e: NotFound) => h("p", {}, e.id), Timeout: undefined } as never,
+      }),
+    ).toThrow(/Async: tag-map handler "Timeout" is not a function/)
+  })
+
+  it("Catch rejects a prototype-keyed handler object at the call site", () => {
+    expect(() => Catch(child, new ProtoHandlers())).toThrow(
+      /Catch: a tag-map of handlers must be a plain object/,
+    )
+  })
+
+  it("Catch rejects a non-function handler slot, naming the key", () => {
+    expect(() =>
+      Catch(child, { NotFound: (e: NotFound) => h("p", {}, e.id), Timeout: undefined } as never),
+    ).toThrow(/Catch: tag-map handler "Timeout" is not a function/)
+  })
+
+  it("plain literals (including empty and null-prototype maps) still construct", () => {
+    expect(() =>
+      Async(get, {
+        success: (n) => h("span", {}, n),
+        failure: { NotFound: (e) => h("p", {}, e.id) },
+      }),
+    ).not.toThrow()
+    expect(() => Catch(child, {})).not.toThrow()
+    const bare = Object.assign(Object.create(null), {
+      NotFound: (e: NotFound) => h("p", {}, e.id),
+    })
+    expect(() => Catch(child, bare as never)).not.toThrow()
+  })
+})


### PR DESCRIPTION
Closes #91. **Stacked on #93** — merge that first; this PR then retargets to main automatically.

The decision from #91, applied to both tag-map surfaces: the type level discharges every `keyof Handlers`, but dispatch honors only OWN, function-valued keys. `assertHandlerMap` now turns the two runtime-detectable mismatches into a **TypeError at the `Async()`/`Catch()` call site**, naming the surface and key:

- prototype-keyed handler objects (class instances — methods never dispatch)
- non-function slots (`Tag: undefined`, which compiles for consumers without `exactOptionalPropertyTypes`; our own eOPT repo can't reproduce it, so the test simulates with a cast)

The third gap — a pre-built map whose *type* declares keys the value doesn't carry — is invisible at runtime (erasure) and stays a **documented limitation**: prefer inline handler literals. Docs updated accordingly (runtime AGENTS.md, `TagHandlers`/`taggedMatch` JSDoc).

Plain literals, `{}`, and null-prototype maps still construct (pinned). `testing/tagmap-validation.test.ts` covers all five cases; `pnpm -r test` + `typecheck` green.