### PR TITLE
feat(check): --watch, severity flags, colored summary (astro-check parity)

### DIFF
--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "typecheck": "node --experimental-strip-types ../../packages/core/src/check/cli.ts"
+    "typecheck": "node --experimental-strip-types ../../packages/core/src/check/cli.ts",
+    "typecheck:watch": "node --experimental-strip-types ../../packages/core/src/check/cli.ts --watch"
   },
   "dependencies": {
     "@verrex/core": "workspace:*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,6 +22,9 @@
   ],
   "type": "module",
   "sideEffects": false,
+  "engines": {
+    "node": ">=20.19.0"
+  },
   "exports": {
     ".": {
       "types": "./src/runtime/index.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -97,15 +97,16 @@
     "test": "vitest run && node --experimental-strip-types test/check/integration.mjs"
   },
   "dependencies": {
+    "@babel/generator": "^7.29.7",
     "@babel/parser": "^7.29.7",
     "@babel/traverse": "^7.29.7",
-    "@babel/generator": "^7.29.7",
     "@babel/types": "^7.29.7",
     "@jridgewell/sourcemap-codec": "^1.5.5",
-    "@volar/language-core": "^2.4.28",
-    "@volar/source-map": "^2.4.28",
     "@volar/kit": "^2.4.28",
+    "@volar/language-core": "^2.4.28",
     "@volar/language-service": "^2.4.28",
+    "@volar/source-map": "^2.4.28",
+    "chokidar": "^5.0.0",
     "volar-service-typescript": "^0.0.71",
     "vscode-uri": "^3.1.0"
   },
@@ -123,10 +124,10 @@
     }
   },
   "devDependencies": {
-    "effect": "4.0.0-beta.78",
     "@effect/vitest": "4.0.0-beta.78",
     "@types/babel__generator": "^7",
     "@types/babel__traverse": "^7",
+    "effect": "4.0.0-beta.78",
     "happy-dom": "^20.10.2",
     "typescript": "^6.0.3",
     "vite": "^8.0.16",

--- a/packages/core/src/check/AGENTS.md
+++ b/packages/core/src/check/AGENTS.md
@@ -12,9 +12,9 @@ Used in `apps/demo`'s `typecheck` script. Modeled on Astro's
 
 | File | Purpose |
 |---|---|
-| `index.ts` | Programmatic API: `runCheck(options) → CheckResult`. Wires the language plugin + `volar-service-typescript` into a kit `TypeScriptChecker`, iterates root files, prints diagnostics. |
-| `cli.ts` | CLI entry. Minimal argv parser (`--tsconfig`, `--root`, `--help`), calls `runCheck`, prints summary, exits 0/1. |
-| `../../test/check/integration.mjs` | Smoke test: known-good fixture → 0 errors; inject broken `.vx` → expect TS2322 with `.vx` source position; cleanup → 0 errors again. |
+| `index.ts` | Programmatic API: `createChecker(options) → VerrexChecker` (persistent, file-event-driven — what `--watch` runs on), `runCheck(options) → CheckResult` (one-shot), `shouldFail(result, severity)` (exit-code policy). Wires the language plugin + `volar-service-typescript` into a kit `TypeScriptChecker`, iterates root files, prints diagnostics at or above `minimumSeverity`. |
+| `cli.ts` | CLI entry. Minimal argv parser (`--tsconfig`, `--root`, `--watch`, `--minimumSeverity`, `--minimumFailingSeverity`, `--preserveWatchOutput`, `--help`), colored summary line, chokidar wiring for watch mode, exits 0/1/2. |
+| `../../test/check/integration.mjs` | Smoke test: known-good fixture → 0 errors; inject broken `.vx` → expect TS2322 with `.vx` source position; cleanup → 0 errors again. Plus: persistent `createChecker` driven by file events (the watch loop's contract), `minimumSeverity` print filtering on a hint-severity suggestion, `shouldFail` threshold cascade. |
 | `../../test/check/fixture/` | Minimal `.vx` project (tsconfig + `Good.vx`) used by the smoke test. Self-contained, no cross-file imports — keep it that way. |
 
 ## Invocation
@@ -22,9 +22,18 @@ Used in `apps/demo`'s `typecheck` script. Modeled on Astro's
 Programmatic:
 
 ```ts
-import { runCheck } from "@verrex/core/check"
+import { createChecker, runCheck, shouldFail } from "@verrex/core/check"
+
 const result = await runCheck({ cwd: "/path/to/project" })
-// result: { filesChecked: number, errors: number, warnings: number }
+// result: { filesChecked: number, errors: number, warnings: number, hints: number }
+process.exitCode = shouldFail(result, "warning") ? 1 : 0
+
+// Persistent (what --watch uses): one ts.LanguageService across runs,
+// file events drive incremental re-checks.
+const checker = createChecker({ cwd: "/path/to/project", minimumSeverity: "hint" })
+await checker.check()
+checker.fileUpdated("/path/to/project/src/Foo.vx") // after an edit
+await checker.check({ cancel: () => superseded })  // polled between files
 ```
 
 CLI:
@@ -33,6 +42,9 @@ CLI:
 verrex-check                       # tsconfig auto-discovered from cwd
 verrex-check --tsconfig path/tsconfig.json
 verrex-check --root /some/project  # cwd override
+verrex-check --watch               # incremental re-check on .vx/.ts change
+verrex-check --minimumSeverity hint            # print hints + warnings too
+verrex-check --minimumFailingSeverity warning  # exit 1 on warnings as well
 ```
 
 In `apps/demo` the script wires it via `node --experimental-strip-types`
@@ -60,23 +72,54 @@ LSP protocol.
   glob produces, expanded with `extraFileExtensions` (`.vx`
   recognized) — for the demo, its `.vx` sources plus its hand-written
   `.ts` (`channels.test-d.ts`, `flash.ts`, `highlight.ts`, `services.ts`).
-- **Diagnostics printed**: errors only by default (matching the
-  bare `tsc --noEmit` flow we replaced). Warnings and hints are
-  counted in `CheckResult` but not printed — `volar-service-typescript`
-  surfaces unused-import suggestions as warnings, and we don't
-  want to drown the output with them. Add a `--minimumSeverity`
-  flag when the astro-parity TODO ticket comes up.
-- **Exit code**: 0 if `result.errors === 0`, else 1. Warnings do
-  not fail. (`tsc` matches: warnings only fail with `noEmitOnError`
-  or `strict` flags that promote them.)
+- **Diagnostics printed**: controlled by `--minimumSeverity`
+  (`error` | `warning` | `hint`, each level including the ones before
+  it). Default `error` — the bare invocation stays a drop-in for the
+  `tsc --noEmit` flow we replaced. This is a *deliberate divergence*
+  from `astro check` (which defaults to `hint`): the flag semantics
+  match astro, only the default differs. Severities below the
+  threshold are still *counted* in `CheckResult` —
+  `volar-service-typescript` maps TS suggestions (e.g. TS6133 unused
+  locals) to **hint** severity (LSP 4), so they land in
+  `CheckResult.hints`.
+- **Exit code**: controlled by `--minimumFailingSeverity`
+  (default `error`), astro semantics: each threshold also fails on
+  everything more severe. Printing and failing are independent — you
+  can print hints without failing on them and vice versa. Usage
+  errors exit 2.
+- **Watch mode** (`--watch`/`-w`): one `createChecker` instance for
+  the process lifetime; chokidar watches the root (ignoring
+  `node_modules`/`.git`, filtering to the extensions the resolved
+  root files actually use) and feeds
+  `fileCreated`/`fileUpdated`/`fileDeleted`. Re-checks are debounced
+  100ms; a superseded pass cancels between files. The screen is
+  cleared between passes unless `--preserveWatchOutput`. Watch mode
+  never exits non-zero on diagnostics.
+  **Upstream caveat:** `fileUpdated` (every save — the hot path) is
+  incremental via kit's project-version bump, but kit's root-file
+  re-expansion is broken (`getScriptFileNames` caches resolved names
+  in a WeakMap keyed by a `ParsedCommandLine` it mutates in place —
+  `@volar/kit` ≤ 2.4.28 and volar main), so `fileCreated`/`fileDeleted`
+  rebuild the kit checker instead. If a kit release fixes that cache,
+  the rebuild in `createChecker` can go back to forwarding the events.
+- **Colors**: the summary line and watch status color only when
+  stdout is a TTY and `NO_COLOR` is unset. Per-diagnostic output is
+  colored upstream by `ts.formatDiagnosticsWithColorAndContext`
+  unconditionally (kit behavior, pre-existing).
 - **In-process isolation**: each `runCheck` call builds its own
   `@volar/kit` checker, which owns the virtual-code lifetime for that
   call. Two calls in the same Node process — e.g. a test that
   exercises the fixture, mutates it, then re-runs — see independent
   virtual-code state, not leftovers from the previous invocation.
-  This package holds no virtual-code cache of its own: it only
-  *writes* (compiles) `.vx` files through the LanguagePlugin and
-  never reads them back, so there is nothing here to share or leak.
+  `createChecker` is the deliberate exception: it keeps one checker
+  alive so a watch loop pays incremental cost, and *requires* file
+  events to observe disk changes (kit snapshots are re-read only when
+  the project version bumps). This package holds no virtual-code
+  cache of its own: it only *writes* (compiles) `.vx` files through
+  the LanguagePlugin and never reads them back, so there is nothing
+  here to share or leak. (One kit-internal exception: a module-level
+  mtime-keyed snapshot cache, shared across checkers in a process —
+  invisible as long as edits actually change mtimes.)
 
 ## Coupling
 
@@ -90,21 +133,25 @@ LSP protocol.
 - **`volar-service-typescript`** — the LSP-style language service
   plugins kit needs to actually produce diagnostics. Without these,
   `linter.check(file)` returns nothing.
+- **`chokidar`** — filesystem watcher for `--watch`, imported lazily
+  so the one-shot path (CI) never loads it.
 
 ## Anti-patterns
 
-- Don't print warnings/hints by default. The replacement flow's
-  expected baseline output is "Checked N files: 0 errors" — adding
-  warning noise breaks the "drop-in for tsc --noEmit" promise.
-  Make it opt-in via a flag when you wire severity filtering.
-- Don't add a watch loop that polls. `@volar/kit` exposes
-  `fileCreated/Updated/Deleted` callbacks; combine them with
-  `chokidar` (like astro-check does) when watch mode is built.
-- Don't add `runCheck` overloads or option types that diverge from
-  Astro's `check()` API beyond what's necessary. The astro-parity
-  TODO list in `cli.ts` is the design intent — if you add a
-  flag here, mirror the Astro name and semantics so future code
-  ports cleanly.
+- Don't change `--minimumSeverity`'s default away from `error`. The
+  replacement flow's expected baseline output is "Checked N files:
+  0 errors" — printing warnings/hints by default breaks the
+  "drop-in for tsc --noEmit" promise. Opting in is one flag away.
+- Don't make the watch loop poll. It's file-event-driven (chokidar →
+  `fileCreated/Updated/Deleted`, like astro-check); the debounce in
+  `cli.ts` plus between-files cancellation is what keeps rapid saves
+  cheap. Don't "fix" `fileCreated`/`fileDeleted` back to forwarding
+  kit's events without checking the upstream WeakMap-cache bug is
+  actually fixed (see the watch-mode caveat above).
+- Don't add flags or option types that diverge from Astro's
+  `check()` API beyond what's necessary. If you add a flag here,
+  mirror the Astro name and semantics (`astro-check`'s `options.ts`
+  in `refs/astro-language-tools`) so future code ports cleanly.
 - Don't reintroduce on-disk sibling `.ts` files. The whole point
   of `@verrex/core/check` replacing the old `verrex-compile + tsc --noEmit`
   flow is that no auxiliary on-disk shim is needed — `.vx`

--- a/packages/core/src/check/AGENTS.md
+++ b/packages/core/src/check/AGENTS.md
@@ -34,6 +34,11 @@ const checker = createChecker({ cwd: "/path/to/project", minimumSeverity: "hint"
 await checker.check()
 checker.fileUpdated("/path/to/project/src/Foo.vx") // after an edit
 await checker.check({ cancel: () => superseded })  // polled between files
+
+// Watch-facing project topology (what cli.ts builds its watcher from):
+checker.getConfigFilePaths()     // tsconfig + extends chain
+checker.getWildcardDirectories() // dirs the include globs expand under
+checker.getTrackedFileNames()    // all program files seen so far (incl. imports)
 ```
 
 CLI:
@@ -88,31 +93,45 @@ LSP protocol.
   can print hints without failing on them and vice versa. Usage
   errors exit 2.
 - **Watch mode** (`--watch`/`-w`): one `createChecker` instance for
-  the process lifetime. chokidar watches the **tsconfig's directory**
-  (the anchor of its include globs — not the invocation cwd, which
-  can differ under `--tsconfig ../app/tsconfig.json`), ignoring
-  `node_modules`/`.git` by **whole path segment** (substring matching
-  would silently kill the watch for e.g. a `user.github.io` checkout),
-  admitting the full set of checkable extensions (the TS family plus
-  `.vx` — not just the extensions present at startup, so a project's
-  first `.tsx` still fires) plus the tsconfig itself (an edit to it
-  re-parses options and includes). Events feed
-  `fileCreated`/`fileUpdated`/`fileDeleted`; a watcher `error`
-  (EPERM dir, inotify ENOSPC) is reported on stderr and watching
-  continues. Re-checks are debounced 100ms; a superseded pass cancels
-  between files and never prints a stale file's diagnostics after its
-  await. The screen clear runs after the debounce (one per executed
-  pass), only on a TTY, and never under `--preserveWatchOutput`.
-  Watch mode never exits non-zero on diagnostics.
+  the process lifetime. chokidar covers **where the program actually
+  lives**, not the invocation cwd: the tsconfig's directory plus
+  every wildcard directory its include globs expand under (they can
+  sit outside it — `"include": ["../shared/**"]`), the config files
+  themselves including the `extends` chain (`tsconfig.base.json`
+  edits re-parse options), and — added file-by-file after each pass —
+  every tracked source the program imported from outside those trees
+  (workspace dependencies: editing `packages/core/src/*` re-checks
+  the demo, the way `tsc --watch` covers its program closure).
+  Ignores match `node_modules`/`.git` by **whole path segment**
+  (substring matching would silently kill the watch for e.g. a
+  `user.github.io` checkout) and admit the full set of checkable
+  extensions (the TS family plus `.vx` — not just the extensions
+  present at startup, so a project's first `.tsx` still fires).
+  Change/unlink events for files that were never part of the project
+  (build output) are skipped without a pass. A watcher `error`
+  (EPERM dir, inotify ENOSPC) and a **failing pass** (tsconfig
+  briefly missing mid-checkout, a transform crash on an
+  unrecoverable mid-edit file) are both reported on stderr and
+  watching continues — no unhandled rejection may escape `lint()`.
+  Re-checks are debounced 100ms; a superseded pass cancels between
+  files and never prints a stale file's diagnostics after its await.
+  The screen clear runs after the debounce, only on a TTY, only once
+  a previous pass has actually printed (ticket ordinality alone
+  would wipe scrollback at startup), and never under
+  `--preserveWatchOutput`. Watch mode never exits non-zero on
+  diagnostics.
   **Upstream caveat:** `fileUpdated` (every save — the hot path) is
   incremental via kit's project-version bump, but kit's root-file
   re-expansion is broken (`getScriptFileNames` caches resolved names
   in a WeakMap keyed by a `ParsedCommandLine` it mutates in place —
-  `@volar/kit` ≤ 2.4.28 and volar main), so create/delete/tsconfig
-  events mark the project stale and the kit checker is rebuilt
-  **lazily at the next `check()`/`getRootFileNames()`** — a burst of
-  N events costs one rebuild, not N. If a kit release fixes that
-  cache, the stale-flag rebuild can go back to forwarding the events.
+  `@volar/kit` ≤ 2.4.28 and volar main), so create/delete/config
+  events mark the project stale and the kit checker is **lazily**
+  re-evaluated at the next `check()`/`getRootFileNames()`: a cheap
+  config re-parse first, a full rebuild only when the root set or
+  options actually changed (build-output churn rebuilds nothing), a
+  parse failure keeps the staleness so the next flush retries. If a
+  kit release fixes that cache, this can go back to forwarding the
+  events.
 - **Colors**: the summary line, watch status, and screen clear only
   when stdout is a TTY (and, for color, `NO_COLOR` unset) — a pipe
   gets plain text and never the `\x1bc` reset. Per-diagnostic output
@@ -127,13 +146,15 @@ LSP protocol.
   virtual-code state, not leftovers from the previous invocation.
   `createChecker` is the deliberate exception: it keeps one checker
   alive so a watch loop pays incremental cost, and *requires* file
-  events to observe disk changes (kit snapshots are re-read only when
-  the project version bumps). This package holds no virtual-code
-  cache of its own: it only *writes* (compiles) `.vx` files through
-  the LanguagePlugin and never reads them back, so there is nothing
-  here to share or leak. (One kit-internal exception: a module-level
-  mtime-keyed snapshot cache, shared across checkers in a process —
-  invisible as long as edits actually change mtimes.)
+  events to observe disk changes — a snapshot is re-read only when
+  the project version bumps **and** kit's module-level mtime-keyed
+  cache sees a changed `getModifiedTime` (both gates must pass; an
+  edit that doesn't tick the mtime — coarse-granularity filesystems,
+  `cp -p`/`rsync -t` restores — is invisible until something else
+  changes it). This package holds no virtual-code cache of its own:
+  it only *writes* (compiles) `.vx` files through the LanguagePlugin
+  and never reads them back, so there is nothing here to share or
+  leak.
 
 ## Coupling
 

--- a/packages/core/src/check/AGENTS.md
+++ b/packages/core/src/check/AGENTS.md
@@ -13,7 +13,7 @@ Used in `apps/demo`'s `typecheck` script. Modeled on Astro's
 | File | Purpose |
 |---|---|
 | `index.ts` | Programmatic API: `createChecker(options) → VerrexChecker` (persistent, file-event-driven — what `--watch` runs on), `runCheck(options) → CheckResult` (one-shot), `shouldFail(result, severity)` (exit-code policy). Wires the language plugin + `volar-service-typescript` into a kit `TypeScriptChecker`, iterates root files, prints diagnostics at or above `minimumSeverity`. |
-| `cli.ts` | CLI entry. Minimal argv parser (`--tsconfig`, `--root`, `--watch`, `--minimumSeverity`, `--minimumFailingSeverity`, `--preserveWatchOutput`, `--help`), colored summary line, chokidar wiring for watch mode, exits 0/1/2. |
+| `cli.ts` | CLI entry. `node:util` `parseArgs` (`--tsconfig`, `--root`, `--watch`, `--minimumSeverity`, `--minimumFailingSeverity`, `--preserveWatchOutput`, `--help`; rejects unknown flags and missing/flag-like option values), colored summary line, chokidar wiring for watch mode, exits 0/1/2. |
 | `../../test/check/integration.mjs` | Smoke test: known-good fixture → 0 errors; inject broken `.vx` → expect TS2322 with `.vx` source position; cleanup → 0 errors again. Plus: persistent `createChecker` driven by file events (the watch loop's contract), `minimumSeverity` print filtering on a hint-severity suggestion, `shouldFail` threshold cascade. |
 | `../../test/check/fixture/` | Minimal `.vx` project (tsconfig + `Good.vx`) used by the smoke test. Self-contained, no cross-file imports — keep it that way. |
 
@@ -88,24 +88,38 @@ LSP protocol.
   can print hints without failing on them and vice versa. Usage
   errors exit 2.
 - **Watch mode** (`--watch`/`-w`): one `createChecker` instance for
-  the process lifetime; chokidar watches the root (ignoring
-  `node_modules`/`.git`, filtering to the extensions the resolved
-  root files actually use) and feeds
-  `fileCreated`/`fileUpdated`/`fileDeleted`. Re-checks are debounced
-  100ms; a superseded pass cancels between files. The screen is
-  cleared between passes unless `--preserveWatchOutput`. Watch mode
-  never exits non-zero on diagnostics.
+  the process lifetime. chokidar watches the **tsconfig's directory**
+  (the anchor of its include globs — not the invocation cwd, which
+  can differ under `--tsconfig ../app/tsconfig.json`), ignoring
+  `node_modules`/`.git` by **whole path segment** (substring matching
+  would silently kill the watch for e.g. a `user.github.io` checkout),
+  admitting the full set of checkable extensions (the TS family plus
+  `.vx` — not just the extensions present at startup, so a project's
+  first `.tsx` still fires) plus the tsconfig itself (an edit to it
+  re-parses options and includes). Events feed
+  `fileCreated`/`fileUpdated`/`fileDeleted`; a watcher `error`
+  (EPERM dir, inotify ENOSPC) is reported on stderr and watching
+  continues. Re-checks are debounced 100ms; a superseded pass cancels
+  between files and never prints a stale file's diagnostics after its
+  await. The screen clear runs after the debounce (one per executed
+  pass), only on a TTY, and never under `--preserveWatchOutput`.
+  Watch mode never exits non-zero on diagnostics.
   **Upstream caveat:** `fileUpdated` (every save — the hot path) is
   incremental via kit's project-version bump, but kit's root-file
   re-expansion is broken (`getScriptFileNames` caches resolved names
   in a WeakMap keyed by a `ParsedCommandLine` it mutates in place —
-  `@volar/kit` ≤ 2.4.28 and volar main), so `fileCreated`/`fileDeleted`
-  rebuild the kit checker instead. If a kit release fixes that cache,
-  the rebuild in `createChecker` can go back to forwarding the events.
-- **Colors**: the summary line and watch status color only when
-  stdout is a TTY and `NO_COLOR` is unset. Per-diagnostic output is
-  colored upstream by `ts.formatDiagnosticsWithColorAndContext`
-  unconditionally (kit behavior, pre-existing).
+  `@volar/kit` ≤ 2.4.28 and volar main), so create/delete/tsconfig
+  events mark the project stale and the kit checker is rebuilt
+  **lazily at the next `check()`/`getRootFileNames()`** — a burst of
+  N events costs one rebuild, not N. If a kit release fixes that
+  cache, the stale-flag rebuild can go back to forwarding the events.
+- **Colors**: the summary line, watch status, and screen clear only
+  when stdout is a TTY (and, for color, `NO_COLOR` unset) — a pipe
+  gets plain text and never the `\x1bc` reset. Per-diagnostic output
+  is colored upstream by `ts.formatDiagnosticsWithColorAndContext`
+  unconditionally (kit behavior, pre-existing). The one-shot path
+  awaits the final write's flush callback before `process.exit` so
+  piped output isn't truncated.
 - **In-process isolation**: each `runCheck` call builds its own
   `@volar/kit` checker, which owns the virtual-code lifetime for that
   call. Two calls in the same Node process — e.g. a test that
@@ -145,9 +159,11 @@ LSP protocol.
 - Don't make the watch loop poll. It's file-event-driven (chokidar →
   `fileCreated/Updated/Deleted`, like astro-check); the debounce in
   `cli.ts` plus between-files cancellation is what keeps rapid saves
-  cheap. Don't "fix" `fileCreated`/`fileDeleted` back to forwarding
-  kit's events without checking the upstream WeakMap-cache bug is
-  actually fixed (see the watch-mode caveat above).
+  cheap. Don't "fix" the stale-flag lazy rebuild back to forwarding
+  create/delete events to kit without checking the upstream
+  WeakMap-cache bug is actually fixed (see the watch-mode caveat
+  above) — and don't make the rebuild eager again: event bursts
+  (git checkout) must cost one rebuild, not N.
 - Don't add flags or option types that diverge from Astro's
   `check()` API beyond what's necessary. If you add a flag here,
   mirror the Astro name and semantics (`astro-check`'s `options.ts`

--- a/packages/core/src/check/cli.ts
+++ b/packages/core/src/check/cli.ts
@@ -5,30 +5,58 @@
  *   verrex-check                  # use tsconfig.json found from cwd
  *   verrex-check --tsconfig path  # explicit tsconfig.json
  *   verrex-check --root dir       # cwd override (resolved before --tsconfig)
+ *   verrex-check --watch          # incremental re-check on file change
  *
- * Exit code: 0 if no errors, 1 otherwise (warnings do not fail).
- *
- * Not yet implemented (astro-parity TODO):
- *   - --watch              chokidar-based incremental check loop
- *   - --minimumSeverity    filter what's printed
- *   - --minimumFailingSeverity  control which severity bumps exit code
- *   - colored output       kleur or similar
+ * Flag semantics follow `astro check` (the parity target), with one
+ * deliberate divergence: `--minimumSeverity` defaults to `error` (astro:
+ * `hint`) so the bare invocation stays a drop-in for `tsc --noEmit` —
+ * see the behavior contract in AGENTS.md.
  */
-import { runCheck } from "./index.ts"
+import * as path from "node:path"
+import { createChecker, runCheck, shouldFail, type CheckResult, type Severity } from "./index.ts"
+
+const SEVERITIES: ReadonlyArray<Severity> = ["error", "warning", "hint"]
 
 interface ParsedArgs {
   root: string | undefined
   tsconfig: string | undefined
+  watch: boolean
+  minimumSeverity: Severity
+  minimumFailingSeverity: Severity
+  preserveWatchOutput: boolean
 }
 
 function parseArgs(argv: ReadonlyArray<string>): ParsedArgs {
-  const out: ParsedArgs = { root: undefined, tsconfig: undefined }
+  const out: ParsedArgs = {
+    root: undefined,
+    tsconfig: undefined,
+    watch: false,
+    minimumSeverity: "error",
+    minimumFailingSeverity: "error",
+    preserveWatchOutput: false,
+  }
+  const severityValue = (flag: string, value: string | undefined): Severity => {
+    if (value !== undefined && (SEVERITIES as ReadonlyArray<string>).includes(value)) {
+      return value as Severity
+    }
+    console.error(`verrex-check: ${flag} expects one of: ${SEVERITIES.join(", ")}`)
+    printHelp()
+    process.exit(2)
+  }
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i]
     if (arg === "--tsconfig" || arg === "-p") {
       out.tsconfig = argv[++i]
     } else if (arg === "--root") {
       out.root = argv[++i]
+    } else if (arg === "--watch" || arg === "-w") {
+      out.watch = true
+    } else if (arg === "--minimumSeverity") {
+      out.minimumSeverity = severityValue(arg, argv[++i])
+    } else if (arg === "--minimumFailingSeverity") {
+      out.minimumFailingSeverity = severityValue(arg, argv[++i])
+    } else if (arg === "--preserveWatchOutput") {
+      out.preserveWatchOutput = true
     } else if (arg === "--help" || arg === "-h") {
       printHelp()
       process.exit(0)
@@ -45,31 +73,113 @@ function printHelp(): void {
   process.stdout.write(`verrex-check — type-check a verrex project via Volar
 
 Usage:
-  verrex-check [--tsconfig <path>] [--root <dir>]
+  verrex-check [--tsconfig <path>] [--root <dir>] [--watch] [severity flags]
 
 Options:
-  --tsconfig, -p <path>   Path to tsconfig.json (relative to --root or absolute)
-  --root <dir>            Project root (defaults to cwd)
-  --help, -h              Show this help
+  --tsconfig, -p <path>          Path to tsconfig.json (relative to --root or absolute)
+  --root <dir>                   Project root (defaults to cwd)
+  --watch, -w                    Re-check on .vx/.ts change without restarting
+  --minimumSeverity <s>          Minimum severity to print: error|warning|hint (default: error)
+  --minimumFailingSeverity <s>   Minimum severity that fails the exit code: error|warning|hint (default: error)
+  --preserveWatchOutput          Don't clear the screen between watch re-checks
+  --help, -h                     Show this help
 
 Exit codes:
-  0  no errors
-  1  errors found
+  0  nothing at or above --minimumFailingSeverity
+  1  failing diagnostics found
   2  usage error
 `)
 }
 
+// Color only when stdout is a TTY and the consumer hasn't opted out
+// (https://no-color.org). The per-diagnostic output is colored upstream by
+// ts.formatDiagnosticsWithColorAndContext; this gates our summary lines.
+const useColor = process.stdout.isTTY === true && process.env.NO_COLOR === undefined
+const paint = (open: number, close: number) => (s: string) =>
+  useColor ? `\x1b[${open}m${s}\x1b[${close}m` : s
+const bold = paint(1, 22)
+const dim = paint(2, 22)
+const red = paint(31, 39)
+const yellow = paint(33, 39)
+
+function printSummary(result: CheckResult, minimumSeverity: Severity): void {
+  const plural = (n: number, word: string) => `${n} ${word}${n === 1 ? "" : "s"}`
+  const parts = [
+    result.errors > 0 ? bold(red(plural(result.errors, "error"))) : dim("0 errors"),
+  ]
+  if (minimumSeverity === "warning" || minimumSeverity === "hint" || result.warnings > 0) {
+    parts.push(result.warnings > 0 ? bold(yellow(plural(result.warnings, "warning"))) : dim("0 warnings"))
+  }
+  if (minimumSeverity === "hint") {
+    parts.push(dim(plural(result.hints, "hint")))
+  }
+  process.stdout.write(
+    `\n${bold(`Checked ${plural(result.filesChecked, "file")}:`)} ${parts.join(", ")}\n`,
+  )
+}
+
 const args = parseArgs(process.argv.slice(2))
-const checkOptions: { cwd?: string; tsconfig?: string } = {}
+const checkOptions: { cwd?: string; tsconfig?: string; minimumSeverity: Severity } = {
+  minimumSeverity: args.minimumSeverity,
+}
 if (args.root !== undefined) checkOptions.cwd = args.root
 if (args.tsconfig !== undefined) checkOptions.tsconfig = args.tsconfig
-const result = await runCheck(checkOptions)
 
-const fileLabel = result.filesChecked === 1 ? "file" : "files"
-process.stdout.write(
-  `\nChecked ${result.filesChecked} ${fileLabel}: ${result.errors} error${result.errors === 1 ? "" : "s"}` +
-    (result.warnings > 0 ? `, ${result.warnings} warning${result.warnings === 1 ? "" : "s"}` : "") +
-    "\n",
-)
+if (args.watch) {
+  // Loaded lazily: the one-shot path (CI, pre-commit) never pays for it.
+  const { watch } = await import("chokidar")
+  const checker = createChecker(checkOptions)
+  const root = path.resolve(args.root ?? process.cwd())
 
-process.exit(result.errors > 0 ? 1 : 0)
+  // Watch the extensions the project actually contains (derived from the
+  // resolved root files — for verrex that's .vx plus .ts/.tsx etc.), not a
+  // hardcoded list. Same trick as astro-check.
+  const watchedExtensions = new Set(
+    checker.getRootFileNames().map((fileName) => path.extname(fileName)),
+  )
+
+  // Debounced re-check: each trigger bumps `req`; an in-flight pass polls its
+  // own ticket between files and yields as soon as it's superseded.
+  let req = 0
+  const lint = async (): Promise<void> => {
+    const current = ++req
+    await new Promise((resolve) => setTimeout(resolve, 100))
+    if (current !== req) return
+    const result = await checker.check({ cancel: () => current !== req })
+    if (current !== req) return
+    printSummary(result, args.minimumSeverity)
+    process.stdout.write(dim("Watching for changes...") + "\n")
+  }
+  const update = (): void => {
+    if (!args.preserveWatchOutput) process.stdout.write("\x1bc")
+    void lint()
+  }
+
+  watch(root, {
+    ignored: (p, stats) =>
+      p.includes("node_modules") ||
+      p.includes(".git") ||
+      (stats?.isFile() === true && !watchedExtensions.has(path.extname(p))),
+    ignoreInitial: true,
+  })
+    .on("add", (fileName) => {
+      checker.fileCreated(fileName)
+      update()
+    })
+    .on("change", (fileName) => {
+      checker.fileUpdated(fileName)
+      update()
+    })
+    .on("unlink", (fileName) => {
+      checker.fileDeleted(fileName)
+      update()
+    })
+
+  // First pass runs immediately (no screen clear); the watcher keeps the
+  // process alive afterwards. Watch mode never exits non-zero on diagnostics.
+  await lint()
+} else {
+  const result = await runCheck(checkOptions)
+  printSummary(result, args.minimumSeverity)
+  process.exit(shouldFail(result, args.minimumFailingSeverity) ? 1 : 0)
+}

--- a/packages/core/src/check/cli.ts
+++ b/packages/core/src/check/cli.ts
@@ -13,9 +13,26 @@
  * see the behavior contract in AGENTS.md.
  */
 import * as path from "node:path"
-import { createChecker, runCheck, shouldFail, type CheckResult, type Severity } from "./index.ts"
+import { parseArgs } from "node:util"
+import {
+  createChecker,
+  runCheck,
+  shouldFail,
+  SEVERITIES,
+  type CheckOptions,
+  type CheckResult,
+  type Severity,
+} from "./index.ts"
 
-const SEVERITIES: ReadonlyArray<Severity> = ["error", "warning", "hint"]
+const OPTIONS = {
+  tsconfig: { type: "string", short: "p" },
+  root: { type: "string" },
+  watch: { type: "boolean", short: "w", default: false },
+  minimumSeverity: { type: "string", default: "error" },
+  minimumFailingSeverity: { type: "string", default: "error" },
+  preserveWatchOutput: { type: "boolean", default: false },
+  help: { type: "boolean", short: "h", default: false },
+} as const
 
 interface ParsedArgs {
   root: string | undefined
@@ -26,47 +43,38 @@ interface ParsedArgs {
   preserveWatchOutput: boolean
 }
 
-function parseArgs(argv: ReadonlyArray<string>): ParsedArgs {
-  const out: ParsedArgs = {
-    root: undefined,
-    tsconfig: undefined,
-    watch: false,
-    minimumSeverity: "error",
-    minimumFailingSeverity: "error",
-    preserveWatchOutput: false,
+function usageError(message: string): never {
+  console.error(`verrex-check: ${message}`)
+  printHelp()
+  process.exit(2)
+}
+
+function parseCliArgs(argv: ReadonlyArray<string>): ParsedArgs {
+  let values: ReturnType<typeof parseArgs<{ options: typeof OPTIONS }>>["values"]
+  try {
+    // parseArgs rejects unknown flags, missing option values, and flag-like
+    // values (`--root --watch`) — the failure modes a hand-rolled `argv[++i]`
+    // loop silently swallows.
+    values = parseArgs({ args: [...argv], options: OPTIONS, allowPositionals: false }).values
+  } catch (error) {
+    usageError(error instanceof Error ? error.message : String(error))
   }
-  const severityValue = (flag: string, value: string | undefined): Severity => {
-    if (value !== undefined && (SEVERITIES as ReadonlyArray<string>).includes(value)) {
-      return value as Severity
-    }
-    console.error(`verrex-check: ${flag} expects one of: ${SEVERITIES.join(", ")}`)
+  if (values.help) {
     printHelp()
-    process.exit(2)
+    process.exit(0)
   }
-  for (let i = 0; i < argv.length; i++) {
-    const arg = argv[i]
-    if (arg === "--tsconfig" || arg === "-p") {
-      out.tsconfig = argv[++i]
-    } else if (arg === "--root") {
-      out.root = argv[++i]
-    } else if (arg === "--watch" || arg === "-w") {
-      out.watch = true
-    } else if (arg === "--minimumSeverity") {
-      out.minimumSeverity = severityValue(arg, argv[++i])
-    } else if (arg === "--minimumFailingSeverity") {
-      out.minimumFailingSeverity = severityValue(arg, argv[++i])
-    } else if (arg === "--preserveWatchOutput") {
-      out.preserveWatchOutput = true
-    } else if (arg === "--help" || arg === "-h") {
-      printHelp()
-      process.exit(0)
-    } else {
-      console.error(`verrex-check: unknown argument: ${arg}`)
-      printHelp()
-      process.exit(2)
-    }
+  const severity = (flag: string, value: string): Severity => {
+    if ((SEVERITIES as ReadonlyArray<string>).includes(value)) return value as Severity
+    usageError(`${flag} expects one of: ${SEVERITIES.join(", ")}`)
   }
-  return out
+  return {
+    root: values.root,
+    tsconfig: values.tsconfig,
+    watch: values.watch,
+    minimumSeverity: severity("--minimumSeverity", values.minimumSeverity),
+    minimumFailingSeverity: severity("--minimumFailingSeverity", values.minimumFailingSeverity),
+    preserveWatchOutput: values.preserveWatchOutput,
+  }
 }
 
 function printHelp(): void {
@@ -102,26 +110,30 @@ const dim = paint(2, 22)
 const red = paint(31, 39)
 const yellow = paint(33, 39)
 
-function printSummary(result: CheckResult, minimumSeverity: Severity): void {
+function formatSummary(result: CheckResult, minimumSeverity: Severity): string {
   const plural = (n: number, word: string) => `${n} ${word}${n === 1 ? "" : "s"}`
   const parts = [
     result.errors > 0 ? bold(red(plural(result.errors, "error"))) : dim("0 errors"),
   ]
-  if (minimumSeverity === "warning" || minimumSeverity === "hint" || result.warnings > 0) {
+  if (minimumSeverity !== "error" || result.warnings > 0) {
     parts.push(result.warnings > 0 ? bold(yellow(plural(result.warnings, "warning"))) : dim("0 warnings"))
   }
   if (minimumSeverity === "hint") {
     parts.push(dim(plural(result.hints, "hint")))
   }
-  process.stdout.write(
-    `\n${bold(`Checked ${plural(result.filesChecked, "file")}:`)} ${parts.join(", ")}\n`,
-  )
+  return `\n${bold(`Checked ${plural(result.filesChecked, "file")}:`)} ${parts.join(", ")}\n`
 }
 
-const args = parseArgs(process.argv.slice(2))
-const checkOptions: { cwd?: string; tsconfig?: string; minimumSeverity: Severity } = {
-  minimumSeverity: args.minimumSeverity,
-}
+// Every extension the checker can ingest (the TS family plus .vx) — NOT the
+// extensions the project happens to contain at startup, so the first file of
+// a new kind still fires its add event. The tsconfig itself is allowed
+// through separately in the `ignored` predicate.
+const WATCHED_EXTENSIONS = new Set(
+  [".vx", ".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs"],
+)
+
+const args = parseCliArgs(process.argv.slice(2))
+const checkOptions: CheckOptions = { minimumSeverity: args.minimumSeverity }
 if (args.root !== undefined) checkOptions.cwd = args.root
 if (args.tsconfig !== undefined) checkOptions.tsconfig = args.tsconfig
 
@@ -129,57 +141,72 @@ if (args.watch) {
   // Loaded lazily: the one-shot path (CI, pre-commit) never pays for it.
   const { watch } = await import("chokidar")
   const checker = createChecker(checkOptions)
-  const root = path.resolve(args.root ?? process.cwd())
 
-  // Watch the extensions the project actually contains (derived from the
-  // resolved root files — for verrex that's .vx plus .ts/.tsx etc.), not a
-  // hardcoded list. Same trick as astro-check.
-  const watchedExtensions = new Set(
-    checker.getRootFileNames().map((fileName) => path.extname(fileName)),
-  )
+  // Watch the directory the tsconfig anchors its include globs to — not the
+  // invocation cwd, which can be elsewhere (`--tsconfig ../app/tsconfig.json`
+  // from a sibling dir would otherwise watch the wrong tree entirely).
+  const watchRoot = path.dirname(checker.tsconfigPath)
 
   // Debounced re-check: each trigger bumps `req`; an in-flight pass polls its
-  // own ticket between files and yields as soon as it's superseded.
+  // own ticket and yields as soon as it's superseded. The screen clear sits
+  // after the debounce (one clear per executed pass, none for coalesced
+  // events) and is TTY-gated — a pipe must never receive the reset sequence.
   let req = 0
   const lint = async (): Promise<void> => {
     const current = ++req
     await new Promise((resolve) => setTimeout(resolve, 100))
     if (current !== req) return
+    if (current > 1 && !args.preserveWatchOutput && process.stdout.isTTY === true) {
+      process.stdout.write("\x1bc")
+    }
     const result = await checker.check({ cancel: () => current !== req })
     if (current !== req) return
-    printSummary(result, args.minimumSeverity)
+    process.stdout.write(formatSummary(result, args.minimumSeverity))
     process.stdout.write(dim("Watching for changes...") + "\n")
   }
-  const update = (): void => {
-    if (!args.preserveWatchOutput) process.stdout.write("\x1bc")
-    void lint()
-  }
 
-  watch(root, {
-    ignored: (p, stats) =>
-      p.includes("node_modules") ||
-      p.includes(".git") ||
-      (stats?.isFile() === true && !watchedExtensions.has(path.extname(p))),
+  watch(watchRoot, {
+    ignored: (p, stats) => {
+      if (path.resolve(p) === checker.tsconfigPath) return false
+      // Match whole path segments below the watch root — substring tests
+      // would ignore the entire tree of e.g. a `user.github.io` checkout.
+      const segments = path.relative(watchRoot, p).split(path.sep)
+      if (segments.includes("node_modules") || segments.includes(".git")) return true
+      return stats?.isFile() === true && !WATCHED_EXTENSIONS.has(path.extname(p))
+    },
     ignoreInitial: true,
   })
     .on("add", (fileName) => {
       checker.fileCreated(fileName)
-      update()
+      void lint()
     })
     .on("change", (fileName) => {
       checker.fileUpdated(fileName)
-      update()
+      void lint()
     })
     .on("unlink", (fileName) => {
       checker.fileDeleted(fileName)
-      update()
+      void lint()
+    })
+    .on("error", (error) => {
+      // An unhandled 'error' event would crash the watch session (chokidar
+      // emits one for EPERM/EACCES dirs and inotify ENOSPC). Report and keep
+      // watching — the checker itself is unaffected.
+      const message = error instanceof Error ? error.message : String(error)
+      process.stderr.write(`verrex-check: watcher error: ${message}\n`)
     })
 
-  // First pass runs immediately (no screen clear); the watcher keeps the
-  // process alive afterwards. Watch mode never exits non-zero on diagnostics.
+  // First pass runs immediately; the watcher keeps the process alive
+  // afterwards. Watch mode never exits non-zero on diagnostics.
   await lint()
 } else {
   const result = await runCheck(checkOptions)
-  printSummary(result, args.minimumSeverity)
+  // Await the final write's flush callback before exiting: stdout-to-pipe is
+  // async on Linux and process.exit() does not drain it — a large diagnostic
+  // dump piped to a slow reader would otherwise be truncated. Writes are
+  // FIFO, so flushing the last one flushes everything before it.
+  await new Promise<void>((resolve) => {
+    process.stdout.write(formatSummary(result, args.minimumSeverity), () => resolve())
+  })
   process.exit(shouldFail(result, args.minimumFailingSeverity) ? 1 : 0)
 }

--- a/packages/core/src/check/cli.ts
+++ b/packages/core/src/check/cli.ts
@@ -31,17 +31,7 @@ const OPTIONS = {
   minimumSeverity: { type: "string", default: "error" },
   minimumFailingSeverity: { type: "string", default: "error" },
   preserveWatchOutput: { type: "boolean", default: false },
-  help: { type: "boolean", short: "h", default: false },
 } as const
-
-interface ParsedArgs {
-  root: string | undefined
-  tsconfig: string | undefined
-  watch: boolean
-  minimumSeverity: Severity
-  minimumFailingSeverity: Severity
-  preserveWatchOutput: boolean
-}
 
 function usageError(message: string): never {
   console.error(`verrex-check: ${message}`)
@@ -49,20 +39,23 @@ function usageError(message: string): never {
   process.exit(2)
 }
 
-function parseCliArgs(argv: ReadonlyArray<string>): ParsedArgs {
-  let values: ReturnType<typeof parseArgs<{ options: typeof OPTIONS }>>["values"]
-  try {
-    // parseArgs rejects unknown flags, missing option values, and flag-like
-    // values (`--root --watch`) — the failure modes a hand-rolled `argv[++i]`
-    // loop silently swallows.
-    values = parseArgs({ args: [...argv], options: OPTIONS, allowPositionals: false }).values
-  } catch (error) {
-    usageError(error instanceof Error ? error.message : String(error))
-  }
-  if (values.help) {
+function parseCliArgs(argv: ReadonlyArray<string>) {
+  // Help wins over everything else on the line, including invalid flags —
+  // `verrex-check --help <candidate-flag>` is a capability probe, not an error.
+  if (argv.includes("--help") || argv.includes("-h")) {
     printHelp()
     process.exit(0)
   }
+  const values = (() => {
+    try {
+      // parseArgs rejects unknown flags, missing option values, and flag-like
+      // values (`--root --watch`) — the failure modes a hand-rolled
+      // `argv[++i]` loop silently swallows.
+      return parseArgs({ args: [...argv], options: OPTIONS, allowPositionals: false }).values
+    } catch (error) {
+      usageError(error instanceof Error ? error.message : String(error))
+    }
+  })()
   const severity = (flag: string, value: string): Severity => {
     if ((SEVERITIES as ReadonlyArray<string>).includes(value)) return value as Severity
     usageError(`${flag} expects one of: ${SEVERITIES.join(", ")}`)
@@ -115,10 +108,13 @@ function formatSummary(result: CheckResult, minimumSeverity: Severity): string {
   const parts = [
     result.errors > 0 ? bold(red(plural(result.errors, "error"))) : dim("0 errors"),
   ]
+  // A nonzero count always surfaces, whatever the print threshold — any
+  // severity can fail the run via --minimumFailingSeverity, and an exit 1
+  // must never come with a summary that reads clean.
   if (minimumSeverity !== "error" || result.warnings > 0) {
     parts.push(result.warnings > 0 ? bold(yellow(plural(result.warnings, "warning"))) : dim("0 warnings"))
   }
-  if (minimumSeverity === "hint") {
+  if (minimumSeverity === "hint" || result.hints > 0) {
     parts.push(dim(plural(result.hints, "hint")))
   }
   return `\n${bold(`Checked ${plural(result.filesChecked, "file")}:`)} ${parts.join(", ")}\n`
@@ -126,11 +122,16 @@ function formatSummary(result: CheckResult, minimumSeverity: Severity): string {
 
 // Every extension the checker can ingest (the TS family plus .vx) — NOT the
 // extensions the project happens to contain at startup, so the first file of
-// a new kind still fires its add event. The tsconfig itself is allowed
-// through separately in the `ignored` predicate.
+// a new kind still fires its add event. Config files are allowed through
+// separately in the `ignored` predicate.
 const WATCHED_EXTENSIONS = new Set(
   [".vx", ".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs"],
 )
+
+function invocationError(error: unknown): never {
+  console.error(`verrex-check: ${error instanceof Error ? error.message : String(error)}`)
+  process.exit(2)
+}
 
 const args = parseCliArgs(process.argv.slice(2))
 const checkOptions: CheckOptions = { minimumSeverity: args.minimumSeverity }
@@ -140,51 +141,113 @@ if (args.tsconfig !== undefined) checkOptions.tsconfig = args.tsconfig
 if (args.watch) {
   // Loaded lazily: the one-shot path (CI, pre-commit) never pays for it.
   const { watch } = await import("chokidar")
-  const checker = createChecker(checkOptions)
+  const checker = (() => {
+    try {
+      return createChecker(checkOptions)
+    } catch (error) {
+      invocationError(error)
+    }
+  })()
 
-  // Watch the directory the tsconfig anchors its include globs to — not the
-  // invocation cwd, which can be elsewhere (`--tsconfig ../app/tsconfig.json`
-  // from a sibling dir would otherwise watch the wrong tree entirely).
-  const watchRoot = path.dirname(checker.tsconfigPath)
+  // Watch where the program actually lives: the tsconfig's directory plus
+  // every wildcard directory its include globs expand under (which may sit
+  // outside it — `"include": ["../shared/**"]`), plus the config files
+  // themselves (an extends base can sit anywhere). Imported sources outside
+  // these trees (workspace dependencies) are added file-by-file below.
+  const watchDirs = [
+    ...new Set([path.dirname(checker.tsconfigPath), ...checker.getWildcardDirectories()]),
+  ]
+
+  const hasIgnoredSegment = (segments: ReadonlyArray<string>) =>
+    segments.includes("node_modules") || segments.includes(".git")
+
+  const watcher = watch([...new Set([...watchDirs, ...checker.getConfigFilePaths()])], {
+    ignored: (p, stats) => {
+      const abs = path.resolve(p)
+      if (checker.getConfigFilePaths().includes(abs)) return false
+      // Match whole path segments below the containing watch dir — substring
+      // tests would ignore the entire tree of e.g. a `user.github.io`
+      // checkout. Explicitly-added files outside every dir fall through with
+      // their absolute segments.
+      const base = watchDirs.find((d) => abs === d || abs.startsWith(d + path.sep))
+      const segments = (base ? path.relative(base, abs) : abs).split(path.sep)
+      if (hasIgnoredSegment(segments)) return true
+      return stats?.isFile() === true && !WATCHED_EXTENSIONS.has(path.extname(abs))
+    },
+    ignoreInitial: true,
+  })
+
+  // Files the program pulled in from outside the watched trees — workspace
+  // dependency sources (`@verrex/core` dev exports resolve to
+  // packages/core/src/*.ts from the demo). tsc --watch covers these; a watch
+  // that doesn't reports stale results until an unrelated in-tree save.
+  const watchedFiles = new Set<string>()
+  const knownFiles = new Set<string>(checker.getRootFileNames().map((f) => path.resolve(f)))
+  const refreshTrackedFiles = () => {
+    for (const fileName of [...checker.getRootFileNames(), ...checker.getTrackedFileNames()]) {
+      const abs = path.resolve(fileName)
+      knownFiles.add(abs)
+      if (watchedFiles.has(abs)) continue
+      if (watchDirs.some((d) => abs.startsWith(d + path.sep))) continue
+      if (hasIgnoredSegment(abs.split(path.sep))) continue
+      if (!WATCHED_EXTENSIONS.has(path.extname(abs))) continue
+      watchedFiles.add(abs)
+      watcher.add(abs)
+    }
+  }
 
   // Debounced re-check: each trigger bumps `req`; an in-flight pass polls its
   // own ticket and yields as soon as it's superseded. The screen clear sits
-  // after the debounce (one clear per executed pass, none for coalesced
-  // events) and is TTY-gated — a pipe must never receive the reset sequence.
+  // after the debounce, only on a TTY, and only once a previous pass has
+  // actually printed — ticket ordinality alone would wipe the user's
+  // scrollback at startup when the first pass is superseded before printing.
   let req = 0
+  let anyPassCompleted = false
   const lint = async (): Promise<void> => {
     const current = ++req
     await new Promise((resolve) => setTimeout(resolve, 100))
     if (current !== req) return
-    if (current > 1 && !args.preserveWatchOutput && process.stdout.isTTY === true) {
+    if (anyPassCompleted && !args.preserveWatchOutput && process.stdout.isTTY === true) {
       process.stdout.write("\x1bc")
     }
-    const result = await checker.check({ cancel: () => current !== req })
-    if (current !== req) return
-    process.stdout.write(formatSummary(result, args.minimumSeverity))
-    process.stdout.write(dim("Watching for changes...") + "\n")
+    try {
+      const result = await checker.check({ cancel: () => current !== req })
+      if (current !== req) return
+      anyPassCompleted = true
+      refreshTrackedFiles()
+      process.stdout.write(
+        formatSummary(result, args.minimumSeverity) + dim("Watching for changes...") + "\n",
+      )
+    } catch (error) {
+      // A failing pass (tsconfig briefly missing mid-checkout, a transform
+      // crash on an unrecoverable mid-edit file) must not kill the session —
+      // report and keep watching; the project re-checks on the next event.
+      const message = error instanceof Error ? error.message : String(error)
+      process.stderr.write(`verrex-check: ${message}\n`)
+      process.stdout.write(dim("Watching for changes...") + "\n")
+    }
   }
 
-  watch(watchRoot, {
-    ignored: (p, stats) => {
-      if (path.resolve(p) === checker.tsconfigPath) return false
-      // Match whole path segments below the watch root — substring tests
-      // would ignore the entire tree of e.g. a `user.github.io` checkout.
-      const segments = path.relative(watchRoot, p).split(path.sep)
-      if (segments.includes("node_modules") || segments.includes(".git")) return true
-      return stats?.isFile() === true && !WATCHED_EXTENSIONS.has(path.extname(p))
-    },
-    ignoreInitial: true,
-  })
+  // A change/unlink for a file that was never part of the project (build
+  // output, scratch files) can't alter diagnostics — skip the pass. Adds
+  // can join the project, so they always go through (the shape comparison
+  // in the checker keeps irrelevant ones from rebuilding anything).
+  const isRelevant = (abs: string) =>
+    knownFiles.has(abs) || checker.getConfigFilePaths().includes(abs)
+
+  watcher
     .on("add", (fileName) => {
       checker.fileCreated(fileName)
       void lint()
     })
     .on("change", (fileName) => {
-      checker.fileUpdated(fileName)
+      const abs = path.resolve(fileName)
+      if (!isRelevant(abs)) return
+      checker.fileUpdated(abs)
       void lint()
     })
     .on("unlink", (fileName) => {
+      if (!isRelevant(path.resolve(fileName))) return
       checker.fileDeleted(fileName)
       void lint()
     })
@@ -200,7 +263,7 @@ if (args.watch) {
   // afterwards. Watch mode never exits non-zero on diagnostics.
   await lint()
 } else {
-  const result = await runCheck(checkOptions)
+  const result = await runCheck(checkOptions).catch(invocationError)
   // Await the final write's flush callback before exiting: stdout-to-pipe is
   // async on Linux and process.exit() does not drain it — a large diagnostic
   // dump piped to a slow reader would otherwise be truncated. Writes are

--- a/packages/core/src/check/index.ts
+++ b/packages/core/src/check/index.ts
@@ -10,6 +10,20 @@ import { createVerrexLanguagePlugin } from "@verrex/core/language"
 // another package just for the enum.
 const SEVERITY_ERROR = 1
 const SEVERITY_WARNING = 2
+const SEVERITY_HINT = 4
+
+/**
+ * Severity threshold names, matching `astro check`'s flag vocabulary.
+ * `"error"` < `"warning"` < `"hint"` — each level includes the ones before it
+ * (`"hint"` also admits LSP Information, like astro's `severity <= Hint` filter).
+ */
+export type Severity = "error" | "warning" | "hint"
+
+const SEVERITY_CEILING: Record<Severity, number> = {
+  error: SEVERITY_ERROR,
+  warning: SEVERITY_WARNING,
+  hint: SEVERITY_HINT,
+}
 
 export interface CheckOptions {
   /**
@@ -22,6 +36,13 @@ export interface CheckOptions {
    * If omitted, `ts.findConfigFile` is used starting from `cwd`.
    */
   tsconfig?: string
+  /**
+   * Minimum severity that gets *printed* (counting is unaffected).
+   * Defaults to `"error"` — the bare `tsc --noEmit` baseline this tool
+   * replaces. (astro check defaults to `"hint"`; the flag semantics match,
+   * only the default differs.)
+   */
+  minimumSeverity?: Severity
 }
 
 export interface CheckResult {
@@ -31,15 +52,48 @@ export interface CheckResult {
   errors: number
   /** Total warning-severity diagnostics. */
   warnings: number
+  /** Total hint-severity diagnostics (TS "suggestions", e.g. unused locals). */
+  hints: number
+}
+
+export interface VerrexChecker {
+  /**
+   * Check every root file, printing qualifying diagnostics to stdout as they
+   * are found. `cancel` is polled between files; a cancelled run returns the
+   * counts accumulated so far (callers driving a re-check loop should discard
+   * superseded results themselves).
+   */
+  check(options?: { cancel?: () => boolean }): Promise<CheckResult>
+  /** Notify the checker of a created file (re-expands the tsconfig include globs). */
+  fileCreated(fileName: string): void
+  /** Notify the checker of an in-place edit (bumps the project version; content re-read from disk). */
+  fileUpdated(fileName: string): void
+  /** Notify the checker of a deletion (re-expands the tsconfig include globs). */
+  fileDeleted(fileName: string): void
+  /** Current root file names (re-resolved after create/delete events). */
+  getRootFileNames(): string[]
 }
 
 /**
- * Type-check a verrex project. Returns a summary; the printed output goes
- * to stdout in tsc's standard "file:line:col - error TS####: message"
- * format (via Volar kit's printErrors helper).
+ * Build a persistent checker for a verrex project. The underlying
+ * `ts.LanguageService` survives across `check()` calls, so a watch loop pays
+ * incremental re-check cost, not project construction — feed file events in
+ * via `fileCreated`/`fileUpdated`/`fileDeleted` (see `cli.ts` for the
+ * chokidar wiring).
+ *
+ * `fileUpdated` (the hot path — every save) is incremental: kit bumps its
+ * project version and the edited file's snapshot is re-read from disk.
+ * `fileCreated`/`fileDeleted` rebuild the kit checker instead: kit's own root
+ * file re-expansion is broken upstream (its `getScriptFileNames` caches
+ * resolved names in a WeakMap keyed by a `ParsedCommandLine` it then mutates
+ * in place, so a re-parsed include glob is never observed — present in
+ * `@volar/kit` ≤ 2.4.28 and on volar main). Rebuild costs one project
+ * construction, only on the rare add/remove events.
  */
-export async function runCheck(options: CheckOptions = {}): Promise<CheckResult> {
+export function createChecker(options: CheckOptions = {}): VerrexChecker {
   const cwd = path.resolve(options.cwd ?? process.cwd())
+  const minimumSeverity = options.minimumSeverity ?? "error"
+  const printCeiling = SEVERITY_CEILING[minimumSeverity]
 
   const tsconfigPath = resolveTsconfig(cwd, options.tsconfig)
   if (!tsconfigPath) {
@@ -50,41 +104,88 @@ export async function runCheck(options: CheckOptions = {}): Promise<CheckResult>
 
   // `@volar/kit` uses `URI` as the script-id type, so the plugin gets URIs
   // and reduces them to filesystem paths for the compiler. The kit checker
-  // owns the virtual-code lifetime per `createTypeScriptChecker` call; we
-  // hold no side-channel state of our own.
-  const languagePlugin = createVerrexLanguagePlugin<URI>((uri) => uri.fsPath)
-  const tsServices = createTypeScriptServices(ts)
-  const linter = kit.createTypeScriptChecker([languagePlugin], tsServices, tsconfigPath)
+  // owns the virtual-code lifetime per linter instance; we hold no
+  // side-channel state of our own.
+  const buildLinter = () => {
+    const languagePlugin = createVerrexLanguagePlugin<URI>((uri) => uri.fsPath)
+    const tsServices = createTypeScriptServices(ts)
+    return kit.createTypeScriptChecker([languagePlugin], tsServices, tsconfigPath)
+  }
+  let linter = buildLinter()
 
-  const fileNames = linter.getRootFileNames()
-  let errors = 0
-  let warnings = 0
+  async function check(checkOptions: { cancel?: () => boolean } = {}): Promise<CheckResult> {
+    const cancel = checkOptions.cancel ?? (() => false)
+    const result: CheckResult = { filesChecked: 0, errors: 0, warnings: 0, hints: 0 }
 
-  for (const fileName of fileNames) {
-    const diagnostics = await linter.check(fileName)
-    if (diagnostics.length === 0) continue
+    // Pin the instance for the whole pass — a create/delete event arriving
+    // mid-pass swaps `linter`, and mixing instances would skew the counts.
+    const pass = linter
+    for (const fileName of pass.getRootFileNames()) {
+      if (cancel()) return result
+      const diagnostics = await pass.check(fileName)
+      result.filesChecked += 1
+      if (diagnostics.length === 0) continue
 
-    // Match `tsc --noEmit` behaviour: only print error-severity diagnostics.
-    // Warnings/hints surfaced by volar-service-typescript (e.g. unused locals
-    // without `noUnusedLocals`) get counted but not printed by default.
-    // TODO(astro-parity): expose --minimumSeverity to control what prints.
-    const errorOnly = diagnostics.filter((d) => (d.severity ?? SEVERITY_ERROR) === SEVERITY_ERROR)
-    if (errorOnly.length > 0) {
-      const text = linter.printErrors(fileName, errorOnly, cwd)
-      if (text) {
-        process.stdout.write(text)
-        if (!text.endsWith("\n")) process.stdout.write("\n")
+      const toPrint = diagnostics.filter((d) => (d.severity ?? SEVERITY_ERROR) <= printCeiling)
+      if (toPrint.length > 0) {
+        const text = pass.printErrors(fileName, toPrint, cwd)
+        if (text) {
+          process.stdout.write(text)
+          if (!text.endsWith("\n")) process.stdout.write("\n")
+        }
+      }
+
+      for (const d of diagnostics) {
+        const sev = d.severity ?? SEVERITY_ERROR
+        if (sev === SEVERITY_ERROR) result.errors += 1
+        else if (sev === SEVERITY_WARNING) result.warnings += 1
+        else if (sev === SEVERITY_HINT) result.hints += 1
       }
     }
 
-    for (const d of diagnostics) {
-      const sev = d.severity ?? SEVERITY_ERROR
-      if (sev === SEVERITY_ERROR) errors += 1
-      else if (sev === SEVERITY_WARNING) warnings += 1
-    }
+    return result
   }
 
-  return { filesChecked: fileNames.length, errors, warnings }
+  return {
+    check,
+    fileCreated: () => {
+      linter = buildLinter()
+    },
+    fileUpdated: (fileName) => linter.fileUpdated(fileName),
+    fileDeleted: () => {
+      linter = buildLinter()
+    },
+    getRootFileNames: () => linter.getRootFileNames(),
+  }
+}
+
+/**
+ * Type-check a verrex project once. Returns a summary; the printed output
+ * goes to stdout in tsc's standard "file:line:col - error TS####: message"
+ * format (via Volar kit's printErrors helper). Each call builds an
+ * independent checker — use `createChecker` to keep one alive across runs.
+ */
+export async function runCheck(options: CheckOptions = {}): Promise<CheckResult> {
+  return createChecker(options).check()
+}
+
+/**
+ * Whether `result` should fail the process, astro-check semantics: each
+ * threshold also fails on everything more severe (`"hint"` fails on any
+ * unfixed hint, warning, or error). Defaults to `"error"`.
+ */
+export function shouldFail(
+  result: CheckResult,
+  minimumFailingSeverity: Severity = "error",
+): boolean {
+  switch (minimumFailingSeverity) {
+    case "error":
+      return result.errors > 0
+    case "warning":
+      return result.errors + result.warnings > 0
+    case "hint":
+      return result.errors + result.warnings + result.hints > 0
+  }
 }
 
 function resolveTsconfig(cwd: string, supplied: string | undefined): string | undefined {

--- a/packages/core/src/check/index.ts
+++ b/packages/core/src/check/index.ts
@@ -17,7 +17,8 @@ const SEVERITY_HINT = 4
  * `"error"` < `"warning"` < `"hint"` — each level includes the ones before it
  * (`"hint"` also admits LSP Information, like astro's `severity <= Hint` filter).
  */
-export type Severity = "error" | "warning" | "hint"
+export const SEVERITIES = ["error", "warning", "hint"] as const
+export type Severity = (typeof SEVERITIES)[number]
 
 const SEVERITY_CEILING: Record<Severity, number> = {
   error: SEVERITY_ERROR,
@@ -52,7 +53,11 @@ export interface CheckResult {
   errors: number
   /** Total warning-severity diagnostics. */
   warnings: number
-  /** Total hint-severity diagnostics (TS "suggestions", e.g. unused locals). */
+  /**
+   * Total diagnostics below warning — LSP Hint (TS "suggestions", e.g. unused
+   * locals) and LSP Information both land here, mirroring the `"hint"` print
+   * ceiling so everything printable is counted somewhere.
+   */
   hints: number
 }
 
@@ -66,12 +71,18 @@ export interface VerrexChecker {
   check(options?: { cancel?: () => boolean }): Promise<CheckResult>
   /** Notify the checker of a created file (re-expands the tsconfig include globs). */
   fileCreated(fileName: string): void
-  /** Notify the checker of an in-place edit (bumps the project version; content re-read from disk). */
+  /**
+   * Notify the checker of an in-place edit (bumps the project version; content
+   * re-read from disk). An edit to the tsconfig itself marks the whole project
+   * stale instead — compiler options and include globs are re-parsed.
+   */
   fileUpdated(fileName: string): void
   /** Notify the checker of a deletion (re-expands the tsconfig include globs). */
   fileDeleted(fileName: string): void
   /** Current root file names (re-resolved after create/delete events). */
   getRootFileNames(): string[]
+  /** Absolute path of the tsconfig this checker resolved. */
+  readonly tsconfigPath: string
 }
 
 /**
@@ -83,24 +94,28 @@ export interface VerrexChecker {
  *
  * `fileUpdated` (the hot path — every save) is incremental: kit bumps its
  * project version and the edited file's snapshot is re-read from disk.
- * `fileCreated`/`fileDeleted` rebuild the kit checker instead: kit's own root
- * file re-expansion is broken upstream (its `getScriptFileNames` caches
- * resolved names in a WeakMap keyed by a `ParsedCommandLine` it then mutates
- * in place, so a re-parsed include glob is never observed — present in
- * `@volar/kit` ≤ 2.4.28 and on volar main). Rebuild costs one project
- * construction, only on the rare add/remove events.
+ * `fileCreated`/`fileDeleted` (and tsconfig edits) mark the project stale
+ * instead, and the kit checker is rebuilt lazily — once, at the start of the
+ * next `check()` — because kit's own root-file re-expansion is broken
+ * upstream (its `getScriptFileNames` caches resolved names in a WeakMap
+ * keyed by a `ParsedCommandLine` it then mutates in place, so a re-parsed
+ * include glob is never observed — present in `@volar/kit` ≤ 2.4.28 and on
+ * volar main). Lazy means a burst of N add/remove events (git checkout,
+ * codegen) costs one project construction, not N.
  */
 export function createChecker(options: CheckOptions = {}): VerrexChecker {
   const cwd = path.resolve(options.cwd ?? process.cwd())
   const minimumSeverity = options.minimumSeverity ?? "error"
   const printCeiling = SEVERITY_CEILING[minimumSeverity]
 
-  const tsconfigPath = resolveTsconfig(cwd, options.tsconfig)
-  if (!tsconfigPath) {
+  const foundTsconfig = resolveTsconfig(cwd, options.tsconfig)
+  if (!foundTsconfig) {
     throw new Error(
       `No tsconfig.json found from ${cwd}. Pass --tsconfig <path> or run from a directory containing one.`,
     )
   }
+  // Normalized so fileUpdated can reliably recognize edits to the tsconfig.
+  const tsconfigPath = path.resolve(foundTsconfig)
 
   // `@volar/kit` uses `URI` as the script-id type, so the plugin gets URIs
   // and reduces them to filesystem paths for the compiler. The kit checker
@@ -112,17 +127,28 @@ export function createChecker(options: CheckOptions = {}): VerrexChecker {
     return kit.createTypeScriptChecker([languagePlugin], tsServices, tsconfigPath)
   }
   let linter = buildLinter()
+  let projectStale = false
+  const freshLinter = () => {
+    if (projectStale) {
+      projectStale = false
+      linter = buildLinter()
+    }
+    return linter
+  }
 
   async function check(checkOptions: { cancel?: () => boolean } = {}): Promise<CheckResult> {
     const cancel = checkOptions.cancel ?? (() => false)
     const result: CheckResult = { filesChecked: 0, errors: 0, warnings: 0, hints: 0 }
 
-    // Pin the instance for the whole pass — a create/delete event arriving
-    // mid-pass swaps `linter`, and mixing instances would skew the counts.
-    const pass = linter
+    // Pin the instance for the whole pass — a superseded-but-draining pass
+    // must not pick up a rebuild a newer overlapping pass just performed.
+    const pass = freshLinter()
     for (const fileName of pass.getRootFileNames()) {
       if (cancel()) return result
       const diagnostics = await pass.check(fileName)
+      // Re-check after the await: a pass superseded mid-file must not print
+      // stale diagnostics over the newer pass's output.
+      if (cancel()) return result
       result.filesChecked += 1
       if (diagnostics.length === 0) continue
 
@@ -139,7 +165,10 @@ export function createChecker(options: CheckOptions = {}): VerrexChecker {
         const sev = d.severity ?? SEVERITY_ERROR
         if (sev === SEVERITY_ERROR) result.errors += 1
         else if (sev === SEVERITY_WARNING) result.warnings += 1
-        else if (sev === SEVERITY_HINT) result.hints += 1
+        // Everything below warning (LSP Information 3 and Hint 4) counts as a
+        // hint — the same bucket the "hint" print ceiling admits, so nothing
+        // can print yet be invisible to the counts and the exit code.
+        else result.hints += 1
       }
     }
 
@@ -149,13 +178,17 @@ export function createChecker(options: CheckOptions = {}): VerrexChecker {
   return {
     check,
     fileCreated: () => {
-      linter = buildLinter()
+      projectStale = true
     },
-    fileUpdated: (fileName) => linter.fileUpdated(fileName),
+    fileUpdated: (fileName) => {
+      if (path.resolve(fileName) === tsconfigPath) projectStale = true
+      else linter.fileUpdated(fileName)
+    },
     fileDeleted: () => {
-      linter = buildLinter()
+      projectStale = true
     },
-    getRootFileNames: () => linter.getRootFileNames(),
+    getRootFileNames: () => freshLinter().getRootFileNames(),
+    tsconfigPath,
   }
 }
 
@@ -185,6 +218,10 @@ export function shouldFail(
       return result.errors + result.warnings > 0
     case "hint":
       return result.errors + result.warnings + result.hints > 0
+    default:
+      // Unreachable for TS callers; guards untyped JS callers passing a typo'd
+      // threshold, which must not read as "success" (astro has the same arm).
+      return result.errors > 0
   }
 }
 

--- a/packages/core/src/check/index.ts
+++ b/packages/core/src/check/index.ts
@@ -83,6 +83,25 @@ export interface VerrexChecker {
   getRootFileNames(): string[]
   /** Absolute path of the tsconfig this checker resolved. */
   readonly tsconfigPath: string
+  /**
+   * The tsconfig plus its `extends` chain (absolute). An update event on any
+   * of them re-parses the project — base configs change options/includes just
+   * as the top-level one does.
+   */
+  getConfigFilePaths(): string[]
+  /**
+   * Directories the tsconfig's include globs expand under (absolute) — the
+   * directories a watcher must cover, which are NOT necessarily under the
+   * tsconfig's own directory (`"include": ["../shared/**"]`).
+   */
+  getWildcardDirectories(): string[]
+  /**
+   * Every file-scheme document the checker has pulled into the program so
+   * far — root files plus imported sources (e.g. workspace dependencies
+   * resolved outside the include globs). Grows as checks run; a watcher can
+   * use it to cover dependency files the way `tsc --watch` does.
+   */
+  getTrackedFileNames(): string[]
 }
 
 /**
@@ -101,7 +120,9 @@ export interface VerrexChecker {
  * keyed by a `ParsedCommandLine` it then mutates in place, so a re-parsed
  * include glob is never observed — present in `@volar/kit` ≤ 2.4.28 and on
  * volar main). Lazy means a burst of N add/remove events (git checkout,
- * codegen) costs one project construction, not N.
+ * codegen) costs one project construction, not N — and none at all when a
+ * fresh config parse shows the root set and options unchanged (build-output
+ * churn never enters the include globs).
  */
 export function createChecker(options: CheckOptions = {}): VerrexChecker {
   const cwd = path.resolve(options.cwd ?? process.cwd())
@@ -117,6 +138,20 @@ export function createChecker(options: CheckOptions = {}): VerrexChecker {
   // Normalized so fileUpdated can reliably recognize edits to the tsconfig.
   const tsconfigPath = path.resolve(foundTsconfig)
 
+  // Every file the language syncs from disk — roots AND imported sources
+  // (workspace dependencies resolved outside the include globs). Volar
+  // consults each plugin's getLanguageId for every script it registers, so a
+  // passive plugin ahead of the verrex one observes the whole program through
+  // public API (kit exposes no program/script iteration). Accumulates across
+  // rebuilds; stale entries are harmless for the watch use case.
+  const trackedFiles = new Set<string>()
+  const trackingPlugin = {
+    getLanguageId: (uri: URI) => {
+      if (uri.scheme === "file") trackedFiles.add(uri.fsPath)
+      return undefined
+    },
+  }
+
   // `@volar/kit` uses `URI` as the script-id type, so the plugin gets URIs
   // and reduces them to filesystem paths for the compiler. The kit checker
   // owns the virtual-code lifetime per linter instance; we hold no
@@ -124,14 +159,70 @@ export function createChecker(options: CheckOptions = {}): VerrexChecker {
   const buildLinter = () => {
     const languagePlugin = createVerrexLanguagePlugin<URI>((uri) => uri.fsPath)
     const tsServices = createTypeScriptServices(ts)
-    return kit.createTypeScriptChecker([languagePlugin], tsServices, tsconfigPath)
+    return kit.createTypeScriptChecker([trackingPlugin, languagePlugin], tsServices, tsconfigPath)
   }
+
+  // The same extraFileExtensions kit hands to its own config parse, so our
+  // shape snapshot expands include globs identically (`.vx` admitted).
+  const extraFileExtensions =
+    createVerrexLanguagePlugin<URI>((uri) => uri.fsPath).typescript?.extraFileExtensions ?? []
+
+  interface ProjectShape {
+    /** Sorted, for cheap equality. */
+    fileNames: string[]
+    optionsKey: string
+    configFiles: string[]
+    wildcardDirectories: string[]
+  }
+
+  // One cheap config parse (milliseconds — no language service) describing
+  // what the project would look like if rebuilt now. Throws a friendly error
+  // when the tsconfig is missing/unreadable: TS 6's parser otherwise dies
+  // with an internal TypeError deep in typescript.js.
+  const parseProjectShape = (): ProjectShape => {
+    if (!ts.sys.fileExists(tsconfigPath)) {
+      throw new Error(`tsconfig not found at ${tsconfigPath}`)
+    }
+    const sourceFile = ts.readJsonConfigFile(tsconfigPath, ts.sys.readFile)
+    const parsed = ts.parseJsonSourceFileConfigFileContent(
+      sourceFile,
+      ts.sys,
+      path.dirname(tsconfigPath),
+      undefined,
+      tsconfigPath,
+      undefined,
+      extraFileExtensions,
+    )
+    return {
+      fileNames: parsed.fileNames.map((f) => path.resolve(f)).sort(),
+      optionsKey: JSON.stringify(parsed.options),
+      configFiles: [tsconfigPath, ...(sourceFile.extendedSourceFiles ?? []).map((f) => path.resolve(f))],
+      wildcardDirectories: Object.keys(parsed.wildcardDirectories ?? {}).map((d) => path.resolve(d)),
+    }
+  }
+
+  let shape = parseProjectShape()
   let linter = buildLinter()
   let projectStale = false
+  const markProjectStale = () => {
+    projectStale = true
+  }
   const freshLinter = () => {
     if (projectStale) {
+      // Re-snapshot first and rebuild only when the project actually changed:
+      // create/delete churn that never enters the root set (build output,
+      // editor temp files) must not pay a full language-service rebuild.
+      // A parse throw (tsconfig briefly missing mid-`git checkout`) leaves
+      // `projectStale` set, so the next call retries instead of silently
+      // serving the outdated project.
+      const next = parseProjectShape()
+      const changed =
+        next.optionsKey !== shape.optionsKey ||
+        next.fileNames.length !== shape.fileNames.length ||
+        next.fileNames.some((fileName, i) => fileName !== shape.fileNames[i])
+      shape = next
+      if (changed) linter = buildLinter()
       projectStale = false
-      linter = buildLinter()
     }
     return linter
   }
@@ -177,18 +268,17 @@ export function createChecker(options: CheckOptions = {}): VerrexChecker {
 
   return {
     check,
-    fileCreated: () => {
-      projectStale = true
-    },
+    fileCreated: markProjectStale,
     fileUpdated: (fileName) => {
-      if (path.resolve(fileName) === tsconfigPath) projectStale = true
+      if (shape.configFiles.includes(path.resolve(fileName))) markProjectStale()
       else linter.fileUpdated(fileName)
     },
-    fileDeleted: () => {
-      projectStale = true
-    },
+    fileDeleted: markProjectStale,
     getRootFileNames: () => freshLinter().getRootFileNames(),
     tsconfigPath,
+    getConfigFilePaths: () => [...shape.configFiles],
+    getWildcardDirectories: () => [...shape.wildcardDirectories],
+    getTrackedFileNames: () => [...trackedFiles],
   }
 }
 

--- a/packages/core/test/check/integration.mjs
+++ b/packages/core/test/check/integration.mjs
@@ -116,9 +116,14 @@ console.log("\n4. createChecker: one instance tracks file events incrementally..
   expect(restored.result.errors === 0, `after fileUpdated restore: expected 0 errors, got ${restored.result.errors}`)
   if (restored.result.errors !== 0) console.error("output was:\n" + restored.output)
 
-  // Create/delete re-expand the tsconfig include globs.
+  // Create/delete re-expand the tsconfig include globs (lazily, at the next
+  // check/getRootFileNames — a burst of events costs one rebuild).
   writeFileSync(brokenPath, `const x: number = "wrong type"\nexport { x }\n`)
   checker.fileCreated(brokenPath)
+  expect(
+    checker.getRootFileNames().some((f) => f.endsWith("Broken.vx")),
+    "after fileCreated: getRootFileNames flushes the stale project",
+  )
   const broken = await captureStdout(() => checker.check())
   expect(broken.result.errors >= 1, `after fileCreated: expected >=1 errors, got ${broken.result.errors}`)
   expect(broken.output.includes("Broken.vx"), "after fileCreated: output should mention Broken.vx")
@@ -126,6 +131,29 @@ console.log("\n4. createChecker: one instance tracks file events incrementally..
     broken.result.filesChecked === baselineFiles + 1,
     `after fileCreated: expected ${baselineFiles + 1} files, got ${broken.result.filesChecked}`,
   )
+
+  // An edit to the tsconfig itself marks the project stale: excluding
+  // Broken.vx must drop its error without a new checker.
+  const tsconfigPath = join(fixtureDir, "tsconfig.json")
+  expect(checker.tsconfigPath === tsconfigPath, "checker.tsconfigPath points at the fixture tsconfig")
+  const tsconfigSource = readFileSync(tsconfigPath, "utf8")
+  try {
+    const config = JSON.parse(tsconfigSource)
+    writeFileSync(tsconfigPath, JSON.stringify({ ...config, exclude: ["Broken.vx"] }, null, 2))
+    checker.fileUpdated(tsconfigPath)
+    const excluded = await captureStdout(() => checker.check())
+    expect(
+      excluded.result.errors === 0,
+      `after tsconfig exclude: expected 0 errors, got ${excluded.result.errors}`,
+    )
+    expect(
+      excluded.result.filesChecked === baselineFiles,
+      `after tsconfig exclude: expected ${baselineFiles} files, got ${excluded.result.filesChecked}`,
+    )
+  } finally {
+    writeFileSync(tsconfigPath, tsconfigSource)
+  }
+  checker.fileUpdated(tsconfigPath)
 
   unlinkSync(brokenPath)
   checker.fileDeleted(brokenPath)
@@ -164,6 +192,9 @@ console.log("\n6. shouldFail: failing-severity thresholds cascade...")
   expect(shouldFail(only("hints", 1), "hint") === true, '"hint": hints fail')
   expect(shouldFail(only("errors", 1), "hint") === true, '"hint": errors still fail')
   expect(shouldFail(only("errors", 0), "hint") === false, '"hint": clean result passes')
+  // Untyped JS callers passing a typo'd threshold must still fail on errors.
+  expect(shouldFail(only("errors", 1), "bogus") === true, "unknown threshold: errors still fail")
+  expect(shouldFail(only("warnings", 1), "bogus") === false, "unknown threshold: falls back to error level")
 }
 
 ensureClean()

--- a/packages/core/test/check/integration.mjs
+++ b/packages/core/test/check/integration.mjs
@@ -6,13 +6,18 @@
  *   2. Add a deliberately-broken .vx → runCheck reports the type error,
  *      with source position pointing at the .vx file.
  *   3. Remove the broken file → back to 0 errors.
+ *   4. createChecker: ONE checker instance tracks create/update/delete via
+ *      file events — the incremental loop `verrex-check --watch` runs on.
+ *   5. minimumSeverity: hint-severity diagnostics (TS suggestions) are
+ *      counted but not printed by default; "hint" prints them.
+ *   6. shouldFail: the failing-severity thresholds cascade.
  *
  * No tsserver subprocess; the check tool is invoked in-process.
  */
-import { writeFileSync, unlinkSync, existsSync } from "node:fs"
+import { writeFileSync, readFileSync, unlinkSync, existsSync } from "node:fs"
 import { dirname, join } from "node:path"
 import { fileURLToPath } from "node:url"
-import { runCheck } from "../../src/check/index.ts"
+import { createChecker, runCheck, shouldFail } from "../../src/check/index.ts"
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const fixtureDir = join(__dirname, "fixture")
@@ -45,8 +50,11 @@ const captureStdout = async (fn) => {
   }
 }
 
+const unusedPath = join(fixtureDir, "Unused.vx")
+
 const ensureClean = () => {
   if (existsSync(brokenPath)) unlinkSync(brokenPath)
+  if (existsSync(unusedPath)) unlinkSync(unusedPath)
 }
 
 ensureClean()
@@ -80,6 +88,82 @@ unlinkSync(brokenPath)
   const { result, output } = await captureStdout(() => runCheck({ cwd: fixtureDir }))
   expect(result.errors === 0, `expected 0 errors after cleanup, got ${result.errors}`)
   if (result.errors !== 0) console.error("output was:\n" + output)
+}
+
+console.log("\n4. createChecker: one instance tracks file events incrementally...")
+{
+  const checker = createChecker({ cwd: fixtureDir })
+  const goodPath = join(fixtureDir, "Good.vx")
+  const goodSource = readFileSync(goodPath, "utf8")
+
+  const clean = await captureStdout(() => checker.check())
+  expect(clean.result.errors === 0, `fresh checker: expected 0 errors, got ${clean.result.errors}`)
+  const baselineFiles = clean.result.filesChecked
+
+  // The hot path: an in-place edit of an EXISTING root file, signalled via
+  // fileUpdated — kit bumps its project version and re-reads the snapshot.
+  try {
+    writeFileSync(goodPath, goodSource + `export const oops: number = "nope"\n`)
+    checker.fileUpdated(goodPath)
+    const edited = await captureStdout(() => checker.check())
+    expect(edited.result.errors >= 1, `after fileUpdated break: expected >=1 errors, got ${edited.result.errors}`)
+    expect(edited.output.includes("Good.vx"), "after fileUpdated break: output should mention Good.vx")
+  } finally {
+    writeFileSync(goodPath, goodSource)
+  }
+  checker.fileUpdated(goodPath)
+  const restored = await captureStdout(() => checker.check())
+  expect(restored.result.errors === 0, `after fileUpdated restore: expected 0 errors, got ${restored.result.errors}`)
+  if (restored.result.errors !== 0) console.error("output was:\n" + restored.output)
+
+  // Create/delete re-expand the tsconfig include globs.
+  writeFileSync(brokenPath, `const x: number = "wrong type"\nexport { x }\n`)
+  checker.fileCreated(brokenPath)
+  const broken = await captureStdout(() => checker.check())
+  expect(broken.result.errors >= 1, `after fileCreated: expected >=1 errors, got ${broken.result.errors}`)
+  expect(broken.output.includes("Broken.vx"), "after fileCreated: output should mention Broken.vx")
+  expect(
+    broken.result.filesChecked === baselineFiles + 1,
+    `after fileCreated: expected ${baselineFiles + 1} files, got ${broken.result.filesChecked}`,
+  )
+
+  unlinkSync(brokenPath)
+  checker.fileDeleted(brokenPath)
+  const removed = await captureStdout(() => checker.check())
+  expect(removed.result.errors === 0, `after fileDeleted: expected 0 errors, got ${removed.result.errors}`)
+  expect(
+    removed.result.filesChecked === baselineFiles,
+    `after fileDeleted: expected ${baselineFiles} files, got ${removed.result.filesChecked}`,
+  )
+
+  const cancelled = await captureStdout(() => checker.check({ cancel: () => true }))
+  expect(cancelled.result.filesChecked === 0, "cancel before the first file: 0 files checked")
+}
+
+console.log("\n5. minimumSeverity: hints counted but not printed by default...")
+writeFileSync(unusedPath, `const unused = 1\nexport const ok = 2\n`)
+{
+  const dflt = await captureStdout(() => runCheck({ cwd: fixtureDir }))
+  expect(dflt.result.errors === 0, `expected 0 errors, got ${dflt.result.errors}`)
+  expect(dflt.result.hints >= 1, `expected >=1 hint (unused local suggestion), got ${dflt.result.hints}`)
+  expect(!dflt.output.includes("Unused.vx"), "default severity: hint should not print")
+
+  const hints = await captureStdout(() => runCheck({ cwd: fixtureDir, minimumSeverity: "hint" }))
+  expect(hints.output.includes("Unused.vx"), 'minimumSeverity "hint": hint should print')
+  expect(hints.output.includes("6133"), "printed hint should be TS6133 (declared but never read)")
+}
+unlinkSync(unusedPath)
+
+console.log("\n6. shouldFail: failing-severity thresholds cascade...")
+{
+  const only = (kind, n) => ({ filesChecked: 1, errors: 0, warnings: 0, hints: 0, [kind]: n })
+  expect(shouldFail(only("errors", 1)) === true, "default: errors fail")
+  expect(shouldFail(only("warnings", 1)) === false, "default: warnings do not fail")
+  expect(shouldFail(only("warnings", 1), "warning") === true, '"warning": warnings fail')
+  expect(shouldFail(only("hints", 1), "warning") === false, '"warning": hints do not fail')
+  expect(shouldFail(only("hints", 1), "hint") === true, '"hint": hints fail')
+  expect(shouldFail(only("errors", 1), "hint") === true, '"hint": errors still fail')
+  expect(shouldFail(only("errors", 0), "hint") === false, '"hint": clean result passes')
 }
 
 ensureClean()

--- a/packages/core/test/check/integration.mjs
+++ b/packages/core/test/check/integration.mjs
@@ -8,13 +8,18 @@
  *   3. Remove the broken file → back to 0 errors.
  *   4. createChecker: ONE checker instance tracks create/update/delete via
  *      file events — the incremental loop `verrex-check --watch` runs on.
+ *      Includes: tsconfig edits re-parse the project; a failed stale-flush
+ *      (tsconfig briefly missing) rejects with a friendly error AND keeps
+ *      the staleness; the watch-facing topology API (config files, wildcard
+ *      dirs, tracked files).
  *   5. minimumSeverity: hint-severity diagnostics (TS suggestions) are
  *      counted but not printed by default; "hint" prints them.
  *   6. shouldFail: the failing-severity thresholds cascade.
+ *   7. A supplied-but-missing tsconfig rejects with a friendly error.
  *
  * No tsserver subprocess; the check tool is invoked in-process.
  */
-import { writeFileSync, readFileSync, unlinkSync, existsSync } from "node:fs"
+import { writeFileSync, readFileSync, unlinkSync, existsSync, renameSync } from "node:fs"
 import { dirname, join } from "node:path"
 import { fileURLToPath } from "node:url"
 import { createChecker, runCheck, shouldFail } from "../../src/check/index.ts"
@@ -51,8 +56,11 @@ const captureStdout = async (fn) => {
 }
 
 const unusedPath = join(fixtureDir, "Unused.vx")
+const fixtureTsconfigPath = join(fixtureDir, "tsconfig.json")
+const hiddenTsconfigPath = fixtureTsconfigPath + ".hidden"
 
 const ensureClean = () => {
+  if (existsSync(hiddenTsconfigPath)) renameSync(hiddenTsconfigPath, fixtureTsconfigPath)
   if (existsSync(brokenPath)) unlinkSync(brokenPath)
   if (existsSync(unusedPath)) unlinkSync(unusedPath)
 }
@@ -110,8 +118,8 @@ console.log("\n4. createChecker: one instance tracks file events incrementally..
     expect(edited.output.includes("Good.vx"), "after fileUpdated break: output should mention Good.vx")
   } finally {
     writeFileSync(goodPath, goodSource)
+    checker.fileUpdated(goodPath)
   }
-  checker.fileUpdated(goodPath)
   const restored = await captureStdout(() => checker.check())
   expect(restored.result.errors === 0, `after fileUpdated restore: expected 0 errors, got ${restored.result.errors}`)
   if (restored.result.errors !== 0) console.error("output was:\n" + restored.output)
@@ -152,8 +160,32 @@ console.log("\n4. createChecker: one instance tracks file events incrementally..
     )
   } finally {
     writeFileSync(tsconfigPath, tsconfigSource)
+    checker.fileUpdated(tsconfigPath)
   }
-  checker.fileUpdated(tsconfigPath)
+
+  // A failed stale-flush must KEEP the staleness: hide the tsconfig so the
+  // flush rejects (friendly error, not a TS-internals TypeError), restore it,
+  // and verify the next check() still sees the pending project change.
+  let rejection = null
+  try {
+    renameSync(fixtureTsconfigPath, hiddenTsconfigPath)
+    try {
+      await checker.check()
+    } catch (error) {
+      rejection = error
+    }
+  } finally {
+    renameSync(hiddenTsconfigPath, fixtureTsconfigPath)
+  }
+  expect(
+    rejection instanceof Error && /tsconfig not found at/.test(rejection.message),
+    `missing tsconfig mid-watch: friendly rejection, got: ${rejection && rejection.message}`,
+  )
+  const afterRestore = await captureStdout(() => checker.check())
+  expect(
+    afterRestore.result.errors >= 1,
+    `staleness survives a failed flush: expected Broken.vx's error, got ${afterRestore.result.errors}`,
+  )
 
   unlinkSync(brokenPath)
   checker.fileDeleted(brokenPath)
@@ -166,6 +198,17 @@ console.log("\n4. createChecker: one instance tracks file events incrementally..
 
   const cancelled = await captureStdout(() => checker.check({ cancel: () => true }))
   expect(cancelled.result.filesChecked === 0, "cancel before the first file: 0 files checked")
+
+  // Watch-facing project topology.
+  expect(checker.getConfigFilePaths().includes(fixtureTsconfigPath), "getConfigFilePaths includes the tsconfig")
+  expect(
+    checker.getWildcardDirectories().includes(fixtureDir),
+    "getWildcardDirectories includes the include-glob root",
+  )
+  expect(
+    checker.getTrackedFileNames().some((f) => f.endsWith("Good.vx")),
+    "getTrackedFileNames observed Good.vx",
+  )
 }
 
 console.log("\n5. minimumSeverity: hints counted but not printed by default...")
@@ -195,6 +238,20 @@ console.log("\n6. shouldFail: failing-severity thresholds cascade...")
   // Untyped JS callers passing a typo'd threshold must still fail on errors.
   expect(shouldFail(only("errors", 1), "bogus") === true, "unknown threshold: errors still fail")
   expect(shouldFail(only("warnings", 1), "bogus") === false, "unknown threshold: falls back to error level")
+}
+
+console.log("\n7. Supplied tsconfig that doesn't exist → friendly rejection...")
+{
+  let rejection = null
+  try {
+    await runCheck({ cwd: fixtureDir, tsconfig: "missing/tsconfig.json" })
+  } catch (error) {
+    rejection = error
+  }
+  expect(
+    rejection instanceof Error && /tsconfig not found at/.test(rejection.message),
+    `expected friendly 'tsconfig not found at' rejection, got: ${rejection && rejection.message}`,
+  )
 }
 
 ensureClean()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       '@volar/source-map':
         specifier: ^2.4.28
         version: 2.4.28
+      chokidar:
+        specifier: ^5.0.0
+        version: 5.0.0
       volar-service-typescript:
         specifier: ^0.0.71
         version: 0.0.71(@volar/language-service@2.4.28)
@@ -567,6 +570,10 @@ packages:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
+  chokidar@5.0.0:
+    resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
+    engines: {node: '>= 20.19.0'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
@@ -771,6 +778,10 @@ packages:
 
   pure-rand@8.4.0:
     resolution: {integrity: sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==}
+
+  readdirp@5.0.0:
+    resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
+    engines: {node: '>= 20.19.0'}
 
   rolldown@1.0.3:
     resolution: {integrity: sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==}
@@ -1323,6 +1334,10 @@ snapshots:
 
   chai@6.2.2: {}
 
+  chokidar@5.0.0:
+    dependencies:
+      readdirp: 5.0.0
+
   convert-source-map@2.0.0: {}
 
   debug@4.4.3:
@@ -1516,6 +1531,8 @@ snapshots:
       source-map-js: 1.2.1
 
   pure-rand@8.4.0: {}
+
+  readdirp@5.0.0: {}
 
   rolldown@1.0.3:
     dependencies:


### PR DESCRIPTION
Closes #78.

Implements the gaps the `cli.ts` TODO named, with `astro check` as the flag-semantics parity target.

## CLI

- **`--watch` / `-w`** — incremental re-check on change, one persistent checker per process. The watcher covers **where the program actually lives**, not just the invocation dir: the tsconfig's directory, every wildcard directory its include globs expand under, the config files themselves including the `extends` chain (a `tsconfig.base.json` edit re-parses options), and imported sources outside those trees added file-by-file (editing `packages/core/src/*` re-checks the demo, the way `tsc --watch` covers its program closure). Ignores match `node_modules`/`.git` by whole path segment; admitted extensions are the full checkable set (TS family + `.vx`), so a project's first file of a new kind still fires. Re-checks debounce 100ms with between-files cancellation; change/unlink events for files that were never in the program skip the pass. Watcher errors and failing passes (tsconfig briefly missing mid-checkout) report to stderr and the session keeps watching. The screen clear is TTY-gated, post-debounce, and only after a pass has printed; `--preserveWatchOutput` disables it.
- **`--minimumSeverity`** (`error`|`warning`|`hint`) gates what *prints*. Default `error` — a **deliberate divergence** from astro's `hint` default, so the bare invocation stays a drop-in for the `tsc --noEmit` flow it replaced (the AGENTS.md behavior contract).
- **`--minimumFailingSeverity`** gates the *exit code*, astro cascade semantics. Printing and failing are independent, with one guarantee: any nonzero count surfaces in the summary, so exit 1 never comes with output reading clean.
- **Colored summary line** — TTY- and `NO_COLOR`-aware. Per-diagnostic output was already colored upstream.
- Argv parsing via `node:util` `parseArgs`: unknown flags, missing values, and flag-like values (`--root --watch`) exit 2 with a precise message; `--help` wins over anything else on the line. A missing/unreadable tsconfig (including `-p=typo` spellings) is a friendly exit-2 error, not a TypeScript-internals stack. The one-shot path flushes stdout before exiting so piped output can't truncate.

## Programmatic API (`@verrex/core/check`)

- `createChecker(options) → VerrexChecker`: persistent, file-event-driven (`fileCreated`/`fileUpdated`/`fileDeleted`), plus the watch-facing topology — `tsconfigPath`, `getConfigFilePaths()` (extends chain), `getWildcardDirectories()`, `getTrackedFileNames()` (all program files seen, observed via a passive `getLanguageId` plugin — public Volar API only).
- `runCheck(options)` — one-shot, unchanged contract; `shouldFail(result, severity)` — exit-code policy with a safe fallback for untyped callers; `SEVERITIES`/`Severity` exported.
- `CheckResult` gains `hints`; everything below warning severity (LSP Information and Hint) counts there, matching the print ceiling so nothing can print yet be invisible to the exit code.

## Upstream caveat worked around

`fileUpdated` (every save — the hot path) is incremental via kit's project-version bump. But kit's root-file re-expansion is broken: its `getScriptFileNames` caches resolved names in a WeakMap keyed by a `ParsedCommandLine` it then mutates in place, so a re-parsed include glob is never observed (`@volar/kit` ≤ 2.4.28 and volar main). Create/delete/config events therefore mark the project stale; the next pass re-parses the config (milliseconds) and rebuilds the kit checker **only when the root set or options actually changed** — build-output churn (`vite build` writing `dist/`) rebuilds nothing, a parse failure keeps the staleness so the next flush retries. Documented in check AGENTS.md with a pointer for when upstream fixes it.

## Verification

- `test/check/integration.mjs`: 41 assertions — persistent checker driven by file events (edit/create/delete/tsconfig change), staleness surviving a failed flush, cancellation, severity print filtering, `shouldFail` cascade, friendly missing-tsconfig rejections, the topology API.
- `pnpm -r test` (206 + 31) and package typechecks green.
- Live `--watch` sessions against `apps/demo`: incremental re-checks with correct `.vx` positions, event bursts coalescing into one pass, `packages/core` and `tsconfig.base.json` edits firing re-checks, tsconfig deletion surviving with recovery on restore.

## Out of scope

- Library/CLI printing seam (diagnostics in `CheckResult` instead of stdout writes from the library): #99.
- `--minimumSeverity hint` surfaced a latent unused import in `apps/demo/src/channels.test-d.ts` — left alone deliberately, PR #88 touches that file.

New dependency: `chokidar ^5.0.0` (lazily imported — the one-shot CI path never loads it). `@verrex/core` now declares `engines: node >=20.19.0` (chokidar 5's floor).
