### PR TITLE
fix(language): degrade to last good compile when mid-edit source won't parse

### DIFF
--- a/packages/core/src/check/AGENTS.md
+++ b/packages/core/src/check/AGENTS.md
@@ -160,8 +160,12 @@ LSP protocol.
 
 - **`@verrex/core/language`** — provides `createVerrexLanguagePlugin`. The CLI
   instantiates the plugin with `<URI>(uri => uri.fsPath)` because kit
-  uses `URI` as its script-id type. No registry is threaded: the kit
-  checker owns the virtual-code lifetime per `runCheck` call.
+  uses `URI` as its script-id type, and passes
+  `onTransformError: "throw"` — a checker must fail loudly on
+  unparseable source, never report against the editor-oriented
+  last-good fallback (the watch loop catches per-pass). No registry is
+  threaded: the kit checker owns the virtual-code lifetime per
+  `runCheck` call.
 - **`@volar/kit`** — `createTypeScriptChecker`,
   `createTypeScriptInferredChecker` (not currently used; would be
   needed for "no tsconfig" mode).

--- a/packages/core/src/check/index.ts
+++ b/packages/core/src/check/index.ts
@@ -157,7 +157,12 @@ export function createChecker(options: CheckOptions = {}): VerrexChecker {
   // owns the virtual-code lifetime per linter instance; we hold no
   // side-channel state of our own.
   const buildLinter = () => {
-    const languagePlugin = createVerrexLanguagePlugin<URI>((uri) => uri.fsPath)
+    // "throw" (not the editor default "recover"): a checker must fail loudly
+    // on unparseable source, never report against a stale last-good compile.
+    // The watch loop catches per-pass and keeps running.
+    const languagePlugin = createVerrexLanguagePlugin<URI>((uri) => uri.fsPath, {
+      onTransformError: "throw",
+    })
     const tsServices = createTypeScriptServices(ts)
     return kit.createTypeScriptChecker([trackingPlugin, languagePlugin], tsServices, tsconfigPath)
   }

--- a/packages/core/src/compiler/transform.ts
+++ b/packages/core/src/compiler/transform.ts
@@ -571,15 +571,18 @@ export const transformVerrex = (
 ): TransformResult => {
   const ast = parse(source, {
     ...PARSER_OPTIONS,
-    // The editor/language-service path (default) needs error recovery: it
+    // The editor/language-service path (default) wants error recovery: it
     // calls this on every keystroke over routinely-unparseable mid-edit
-    // source (`count.` with no property yet). Without recovery Babel throws →
-    // createVirtualCode propagates → Volar has no virtual code → tsserver
-    // returns the global scope for completions. With recovery Babel emits a
-    // partial AST and attaches errors to `ast.errors` (which we don't read —
-    // tsc surfaces the real errors). The build path passes `false` so a
-    // genuine syntax error throws loudly here instead of silently emitting a
-    // recovered/garbage module that the bundler would then ship.
+    // source. With recovery Babel emits a partial AST for RECOVERABLE errors
+    // and attaches them to `ast.errors` (which we don't read — tsc surfaces
+    // the real errors). But recovery is not a no-throw guarantee: Babel still
+    // hard-throws on fatal states, including the most common mid-edit ones
+    // (`count.` at EOF, an unterminated tag → "Unexpected token"). Callers
+    // that must survive those wrap this call — the language plugin degrades
+    // to the file's last good compile (`onTransformError: "recover"`). The
+    // build path passes `false` so a genuine syntax error throws loudly here
+    // instead of silently emitting a recovered/garbage module that the
+    // bundler would then ship.
     errorRecovery: options.errorRecovery ?? true,
     sourceFilename: filename,
   })

--- a/packages/core/src/language/AGENTS.md
+++ b/packages/core/src/language/AGENTS.md
@@ -175,13 +175,17 @@ picked by `options.onTransformError`:
 
 - **`"recover"`** (default — editor hosts, `@verrex/ts-plugin`): serve
   the file's **last good compile** with the current source text.
-  Cross-file types stay stable (exports don't flicker in dependents);
-  in-file features go slightly stale — the cached mappings refer to
-  the previous source, off by at most the edit delta, and Volar drops
-  lookups outside a mapped span (degraded, never corrupt). A file
-  that has never compiled falls back to an empty module
-  (`export {}`), keeping the script in the project with no false
-  claims.
+  Cross-file types stay stable (exports don't flicker in dependents).
+  The cached mappings refer to the *previous* source — every offset is
+  suspect by the edit delta — so they're served **completion-only**
+  (`FALLBACK_DATA`): completions/signature help stay live (the point
+  of surviving mid-edit states; cursor-anchored, transient UI), while
+  features that *decorate* positions (inlay hints, hover, semantic
+  tokens, diagnostics) or *write* at them (rename, format) are off —
+  a shifted hint renders inside the wrong token, a shifted rename
+  edits the wrong code. A file that has never compiled falls back to
+  an empty module (`export {}`), keeping the script in the project
+  with no false claims.
 - **`"throw"`** (batch hosts — `@verrex/core/check` passes this): a
   checker must fail loudly, never report against a stale compile.
   The check watch loop catches per-pass and keeps the session alive.

--- a/packages/core/src/language/AGENTS.md
+++ b/packages/core/src/language/AGENTS.md
@@ -183,9 +183,19 @@ picked by `options.onTransformError`:
   features that *decorate* positions (inlay hints, hover, semantic
   tokens, diagnostics) or *write* at them (rename, format) are off —
   a shifted hint renders inside the wrong token, a shifted rename
-  edits the wrong code. A file that has never compiled falls back to
-  an empty module (`export {}`), keeping the script in the project
-  with no false claims.
+  edits the wrong code. `jsxRanges` are **dropped, not served stale**:
+  `@verrex/ts-plugin` consumes them directly off the instance
+  (tag-pair highlights), bypassing the mapping gates entirely, so the
+  only safe stale value is none. Residual accepted risk: completion
+  is itself a write path (auto-import edits) — see `FALLBACK_DATA`'s
+  comment for why it stays on anyway. A file that has never compiled
+  falls back to an empty module (`export {}`), keeping the script in
+  the project with no false claims. The `lastGood` entry is evicted
+  via `disposeVirtualCode` when Volar drops the script, so a deleted
+  file's exports can't be resurrected for a recreated path. In
+  `"throw"` mode the error is rethrown with the file named — Babel's
+  message carries only line:col, and `verrex-check --watch` prints it
+  verbatim.
 - **`"throw"`** (batch hosts — `@verrex/core/check` passes this): a
   checker must fail loudly, never report against a stale compile.
   The check watch loop catches per-pass and keeps the session alive.

--- a/packages/core/src/language/AGENTS.md
+++ b/packages/core/src/language/AGENTS.md
@@ -17,7 +17,7 @@ certainly want to depend on this package rather than copy it.
 
 | File | Purpose |
 |---|---|
-| `language-plugin.ts` | `createVerrexLanguagePlugin<T>(asFileName)` factory. Builds the Volar `LanguagePlugin` with `getLanguageId`, `createVirtualCode`, and `typescript: { extraFileExtensions, getServiceScript }`. Returns each per-`.vx` `VerrexVirtualCode` to Volar, which owns and indexes it. Returns `LanguagePlugin<T, VerrexVirtualCode>` so consumers can rely on the concrete class type at the boundary. |
+| `language-plugin.ts` | `createVerrexLanguagePlugin<T>(asFileName, options?)` factory. Builds the Volar `LanguagePlugin` with `getLanguageId`, `createVirtualCode`, and `typescript: { extraFileExtensions, getServiceScript }`. Returns each per-`.vx` `VerrexVirtualCode` to Volar, which owns and indexes it. Returns `LanguagePlugin<T, VerrexVirtualCode>` so consumers can rely on the concrete class type at the boundary. `options.onTransformError` picks the parse-failure policy (see below). |
 | `source-map.ts` | `convertSourceMap` — thin translator from `@verrex/core/compiler`'s `CompilerMapping[]` to Volar's `Mapping<CodeInformation>[]`. Maps the compiler's `"user"` / `"h-call"` / `"punctuation"` kinds to Volar profiles. ~15 LOC of actual logic + the three profile objects. |
 | `virtual-code.ts` | `VerrexVirtualCode` class — implements Volar's `VirtualCode` interface so Volar and downstream consumers share one object per `.vx` file. Holds `source` / `compiled` / `mappings` / `jsxRanges` alongside Volar's `id` / `languageId` / `snapshot` / `embeddedCodes`. Volar owns the instance; consumers read it back via `language.scripts.get(id).generated.root`. |
 | `source-map.test.ts` | Vitest suite pinning `convertSourceMap`'s span-length passthrough and the user/h-call/punctuation profile assignments. |
@@ -155,7 +155,39 @@ Lifetime is Volar's concern: each tsserver session and each
 so two in-process `runCheck` calls never see each other's virtual
 codes. Re-compilation on edits, eviction of deleted files, and
 staleness are all handled by Volar's script lifecycle — this package
-holds no state that could drift.
+holds no *authoritative* state that could drift. (The one piece of
+plugin-internal state is the `lastGood` fallback cache described in
+the next section: per-file compile *outputs* used only when the
+current source won't parse, never an index of live objects.)
+
+## Transform errors: recover in editors, throw in batch
+
+`transformVerrex` hard-throws on source Babel can't parse — and
+despite `errorRecovery: true`, that includes the most common mid-edit
+states (`count.` at EOF, an unterminated tag → "Unexpected token").
+An editor host recompiles on every keystroke, so an escaping throw
+fails the tsserver request the user just made (surfaced by vtsls/
+VS Code as `-32603 ... SyntaxError` noise on every inlay-hint/
+completion call while the buffer is mid-edit).
+
+`createVirtualCode` therefore wraps the transform, with the policy
+picked by `options.onTransformError`:
+
+- **`"recover"`** (default — editor hosts, `@verrex/ts-plugin`): serve
+  the file's **last good compile** with the current source text.
+  Cross-file types stay stable (exports don't flicker in dependents);
+  in-file features go slightly stale — the cached mappings refer to
+  the previous source, off by at most the edit delta, and Volar drops
+  lookups outside a mapped span (degraded, never corrupt). A file
+  that has never compiled falls back to an empty module
+  (`export {}`), keeping the script in the project with no false
+  claims.
+- **`"throw"`** (batch hosts — `@verrex/core/check` passes this): a
+  checker must fail loudly, never report against a stale compile.
+  The check watch loop catches per-pass and keeps the session alive.
+
+Pinned by `language-plugin.test.ts` (last-good service, per-file
+isolation, recompile-on-fix, empty-module fallback, throw mode).
 
 ### Why read from Volar's context, not a threaded cache
 

--- a/packages/core/src/language/index.ts
+++ b/packages/core/src/language/index.ts
@@ -1,4 +1,8 @@
-export { createVerrexLanguagePlugin, type TypeScriptConfig } from "./language-plugin.ts"
+export {
+  createVerrexLanguagePlugin,
+  type TypeScriptConfig,
+  type VerrexLanguagePluginOptions,
+} from "./language-plugin.ts"
 export { convertSourceMap } from "./source-map.ts"
 export { VerrexVirtualCode } from "./virtual-code.ts"
 export type { JsxRange } from "@verrex/core/compiler"

--- a/packages/core/src/language/language-plugin.test.ts
+++ b/packages/core/src/language/language-plugin.test.ts
@@ -50,6 +50,19 @@ describe("createVerrexLanguagePlugin transform-error recovery", () => {
     expect(code.compiled).toContain("greeting")
     // The virtual code still carries the CURRENT (broken) source text.
     expect(code.source).toBe(BROKEN)
+    // jsxRanges are never served stale: the ts-plugin reads them directly
+    // off the instance (tag-pair highlights), bypassing the mapping gates.
+    expect(code.jsxRanges).toEqual([])
+  })
+
+  it("evicts the last-good entry when Volar disposes the script", () => {
+    const p = plugin()
+    const good = compile(p, "/a.vx", GOOD) as VerrexVirtualCode
+    p.disposeVirtualCode!("/a.vx", good)
+    const code = compile(p, "/a.vx", BROKEN) as VerrexVirtualCode
+    // A recreated path with unparseable content must not be served the dead
+    // file's exports.
+    expect(code.compiled).toBe("export {}\n")
   })
 
   it("degrades fallback mappings to completion-only", () => {
@@ -90,11 +103,13 @@ describe("createVerrexLanguagePlugin transform-error recovery", () => {
     expect(code.compiled).toBe("export {}\n")
   })
 
-  it('"throw" mode propagates, for batch hosts', () => {
+  it('"throw" mode propagates with the file named, for batch hosts', () => {
     const p = createVerrexLanguagePlugin<string>((scriptId) => scriptId, {
       onTransformError: "throw",
     })
     compile(p, "/a.vx", GOOD)
-    expect(() => compile(p, "/a.vx", BROKEN)).toThrow(/Unexpected token/)
+    // Babel's message carries only line:col; batch hosts print this verbatim,
+    // so the file must be named.
+    expect(() => compile(p, "/a.vx", BROKEN)).toThrow(/\/a\.vx: Unexpected token/)
   })
 })

--- a/packages/core/src/language/language-plugin.test.ts
+++ b/packages/core/src/language/language-plugin.test.ts
@@ -52,6 +52,26 @@ describe("createVerrexLanguagePlugin transform-error recovery", () => {
     expect(code.source).toBe(BROKEN)
   })
 
+  it("degrades fallback mappings to completion-only", () => {
+    const p = plugin()
+    const good = compile(p, "/a.vx", GOOD) as VerrexVirtualCode
+    expect(good.mappings.length).toBeGreaterThan(0)
+    const fallback = compile(p, "/a.vx", BROKEN) as VerrexVirtualCode
+    expect(fallback.mappings.length).toBe(good.mappings.length)
+    for (const mapping of fallback.mappings) {
+      // Stale offsets must not decorate (inlay hints, diagnostics) or write
+      // (rename, format); completions stay on — they're the point of
+      // surviving mid-edit states.
+      expect(mapping.data.completion).toBe(true)
+      expect(mapping.data.semantic).toBe(false)
+      expect(mapping.data.verification).toBe(false)
+      expect(mapping.data.navigation).toBe(false)
+      expect(mapping.data.format).toBe(false)
+    }
+    // The good compile's own mappings are untouched (no shared mutation).
+    expect(good.mappings.some((mapping) => mapping.data.semantic !== false)).toBe(true)
+  })
+
   it("recompiles fresh once the source parses again", () => {
     const p = plugin()
     compile(p, "/a.vx", GOOD)

--- a/packages/core/src/language/language-plugin.test.ts
+++ b/packages/core/src/language/language-plugin.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest"
+import type * as ts from "typescript"
+import { createVerrexLanguagePlugin } from "./language-plugin.ts"
+import { VerrexVirtualCode } from "./virtual-code.ts"
+
+/**
+ * The transform-error contract: editor hosts recompile on every keystroke
+ * over routinely-unparseable source, and Babel hard-throws on the common
+ * mid-edit states (`foo.` at EOF, an unterminated tag) even with
+ * errorRecovery. The plugin must absorb that — degrade to the file's last
+ * good compile (or an empty module), never let the throw reach tsserver —
+ * except in "throw" mode, where batch hosts (verrex-check) need the failure
+ * loud.
+ */
+
+const GOOD = `export const greeting: string = "hello"\n`
+const GOOD_V2 = `export const farewell: string = "bye"\n`
+// Unexpected EOF after `.` — fatal for Babel even with errorRecovery.
+const BROKEN = `export const greeting = something.\n`
+
+const snapshotOf = (text: string): ts.IScriptSnapshot => ({
+  getText: (start, end) => text.slice(start, end),
+  getLength: () => text.length,
+  getChangeRange: () => undefined,
+})
+
+const plugin = () => createVerrexLanguagePlugin<string>((scriptId) => scriptId)
+
+const compile = (p: ReturnType<typeof plugin>, fileName: string, source: string) =>
+  p.createVirtualCode!(fileName, "verrex", snapshotOf(source), { getAssociatedScript: () => undefined })
+
+describe("createVerrexLanguagePlugin transform-error recovery", () => {
+  it("compiles parseable source (sanity)", () => {
+    const code = compile(plugin(), "/a.vx", GOOD)
+    expect(code).toBeInstanceOf(VerrexVirtualCode)
+    expect((code as VerrexVirtualCode).compiled).toContain("greeting")
+  })
+
+  it("falls back to an empty module when the file never compiled", () => {
+    const code = compile(plugin(), "/a.vx", BROKEN) as VerrexVirtualCode
+    expect(code).toBeInstanceOf(VerrexVirtualCode)
+    expect(code.compiled).toBe("export {}\n")
+    expect(code.mappings).toEqual([])
+  })
+
+  it("serves the last good compile while the source is unparseable", () => {
+    const p = plugin()
+    compile(p, "/a.vx", GOOD)
+    const code = compile(p, "/a.vx", BROKEN) as VerrexVirtualCode
+    expect(code.compiled).toContain("greeting")
+    // The virtual code still carries the CURRENT (broken) source text.
+    expect(code.source).toBe(BROKEN)
+  })
+
+  it("recompiles fresh once the source parses again", () => {
+    const p = plugin()
+    compile(p, "/a.vx", GOOD)
+    compile(p, "/a.vx", BROKEN)
+    const code = compile(p, "/a.vx", GOOD_V2) as VerrexVirtualCode
+    expect(code.compiled).toContain("farewell")
+    // And the new compile becomes the fallback.
+    const again = compile(p, "/a.vx", BROKEN) as VerrexVirtualCode
+    expect(again.compiled).toContain("farewell")
+  })
+
+  it("keeps last-good compiles per file", () => {
+    const p = plugin()
+    compile(p, "/a.vx", GOOD)
+    const code = compile(p, "/b.vx", BROKEN) as VerrexVirtualCode
+    expect(code.compiled).toBe("export {}\n")
+  })
+
+  it('"throw" mode propagates, for batch hosts', () => {
+    const p = createVerrexLanguagePlugin<string>((scriptId) => scriptId, {
+      onTransformError: "throw",
+    })
+    compile(p, "/a.vx", GOOD)
+    expect(() => compile(p, "/a.vx", BROKEN)).toThrow(/Unexpected token/)
+  })
+})

--- a/packages/core/src/language/language-plugin.ts
+++ b/packages/core/src/language/language-plugin.ts
@@ -1,8 +1,28 @@
-import type { LanguagePlugin, VirtualCode } from "@volar/language-core"
+import type { CodeInformation, LanguagePlugin, VirtualCode } from "@volar/language-core"
 import type * as ts from "typescript"
 import { transformVerrex } from "@verrex/core/compiler"
 import { convertSourceMap } from "./source-map.ts"
 import { VerrexVirtualCode } from "./virtual-code.ts"
+
+// The capability profile for last-good fallback mappings. They refer to the
+// PREVIOUS source text, so every offset is suspect by the edit delta:
+// - completion stays on — completions/signature help are the whole point of
+//   keeping a language service alive mid-edit, are cursor-anchored, and a
+//   slightly-off result is transient UI;
+// - semantic (inlay hints, hover, semantic tokens) and verification
+//   (diagnostics) are off — they DECORATE positions, and a shifted hint
+//   renders inside the wrong token (a `: HttpError` hint chopping an
+//   identifier apart);
+// - navigation (rename!) and format are off — they WRITE at mapped offsets,
+//   and a stale offset would edit the wrong code.
+const FALLBACK_DATA: CodeInformation = {
+  verification: false,
+  completion: true,
+  semantic: false,
+  navigation: false,
+  structure: false,
+  format: false,
+}
 
 // Volar's typescript property type isn't in the public LanguagePlugin interface
 // but is expected by createLanguageServicePlugin
@@ -29,9 +49,9 @@ export interface VerrexLanguagePluginOptions {
    * just made (surfaced as `-32603 ... SyntaxError` noise in the editor).
    *
    * - `"recover"` (default — editor hosts): degrade to the file's last good
-   *   compile, so cross-file types stay stable and in-file features go
-   *   slightly stale until the source parses again; an empty module if the
-   *   file has never compiled.
+   *   compile served with completion-only mappings (see `FALLBACK_DATA`), so
+   *   cross-file types stay stable and completions keep working until the
+   *   source parses again; an empty module if the file has never compiled.
    * - `"throw"` (batch hosts: verrex-check): propagate, keeping failures
    *   loud — a checker must never silently report against stale output.
    */
@@ -89,10 +109,12 @@ export function createVerrexLanguagePlugin<T>(
         if (onTransformError === "throw") throw error
         const cached = lastGood.get(fileName)
         if (cached) {
-          // The cached mappings refer to the previous source text; mid-edit
-          // they're off by at most the edit delta, and Volar drops lookups
-          // that fall outside a mapped span — degraded, never corrupt.
-          return new VerrexVirtualCode(source, cached.compiled, [...cached.mappings], cached.jsxRanges)
+          // The cached mappings refer to the previous source text, so they're
+          // served with FALLBACK_DATA: completion-only (see above) — features
+          // that decorate or write at mapped positions stay off until the
+          // source parses again.
+          const mappings = cached.mappings.map((mapping) => ({ ...mapping, data: FALLBACK_DATA }))
+          return new VerrexVirtualCode(source, cached.compiled, mappings, cached.jsxRanges)
         }
         // Never compiled successfully (file created mid-edit): an empty
         // module keeps the script in the project with no false claims.

--- a/packages/core/src/language/language-plugin.ts
+++ b/packages/core/src/language/language-plugin.ts
@@ -20,14 +20,31 @@ export interface TypeScriptConfig {
   resolveHiddenExtensions?: boolean
 }
 
+export interface VerrexLanguagePluginOptions {
+  /**
+   * What to do when the compiler throws on unparseable source. Babel's
+   * `errorRecovery` absorbs most mid-edit states, but some token sequences
+   * are unrecoverable and throw — and an editor host recompiles on every
+   * keystroke, so a throw here fails the whole tsserver request the user
+   * just made (surfaced as `-32603 ... SyntaxError` noise in the editor).
+   *
+   * - `"recover"` (default — editor hosts): degrade to the file's last good
+   *   compile, so cross-file types stay stable and in-file features go
+   *   slightly stale until the source parses again; an empty module if the
+   *   file has never compiled.
+   * - `"throw"` (batch hosts: verrex-check): propagate, keeping failures
+   *   loud — a checker must never silently report against stale output.
+   */
+  readonly onTransformError?: "recover" | "throw"
+}
+
 /**
  * Build a Volar LanguagePlugin describing `.vx` files for a given Volar host.
  *
  * The factory takes `asFileName` because different Volar hosts identify scripts
  * differently: tsserver passes string paths, `@volar/kit` (used by verrex-check)
  * passes `URI` instances. Internally we always pass to the compiler by
- * file-path string, so the host-specific identity collapses here. This is the
- * plugin's only axis of variation.
+ * file-path string, so the host-specific identity collapses here.
  *
  * The `VerrexVirtualCode` instance returned from `createVirtualCode` is the one
  * Volar owns and indexes (`language.scripts.get(id).generated.root`). Downstream
@@ -38,7 +55,16 @@ export interface TypeScriptConfig {
  */
 export function createVerrexLanguagePlugin<T>(
   asFileName: (scriptId: T) => string,
+  options: VerrexLanguagePluginOptions = {},
 ): LanguagePlugin<T, VerrexVirtualCode> & { typescript: TypeScriptConfig } {
+  const onTransformError = options.onTransformError ?? "recover"
+  // Last successful compile per file, the "recover" fallback. Bounded by the
+  // project's .vx file count; entries are the size of the compiled output.
+  const lastGood = new Map<
+    string,
+    Pick<VerrexVirtualCode, "compiled" | "mappings" | "jsxRanges">
+  >()
+
   return {
     getLanguageId(scriptId) {
       if (asFileName(scriptId).endsWith(".vx")) {
@@ -54,9 +80,24 @@ export function createVerrexLanguagePlugin<T>(
 
       const fileName = asFileName(scriptId)
       const source = snapshot.getText(0, snapshot.getLength())
-      const result = transformVerrex(source, fileName)
-      const mappings = convertSourceMap(result.mappings)
-      return new VerrexVirtualCode(source, result.code, mappings, result.jsxRanges)
+      try {
+        const result = transformVerrex(source, fileName)
+        const mappings = convertSourceMap(result.mappings)
+        lastGood.set(fileName, { compiled: result.code, mappings, jsxRanges: result.jsxRanges })
+        return new VerrexVirtualCode(source, result.code, mappings, result.jsxRanges)
+      } catch (error) {
+        if (onTransformError === "throw") throw error
+        const cached = lastGood.get(fileName)
+        if (cached) {
+          // The cached mappings refer to the previous source text; mid-edit
+          // they're off by at most the edit delta, and Volar drops lookups
+          // that fall outside a mapped span — degraded, never corrupt.
+          return new VerrexVirtualCode(source, cached.compiled, [...cached.mappings], cached.jsxRanges)
+        }
+        // Never compiled successfully (file created mid-edit): an empty
+        // module keeps the script in the project with no false claims.
+        return new VerrexVirtualCode(source, "export {}\n", [], [])
+      }
     },
 
     typescript: {

--- a/packages/core/src/language/language-plugin.ts
+++ b/packages/core/src/language/language-plugin.ts
@@ -15,6 +15,12 @@ import { VerrexVirtualCode } from "./virtual-code.ts"
 //   identifier apart);
 // - navigation (rename!) and format are off — they WRITE at mapped offsets,
 //   and a stale offset would edit the wrong code.
+//
+// Residual risk, accepted: completion is itself a write path (auto-import
+// additionalTextEdits land at the import block's mapped offsets). Those
+// offsets only shift when the breaking edit sits ABOVE the imports — mid-edit
+// deltas almost always sit below them — and disabling completion would gut
+// the fallback's purpose.
 const FALLBACK_DATA: CodeInformation = {
   verification: false,
   completion: true,
@@ -79,11 +85,10 @@ export function createVerrexLanguagePlugin<T>(
 ): LanguagePlugin<T, VerrexVirtualCode> & { typescript: TypeScriptConfig } {
   const onTransformError = options.onTransformError ?? "recover"
   // Last successful compile per file, the "recover" fallback. Bounded by the
-  // project's .vx file count; entries are the size of the compiled output.
-  const lastGood = new Map<
-    string,
-    Pick<VerrexVirtualCode, "compiled" | "mappings" | "jsxRanges">
-  >()
+  // project's .vx file count (evicted via disposeVirtualCode); entries are
+  // the size of the compiled output. No jsxRanges: the fallback never serves
+  // them (see below).
+  const lastGood = new Map<string, Pick<VerrexVirtualCode, "compiled" | "mappings">>()
 
   return {
     getLanguageId(scriptId) {
@@ -103,23 +108,42 @@ export function createVerrexLanguagePlugin<T>(
       try {
         const result = transformVerrex(source, fileName)
         const mappings = convertSourceMap(result.mappings)
-        lastGood.set(fileName, { compiled: result.code, mappings, jsxRanges: result.jsxRanges })
+        lastGood.set(fileName, { compiled: result.code, mappings })
         return new VerrexVirtualCode(source, result.code, mappings, result.jsxRanges)
       } catch (error) {
-        if (onTransformError === "throw") throw error
+        if (onTransformError === "throw") {
+          // Babel's message carries only line:col — name the file for batch
+          // hosts (a multi-file `verrex-check --watch` pass reports this
+          // message verbatim).
+          throw new Error(
+            `${fileName}: ${error instanceof Error ? error.message : String(error)}`,
+            { cause: error },
+          )
+        }
         const cached = lastGood.get(fileName)
         if (cached) {
           // The cached mappings refer to the previous source text, so they're
           // served with FALLBACK_DATA: completion-only (see above) — features
           // that decorate or write at mapped positions stay off until the
-          // source parses again.
+          // source parses again. jsxRanges are dropped, not served stale:
+          // the ts-plugin consumes them directly off the instance (tag-pair
+          // highlights), bypassing the mapping gates, and shifted ranges
+          // would decorate the wrong tokens — the failure FALLBACK_DATA
+          // exists to prevent.
           const mappings = cached.mappings.map((mapping) => ({ ...mapping, data: FALLBACK_DATA }))
-          return new VerrexVirtualCode(source, cached.compiled, mappings, cached.jsxRanges)
+          return new VerrexVirtualCode(source, cached.compiled, mappings, [])
         }
         // Never compiled successfully (file created mid-edit): an empty
         // module keeps the script in the project with no false claims.
         return new VerrexVirtualCode(source, "export {}\n", [], [])
       }
+    },
+
+    // Volar calls this when a script is removed; without it the lastGood
+    // entry would outlive the file, and a path recreated with unparseable
+    // content would be served the dead file's exports as current.
+    disposeVirtualCode(scriptId) {
+      lastGood.delete(asFileName(scriptId))
     },
 
     typescript: {


### PR DESCRIPTION
## Behavior

`createVerrexLanguagePlugin` takes an `onTransformError` option deciding what happens when the compiler throws on unparseable `.vx` source:

- **`"recover"`** (default — editor hosts, what `@verrex/ts-plugin` gets): `createVirtualCode` serves the file's **last good compile** with the current source text, so cross-file types stay stable (no export flicker in dependents). Because the cached mappings refer to the *previous* source — every offset suspect by the edit delta — the fallback is **completion-only**: completions/signature help stay live (cursor-anchored, transient UI, the point of surviving mid-edit states), while features that *decorate* positions (inlay hints, hover, semantic tokens, diagnostics) or *write* at them (rename, format) are disabled until the source parses again. `jsxRanges` are dropped rather than served stale — the ts-plugin's tag-pair highlights read them directly off the instance, bypassing the mapping gates, so the only safe stale value is none. A file that has never compiled falls back to an empty module (`export {}`). The cache is evicted via `disposeVirtualCode` when Volar drops a script, so a deleted file's exports can't be resurrected for a recreated path.
- **`"throw"`** (batch hosts — `@verrex/core/check` passes this): the throw propagates **with the file named** (Babel's message carries only line:col, and `verrex-check --watch` prints it verbatim), so the checker fails loudly per pass instead of reporting against stale output.

Accepted residual, documented in code: completion is itself a write path (auto-import edits at mapped offsets), but those offsets only shift when the breaking edit sits above the import block, and disabling completion would gut the fallback's purpose.

## Why

Babel hard-throws on the most common mid-edit states (`count.` at EOF, an unterminated tag) **even with `errorRecovery: true`** — recovery only covers recoverable errors, not fatal token states. Editor hosts recompile on every keystroke, so the throw escaped `createVirtualCode` into tsserver and failed whatever request was in flight, surfacing in Neovim/vtsls as

```
vtsls: -32603: Request textDocument/inlayHint failed ... SyntaxError: Unexpected token (80:15)
```

on essentially every keystroke that left the buffer momentarily unparseable. The `transformVerrex` comment claiming errorRecovery prevented this was wrong and is corrected.

The capability restrictions exist because stale-offset decorations are visible garbage: a hint or tag-pair highlight mapped through the previous source's offsets renders inside the wrong token (a `: HttpError` type hint chopping an identifier apart mid-line), and a rename through stale offsets would edit the wrong code.

## Verification

- `language-plugin.test.ts` (8): last-good service, completion-only fallback profile (no mutation of the good compile's mappings), stale jsxRanges never served, per-file isolation, recompile-on-fix, empty-module fallback, disposal eviction, throw mode naming the file
- `pnpm -r test` (225 + 31, ts-plugin suite runs a real tsserver against the rebuilt bundle) and `pnpm -r typecheck` green
- AGENTS.md contracts updated (language: the recover/throw policy, the `FALLBACK_DATA` profile and its side-channel rules, the `lastGood` cache as the one piece of non-authoritative plugin state; check: why it passes `"throw"`)
