### PR TITLE
fix(demo): mobile layout — kill horizontal overflow, grow touch targets

### DIFF
--- a/apps/demo/index.html
+++ b/apps/demo/index.html
@@ -211,6 +211,9 @@
       }
 
       /* ─── Small screens & touch ────────────────────────────── */
+      /* No double-tap-to-zoom (the demo buttons invite rapid taps);
+         pinch-zoom still works, unlike viewport user-scalable=no. */
+      html { touch-action: manipulation; }
       @media (max-width: 480px) {
         body { padding: 1.5rem 1rem 3rem; }
         .hero h1 { font-size: 2.25rem; }

--- a/apps/demo/index.html
+++ b/apps/demo/index.html
@@ -70,8 +70,11 @@
         padding: 1.75rem 0;
         border-top: 1px solid var(--border);
       }
+      /* Single column on small screens. minmax(0, 1fr) — not plain 1fr,
+         whose auto minimum lets the white-space:pre code blocks force the
+         column (and the whole page) wider than the viewport. */
       @media (max-width: 820px) {
-        .tour { grid-template-columns: 1fr; gap: 1rem; }
+        .tour { grid-template-columns: minmax(0, 1fr); gap: 1rem; }
       }
       .tour-head { display: flex; align-items: baseline; gap: 0.6rem; }
       .step {
@@ -205,6 +208,25 @@
       .boundary-fallback .cause {
         margin: 0 0 0.7rem; font-size: 0.75rem; color: var(--muted);
         white-space: pre-wrap; word-break: break-word; max-height: 8rem; overflow: auto;
+      }
+
+      /* ─── Small screens & touch ────────────────────────────── */
+      @media (max-width: 480px) {
+        body { padding: 1.5rem 1rem 3rem; }
+        .hero h1 { font-size: 2.25rem; }
+        .tagline { font-size: 1rem; }
+        .how { padding: 1rem 1.1rem; }
+        .tour-demo { padding-inline: 0.9rem; }
+      }
+      @media (pointer: coarse) {
+        .counter button, .controls button, .catch-demo button,
+        .boundary-fallback button {
+          padding: 0.5rem 0.9rem;
+        }
+        .todos li .toggle, .todos li .remove {
+          padding: 0.35rem 0.6rem; min-width: 2.2rem;
+        }
+        .demo-refresh { padding: 0.35rem 0.7rem; }
       }
     </style>
   </head>


### PR DESCRIPTION
## Problem

On a phone (375px viewport) the demo page pans horizontally — document scroll width was **568px**. Every `.tour` section overflowed the right edge.

## Root cause

The `<=820px` media query collapses the tour grid to plain `1fr`. Plain `1fr` means `minmax(auto, 1fr)` — the column's *minimum* is the min-content of its children, and the `white-space: pre` code blocks have a huge min-content width. The desktop columns already used `minmax(0, …)`; the mobile override didn't.

## Fix

- `grid-template-columns: minmax(0, 1fr)` in the mobile query — code blocks now scroll inside their own `overflow-x: auto` boxes.
- `<=480px`: tighter body padding, smaller hero, slimmer demo-panel padding.
- `pointer: coarse`: larger padding on demo/todo/reset buttons (were 17–25px tall).

## Verification

Headless Chromium audit (375×812, iPhone UA, touch):
- before: doc scroll width 568px, 40+ elements past the viewport edge
- after: doc scroll width **375px**, zero overflowing elements; action buttons ≥27px tall
- desktop 1280px: two-column layout unchanged

Touches only `apps/demo/` → no package release.