### PR TITLE
feat(compiler)!: lower component tags to direct calls — generics survive, Tag* folds die

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,7 +101,8 @@ Service plugins only by bare package name.
   `mount`, `Async`, `asyncRef` (returning `AsyncHandle`), `list`, `Catch`, the View IR (mount switches on it),
   reactivity wiring, channel-fold types. The thing components import from.
 - **[`src/compiler/`](./packages/core/src/compiler/AGENTS.md)** — export
-  `@verrex/core/compiler`. The Babel transform: JSX → `h()`, `.value` → `h.read()`,
+  `@verrex/core/compiler`. The Babel transform: intrinsic JSX → `h()`,
+  component tags → direct calls (`MyComp({...})`), `.value` → `h.read()`,
   `<expr>.value.map(arrow → JSX)` → `list(<expr>, arrow)`. Smart-skip wrap.
 - **[`src/language/`](./packages/core/src/language/AGENTS.md)** — export
   `@verrex/core/language`. The Volar `LanguagePlugin` describing `.vx` files (file id,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,8 +170,8 @@ Service plugins only by bare package name.
   single-prop signature is what makes `<Counter />`
   compile (h's tag-as-function path calls `tag(props)`); a propless
   component takes **no parameter at all** — the old
-  `_props: {} = {}` boilerplate is gone (a zero-param tag still
-  satisfies `h`, and `TagProps` folds it to the empty object;
+  `_props: {} = {}` boilerplate is gone (the compiler emits the
+  zero-arg call `Counter()` for an attr-less, child-less tag;
   pinned in `Component.test-d.ts`). A *generic* component uses the
   Effect-returning form
   (`Component.make(<T,>(props: { item: T }) => Effect.gen(…))`),

--- a/apps/demo/src/channels.test-d.ts
+++ b/apps/demo/src/channels.test-d.ts
@@ -82,20 +82,35 @@ const WithList = h("ul", {}, ids.map((id) => UserPage({ userId: id })))
 type WithListType = typeof WithList
 assertEquals<WithListType, Effect.Effect<View, HttpError, Http | Theme>>()
 
-// ─── <Component /> form: h(Component, props) carries the component's E/R ─
+// ─── <Component /> form: the compiler lowers component tags to DIRECT calls
+//     (#71) — `<UserPage userId="42"/>` is `UserPage({ userId: "42" })` in the
+//     emitted code, so the component's E/R is just the call's Effect type and
+//     folds into a surrounding h() as an ordinary child. (These direct calls
+//     ARE the compiled form of the JSX tags.)
 
-const CounterAsTag = h(Counter, {})
+const CounterAsTag = Counter()                      // <Counter />
 assertEquals<typeof CounterAsTag, Effect.Effect<View, never, never>>()
 
-const UserPageAsTag = h(UserPage, { userId: "42" })
+const UserPageAsTag = UserPage({ userId: "42" })    // <UserPage userId="42"/>
 assertEquals<typeof UserPageAsTag, Effect.Effect<View, HttpError, Http | Theme>>()
 
-// Tag E/R unions with child E/R
+// Component children union with the surrounding element's other children.
 const Mixed = h("div", {},
-  h(UserPage, { userId: "42" }),       // tag contributes HttpError + Http | Theme
-  h(Counter, {}),                       // contributes nothing
+  UserPage({ userId: "42" }),          // contributes HttpError + Http | Theme
+  Counter(),                            // contributes nothing
 )
 assertEquals<typeof Mixed, Effect.Effect<View, HttpError, Http | Theme>>()
+
+// ─── Generic components survive JSX tags (#71's acceptance) ─────────────
+//     Direct calls infer the type parameter natively — the old h()-mediated
+//     higher-rank erasure is gone.
+
+declare const GenericRow: <T>(props: { item: T; render: (item: T) => string }) =>
+  Effect.Effect<View, never, never>
+// <GenericRow item={42} render={n => n.toFixed(2)}/> — T pins to number;
+// `n.toFixed` compiles only because T survived.
+const RowCall = GenericRow({ item: 42, render: (n) => n.toFixed(2) })
+assertEquals<typeof RowCall, Effect.Effect<View, never, never>>()
 
 // ─── Event handlers on intrinsic elements get typed event arguments ─────
 
@@ -138,20 +153,23 @@ h("div", { "data-id": "x", "aria-hidden": "true", customX: 42 })
 
 // ─── Props are type-checked against the component's declared shape ───────
 
+// (the direct-call lowering means these errors point at UserPage's own
+// signature, not at h's conditional types)
+
 // @ts-expect-error — missing required prop `userId`
-const Missing = h(UserPage, {})
+const Missing = UserPage({})
 void Missing
 
 // @ts-expect-error — typo: `userid` is not in `{ userId: string }`
-const Typo = h(UserPage, { userid: "42" })
+const Typo = UserPage({ userid: "42" })
 void Typo
 
 // @ts-expect-error — wrong type: number not assignable to string
-const WrongType = h(UserPage, { userId: 42 })
+const WrongType = UserPage({ userId: 42 })
 void WrongType
 
 // @ts-expect-error — extra prop not declared on component
-const Extra = h(UserPage, { userId: "42", nope: true })
+const Extra = UserPage({ userId: "42", nope: true })
 void Extra
 
 // ─── Container parity: ChildE/ChildR must peel exactly what coerceAsync

--- a/apps/demo/src/main.vx
+++ b/apps/demo/src/main.vx
@@ -92,11 +92,15 @@ const App = (
           point is that <code>E</code>/<code>R</code> survive composition. So
           verrex never lets <code>tsc</code> see JSX: source files use a{" "}
           <code>.vx</code> extension, and <code>verrex/compiler</code> rewrites
-          every <code>{"<tag/>"}</code> into an <code>h(tag, props, …children)</code>{" "}
-          call <em>before</em> tsc parses the file. <code>h()</code>'s
-          conditional-type signature then unions every child's <code>E</code>{" "}
-          and <code>R</code> into the result. tsc only ever type-checks plain
-          function calls — so the channels can't be erased.
+          every intrinsic <code>{"<tag/>"}</code> into an{" "}
+          <code>h(tag, props, …children)</code> call and every component{" "}
+          <code>{"<MyComp/>"}</code> into the direct call{" "}
+          <code>{"MyComp({…})"}</code> <em>before</em> tsc parses the file.{" "}
+          <code>h()</code>'s conditional-type signature unions every child's{" "}
+          <code>E</code> and <code>R</code> into the result — a component's
+          channels are just its call's Effect type, and generic components keep
+          their type parameter. tsc only ever type-checks plain function calls
+          — so the channels can't be erased.
         </p>
         <p class="how-note">
           Every <code>inferred type</code> below is real, checked by{" "}

--- a/packages/core/src/compiler/AGENTS.md
+++ b/packages/core/src/compiler/AGENTS.md
@@ -3,10 +3,11 @@
 Single Babel transform. Takes `.vx` source (TypeScript with
 angle-bracket `<div>...</div>` syntax — JSX-shape only, no JSX
 semantics; see root [AGENTS.md](../../../../AGENTS.md)) and emits plain
-TypeScript with every `<...>` expression rewritten as an
-`h(tag, props, ...children)` call. The output contains zero angle
-brackets — they are gone before tsc, Vite, or any other downstream
-tool sees the file.
+TypeScript with every `<...>` expression rewritten as a call:
+intrinsic elements become `h(tag, props, ...children)`, component tags
+become DIRECT calls (`MyComp({ ...attrs, children: [...] })` — see
+"Tag dispatch"). The output contains zero angle brackets — they are
+gone before tsc, Vite, or any other downstream tool sees the file.
 
 Entry point: `transformVerrex(source, filename) → { code, map, jsxRanges, mappings }`.
 
@@ -197,11 +198,28 @@ identifier (no alias) are skipped to avoid duplicates.
 
 ## Tag dispatch
 
-- Lowercase identifier → string literal (`<div>` → `h("div", ...)`)
-- Uppercase identifier → identifier reference (`<Counter>` → `h(Counter, ...)`)
-- `JSXMemberExpression` → member expression (`<X.Y>` → `h(X.Y, ...)`)
-- `JSXNamespacedName` → string literal with `:` (`<svg:rect>`)
-- Fragment (`<>`) → `h(Fragment, {}, ...children)`
+- Lowercase identifier → intrinsic: `<div>` → `h("div", props, ...children)`
+- `JSXNamespacedName` → intrinsic: `<svg:rect>` → `h("svg:rect", ...)`
+- Uppercase identifier → DIRECT call (`isComponentTag`):
+  `<Counter/>` → `Counter()` (zero-arg when no attrs and no children, so
+  propless `function* ()` components typecheck);
+  `<Foo bar={1}>kid</Foo>` → `Foo({ bar: 1, children: [...] })`
+- `JSXMemberExpression` → direct call regardless of case
+  (`<X.Y>` → `X.Y({...})` — components by JSX convention)
+- Fragment (`<>`) → `Fragment({ children: [...] })` — `Fragment` is itself a
+  direct-call component (generic over the children tuple, coerces raw
+  children; see runtime AGENTS.md)
+
+The direct-call lowering (#71) is why generic components keep their type
+parameter at JSX call sites and why the `Tag*` fold families no longer
+exist — a component's channels are just its call's Effect type, folding
+into the surrounding `h()` as an ordinary child. Children pass RAW in the
+`children` array prop (coercion happens where the component embeds them);
+JSX children win over an explicit `children={...}` attr (React semantics
+— and a duplicate literal key would be a TS error in the emitted object).
+Consequence for imports: `h` is auto-imported per-emission (an intrinsic
+element, an `h.track` wrap, or an `h.read` rewrite) — a component-only
+file imports nothing.
 
 ## JSX text whitespace
 

--- a/packages/core/src/compiler/transform.test.ts
+++ b/packages/core/src/compiler/transform.test.ts
@@ -42,18 +42,18 @@ describe("JSX → h() rewrites", () => {
       .toMatch(/h\("div",\s*\{\s*\.\.\.props\s*\}\s*\)/)
   })
 
-  it("capitalized tag becomes identifier (component)", () => {
+  it("capitalized tag becomes a direct call (component lowering)", () => {
     expect(compile(`
       const x = <Foo bar={1} />
     `))
-      .toContain(`h(Foo, { bar: 1 })`)
+      .toContain(`Foo({ bar: 1 })`)
   })
 
   it("fragment <>...</> uses Fragment identifier", () => {
     expect(compile(`
       const x = <><span /><span /></>
     `))
-      .toContain(`h(Fragment, {}, h("span", {}), h("span", {}))`)
+      .toContain(`Fragment({ children: [h("span", {}), h("span", {})] })`)
   })
 
   it("nested JSX is recursively rewritten", () => {
@@ -129,7 +129,7 @@ describe("tracking-scope rewrites (h.track / h.read)", () => {
     const out = compile(`
       const x = <Row item={item} />
     `)
-    expect(out).toContain(`h(Row, { item: item })`)
+    expect(out).toContain(`Row({ item: item })`)
     expect(out).not.toContain(`h.track`)
   })
 
@@ -181,7 +181,7 @@ describe(".value.map(arrow → JSX) → list(...) rewrite", () => {
     `,
     )
     expect(out).toContain(`list(coll, item =>`)
-    expect(out).toContain(`h(Row, { item: item })`)
+    expect(out).toContain(`Row({ item: item })`)
   })
 
   it("does NOT wrap the rewritten call in h.track (no redundant reactivity)", () => {
@@ -211,7 +211,7 @@ describe(".value.map(arrow → JSX) → list(...) rewrite", () => {
     `,
     )
     expect(out).toContain(`list(coll,`)
-    expect(out).toContain(`h(Row, { item: item })`)
+    expect(out).toContain(`Row({ item: item })`)
   })
 
   it("supports JSX fragment as arrow body (direct and via block)", () => {
@@ -225,7 +225,7 @@ describe(".value.map(arrow → JSX) → list(...) rewrite", () => {
     `,
     )
     expect(direct).toContain(`list(coll,`)
-    expect(direct).toContain(`h(Fragment,`)
+    expect(direct).toContain(`Fragment({ children:`)
 
     const block = compile(
       `
@@ -233,7 +233,7 @@ describe(".value.map(arrow → JSX) → list(...) rewrite", () => {
     `,
     )
     expect(block).toContain(`list(coll,`)
-    expect(block).toContain(`h(Fragment,`)
+    expect(block).toContain(`Fragment({ children:`)
   })
 
   it("does NOT rewrite when the arrow body is not JSX (preserves Array.map / Collection.map)", () => {
@@ -812,5 +812,56 @@ describe("Component.make name injection", () => {
       const { x } = Component.make(fn)
     `)
     expect(out).toContain(`Component.make(fn)`)
+  })
+})
+
+describe("component-tag lowering (direct calls, #71)", () => {
+  it("no attrs, no children → zero-arg call (propless components stay callable)", () => {
+    expect(compile(`const x = <Counter />`)).toContain(`Counter()`)
+  })
+
+  it("children land as a `children` array prop", () => {
+    const out = compile(`const x = <Layout><span /\>hi</Layout>`)
+    expect(out).toContain(`Layout({ children: [h("span", {}), "hi"] })`)
+  })
+
+  it("attrs and children combine in one props object", () => {
+    const out = compile(`const x = <Layout pad={2}><span /></Layout>`)
+    expect(out).toContain(`Layout({ pad: 2, children: [h("span", {})] })`)
+  })
+
+  it("JSX children override an explicit children attr (React semantics)", () => {
+    const out = compile(`const x = <Layout children={old}><span /></Layout>`)
+    expect(out).not.toContain(`old`)
+    expect(out).toContain(`children: [h("span", {})]`)
+  })
+
+  it("member-expression tags lower to direct calls too", () => {
+    expect(compile(`const x = <UI.Button label="ok" />`)).toContain(`UI.Button({ label: "ok" })`)
+  })
+
+  it("spread attrs pass through into the props object", () => {
+    expect(compile(`const x = <Foo {...rest} />`)).toContain(`Foo({ ...rest })`)
+  })
+
+  it("a component-only file imports no `h` at all", () => {
+    const out = compile(`export const x = <Counter />`)
+    expect(out).not.toContain(`import`)
+  })
+
+  it("a fragment-only file imports Fragment but not h", () => {
+    const out = compile(`const x = <>{Counter()}</>`)
+    expect(out).toMatch(/import \{ Fragment \} from "@verrex\/core"/)
+    expect(out).not.toMatch(/\bh\b[^.]*from/)
+  })
+
+  it("intrinsics still route through h (and import it)", () => {
+    const out = compile(`const x = <div><Counter /></div>`)
+    expect(out).toContain(`h("div", {}, Counter())`)
+    expect(out).toMatch(/import \{ h \} from "@verrex\/core"/)
+  })
+
+  it("namespaced tags stay string-tagged through h", () => {
+    expect(compile(`const x = <svg:rect width="1" />`)).toContain(`h("svg:rect", { width: "1" })`)
   })
 })

--- a/packages/core/src/compiler/transform.test.ts
+++ b/packages/core/src/compiler/transform.test.ts
@@ -864,4 +864,9 @@ describe("component-tag lowering (direct calls, #71)", () => {
   it("namespaced tags stay string-tagged through h", () => {
     expect(compile(`const x = <svg:rect width="1" />`)).toContain(`h("svg:rect", { width: "1" })`)
   })
+
+  it("a spread child expands into the children array (component) and the call args (intrinsic)", () => {
+    expect(compile(`const x = <Foo>{...items}</Foo>`)).toContain(`Foo({ children: [...items] })`)
+    expect(compile(`const y = <div>{...items}</div>`)).toContain(`h("div", {}, ...items)`)
+  })
 })

--- a/packages/core/src/compiler/transform.ts
+++ b/packages/core/src/compiler/transform.ts
@@ -381,6 +381,14 @@ const copyLoc = <T extends t.Node>(target: T, source: t.Node): T => {
   return target
 }
 
+/**
+ * The single source of truth for the tag-dispatch rule: a lowercase first
+ * letter means intrinsic element. Used by `tagExpression` (string literal vs
+ * identifier) and `isComponentTag` (h() vs direct call) — keep it one
+ * predicate so the two can't drift.
+ */
+const isIntrinsicName = (name: string): boolean => /^[a-z]/.test(name)
+
 /** Decide the tag expression: lowercase → string literal, otherwise identifier. */
 const tagExpression = (name: t.JSXIdentifier | t.JSXMemberExpression | t.JSXNamespacedName): t.Expression => {
   if (t.isJSXNamespacedName(name)) {
@@ -391,7 +399,7 @@ const tagExpression = (name: t.JSXIdentifier | t.JSXMemberExpression | t.JSXName
     return jsxMemberToMember(name)
   }
   // JSXIdentifier - preserve location for go-to-definition
-  const lower = /^[a-z]/.test(name.name)
+  const lower = isIntrinsicName(name.name)
   const expr = lower ? t.stringLiteral(name.name) : t.identifier(name.name)
   return copyLoc(expr, name)
 }
@@ -437,7 +445,7 @@ const cleanJsxText = (value: string): string => {
 const transformChild = (
   child: t.JSXElement["children"][number],
   state: RewriteState,
-): t.Expression | null => {
+): t.Expression | t.SpreadElement | null => {
   if (t.isJSXText(child)) {
     const text = cleanJsxText(child.value)
     if (text === "") return null
@@ -449,8 +457,12 @@ const transformChild = (
       : wrapTracked(child.expression, state)
   }
   if (t.isJSXSpreadChild(child)) {
-    // Rare; treat as a passthrough spread.
-    return child.expression
+    // `{...items}` expands as individual children (JSX semantics): emit a
+    // real SpreadElement — valid both as an `h(...)` call argument and as a
+    // `children: [...]` array element. A bare passthrough would land the
+    // whole array as ONE child and pick up a redundant Fragment wrapper
+    // from coerceAsync's array peel.
+    return copyLoc(t.spreadElement(child.expression), child)
   }
   return transformJsxNode(child, state)
 }
@@ -549,7 +561,7 @@ const collectJsxRange = (node: t.JSXElement | t.JSXFragment): JsxRange => {
 const isComponentTag = (
   name: t.JSXIdentifier | t.JSXMemberExpression | t.JSXNamespacedName,
 ): boolean =>
-  t.isJSXMemberExpression(name) || (t.isJSXIdentifier(name) && !/^[a-z]/.test(name.name))
+  t.isJSXMemberExpression(name) || (t.isJSXIdentifier(name) && !isIntrinsicName(name.name))
 
 /**
  * Transform a JSX element or fragment node into its compiled call:
@@ -572,7 +584,7 @@ const transformJsxNode = (
   node: t.JSXElement | t.JSXFragment,
   state: RewriteState,
 ): t.CallExpression => {
-  const childArgs: t.Expression[] = []
+  const childArgs: Array<t.Expression | t.SpreadElement> = []
   for (const child of node.children) {
     const transformed = transformChild(child, state)
     if (transformed) childArgs.push(transformed)
@@ -710,13 +722,11 @@ export const transformVerrex = (
   // missing names there; otherwise prepends a new import. Keeps the user's
   // imports untouched and avoids duplicate specifiers. `h` is needed if the
   // JSX pass emitted `h(...)` OR pass 3 emitted any `h.read(...)`.
-  if (state.usedH || usedHRead || state.usedFragment || state.wroteList) {
-    const wanted = new Set<string>()
-    if (state.usedH || usedHRead) wanted.add("h")
-    if (state.usedFragment) wanted.add("Fragment")
-    if (state.wroteList) wanted.add("list")
-    ensureRuntimeImports(ast.program, wanted)
-  }
+  const wanted = new Set<string>()
+  if (state.usedH || usedHRead) wanted.add("h")
+  if (state.usedFragment) wanted.add("Fragment")
+  if (state.wroteList) wanted.add("list")
+  if (wanted.size > 0) ensureRuntimeImports(ast.program, wanted)
 
   const result = generate(
     ast,

--- a/packages/core/src/compiler/transform.ts
+++ b/packages/core/src/compiler/transform.ts
@@ -100,11 +100,16 @@ const attrName = (id: t.JSXIdentifier | t.JSXNamespacedName): t.Identifier | t.S
 
 /**
  * Per-call mutable state, threaded through every helper that may emit a
- * `list(...)` call. `transformVerrex` creates a fresh instance and reads
- * `wroteList` at the end to decide whether to auto-import `list`.
+ * runtime call. `transformVerrex` creates a fresh instance and reads the
+ * flags at the end to decide which runtime imports to auto-inject. `usedH`
+ * is per-emission (an intrinsic `h(...)`, an `h.track` wrap, or an
+ * `h.read` rewrite) — a file whose JSX is all component tags emits direct
+ * calls and needs no `h` at all.
  */
 interface RewriteState {
   wroteList: boolean
+  usedH: boolean
+  usedFragment: boolean
 }
 
 /**
@@ -146,6 +151,7 @@ const isSelfTrackingCall = (expr: t.Expression): boolean =>
 const wrapTracked = (expr: t.Expression, state: RewriteState): t.Expression => {
   const { expr: rewritten, rewroteRead } = rewriteTrackedExpression(expr, state)
   if (!rewroteRead) return rewritten
+  state.usedH = true // the rewrite emitted h.read (and below, possibly h.track)
   // Async / Catch self-track; the `.value`→`h.read` rewrite inside them is
   // kept, but the outer `h.track` wrap is skipped so their channels survive the fold.
   if (isSelfTrackingCall(rewritten)) return rewritten
@@ -532,25 +538,76 @@ const collectJsxRange = (node: t.JSXElement | t.JSXFragment): JsxRange => {
   }
 }
 
-/** Transform a JSX element or fragment node into an h(...) call expression. */
+/**
+ * True when the JSX tag names a component (the compiler lowers it to a
+ * direct call) rather than an intrinsic element (routed through `h`).
+ * Components are capitalized identifiers (`<MyComp/>` — same first-letter
+ * rule `tagExpression` uses) and member expressions (`<X.Y/>` — components
+ * by JSX convention regardless of case). Namespaced names (`<svg:rect/>`)
+ * are intrinsic.
+ */
+const isComponentTag = (
+  name: t.JSXIdentifier | t.JSXMemberExpression | t.JSXNamespacedName,
+): boolean =>
+  t.isJSXMemberExpression(name) || (t.isJSXIdentifier(name) && !/^[a-z]/.test(name.name))
+
+/**
+ * Transform a JSX element or fragment node into its compiled call:
+ *
+ *  - intrinsic element → `h("tag", props, ...children)` (unchanged)
+ *  - component tag     → direct call: `MyComp({ ...attrs, children: [...] })`,
+ *    `MyComp({ ...attrs })`, or `MyComp()` when there are no attrs and no
+ *    children (so zero-param components stay callable)
+ *  - fragment          → `Fragment({ children: [...] })` (Fragment is itself
+ *    a component since #71; it coerces the raw children)
+ *
+ * Direct calls are what let a generic component's type parameter infer at
+ * the call site, and what makes the component's channels fold as an
+ * ordinary Effect child of the surrounding `h()` — no `Tag*` fold types.
+ * JSX children always win over an explicit `children={...}` attr (React
+ * semantics; a duplicate key would also be a TS error in the emitted
+ * object literal).
+ */
 const transformJsxNode = (
   node: t.JSXElement | t.JSXFragment,
   state: RewriteState,
 ): t.CallExpression => {
-  const tag: t.Expression = t.isJSXFragment(node)
-    ? copyLoc(t.identifier("Fragment"), node)
-    : tagExpression(node.openingElement.name)
-
-  const props: t.Expression = t.isJSXFragment(node)
-    ? t.objectExpression([])
-    : buildProps(node.openingElement.attributes, state)
-
   const childArgs: t.Expression[] = []
   for (const child of node.children) {
     const transformed = transformChild(child, state)
     if (transformed) childArgs.push(transformed)
   }
 
+  const isFragment = t.isJSXFragment(node)
+  if (isFragment || isComponentTag(node.openingElement.name)) {
+    const callee: t.Expression = isFragment
+      ? copyLoc(t.identifier("Fragment"), node)
+      : tagExpression(node.openingElement.name)
+    if (isFragment) state.usedFragment = true
+
+    const props = isFragment
+      ? t.objectExpression([])
+      : (buildProps(node.openingElement.attributes, state) as t.ObjectExpression)
+    if (childArgs.length > 0) {
+      props.properties = props.properties.filter(
+        (p) =>
+          !(t.isObjectProperty(p) &&
+            (t.isIdentifier(p.key, { name: "children" }) ||
+              t.isStringLiteral(p.key, { value: "children" }))),
+      )
+      props.properties.push(
+        t.objectProperty(t.identifier("children"), t.arrayExpression(childArgs)),
+      )
+    }
+    // No attrs, no children → zero-arg call, so propless `function* ()`
+    // components typecheck. Fragment always takes its (required) props arg.
+    const args = !isFragment && props.properties.length === 0 ? [] : [props]
+    return copyLoc(t.callExpression(callee, args), node)
+  }
+
+  state.usedH = true
+  const tag = tagExpression(node.openingElement.name)
+  const props = buildProps(node.openingElement.attributes, state)
   // Preserve location on the h() call for source map accuracy
   const hCall = t.callExpression(t.identifier("h"), [tag, props, ...childArgs])
   return copyLoc(hCall, node)
@@ -602,18 +659,13 @@ export const transformVerrex = (
     },
   })
 
-  const state: RewriteState = { wroteList: false }
-  let usedH = false
-  let usedFragment = false
+  const state: RewriteState = { wroteList: false, usedH: false, usedFragment: false }
 
   traverse(ast, {
     JSXElement(path: NodePath<t.JSXElement>) {
-      usedH = true
       path.replaceWith(transformJsxNode(path.node, state))
     },
     JSXFragment(path: NodePath<t.JSXFragment>) {
-      usedH = true
-      usedFragment = true
       path.replaceWith(transformJsxNode(path.node, state))
     },
   })
@@ -658,9 +710,10 @@ export const transformVerrex = (
   // missing names there; otherwise prepends a new import. Keeps the user's
   // imports untouched and avoids duplicate specifiers. `h` is needed if the
   // JSX pass emitted `h(...)` OR pass 3 emitted any `h.read(...)`.
-  if (usedH || usedHRead) {
-    const wanted = new Set(["h"])
-    if (usedFragment) wanted.add("Fragment")
+  if (state.usedH || usedHRead || state.usedFragment || state.wroteList) {
+    const wanted = new Set<string>()
+    if (state.usedH || usedHRead) wanted.add("h")
+    if (state.usedFragment) wanted.add("Fragment")
     if (state.wroteList) wanted.add("list")
     ensureRuntimeImports(ast.program, wanted)
   }

--- a/packages/core/src/language/source-map.test.ts
+++ b/packages/core/src/language/source-map.test.ts
@@ -134,9 +134,9 @@ describe("convertSourceMap — span lengths", () => {
   it("list arrow body: the inner `<Row>` tag-name position still maps for go-to-def", () => {
     // The `.value.map → list(...)` rewrite uses `path.skip()` to halt the
     // inner traversal, but the outer JSX traversal still rewrites the inner
-    // `<Row>` to `h(Row, ...)`. The Row tag's nameStart in source must keep
-    // a mapping that lands inside the generated `h(Row,` so editor
-    // go-to-definition on Row inside the list arrow still resolves.
+    // `<Row>` to the direct call `Row({...})`. The Row tag's nameStart in
+    // source must keep a mapping that lands on the generated `Row` callee so
+    // editor go-to-definition on Row inside the list arrow still resolves.
     const src = `
       const Row = (props: { item: number }) => null
       const coll = { value: [] as number[] }
@@ -144,16 +144,16 @@ describe("convertSourceMap — span lengths", () => {
     `
     const { code, mappings } = buildMappings(src)
     expect(code).toContain("list(coll,")
-    expect(code).toContain("h(Row,")
+    expect(code).toContain("Row({")
     // Find the `R` of `<Row` in source (the tag name's start, +1 to skip `<`).
     const rowTagSrc = src.indexOf("<Row") + 1
-    // ...and the `R` of `h(Row,` in generated.
-    const rowGenStart = code.indexOf("h(Row,") + "h(".length
+    // ...and the `R` of the direct call `Row({` in generated.
+    const rowGenStart = code.indexOf("Row({")
     const m = findBySourceOffset(mappings, rowTagSrc)
     expect(m, "expected a mapping at source `Row` tag name").toBeDefined()
     expect(
       m!.generatedOffsets[0],
-      "source `Row` must map into generated `h(Row,` region",
+      "source `Row` must map into the generated `Row({` callee",
     ).toBeGreaterThanOrEqual(rowGenStart)
     expect(m!.generatedOffsets[0]).toBeLessThanOrEqual(rowGenStart + "Row".length)
   })
@@ -257,14 +257,14 @@ describe("convertSourceMap — structural cases", () => {
     expect(mappings.some((m) => m.sourceOffsets[0]! >= openSrc && m.sourceOffsets[0]! <= openSrc + 2)).toBe(true)
   })
 
-  it("member-expression tag: <X.Y>...</X.Y> emits h(X.Y, ...)", () => {
+  it("member-expression tag: <X.Y>...</X.Y> lowers to the direct call X.Y(...)", () => {
     const src = `
       import * as M from "./mod"
       const view = <M.X />
     `
     const { code, mappings } = buildMappings(src)
-    expect(code).toContain("h(M.X")
-    // The `M.X` source identifiers map into the h(M.X, ...) call.
+    expect(code).toContain("M.X(")
+    // The `M.X` source identifiers map into the M.X(...) call.
     const mSrc = src.indexOf("<M.X") + 1
     expect(mappings.some((m) => m.sourceOffsets[0] === mSrc)).toBe(true)
   })

--- a/packages/core/src/runtime/AGENTS.md
+++ b/packages/core/src/runtime/AGENTS.md
@@ -3,8 +3,9 @@
 What the user actually imports from when writing components.
 Public surface (from `index.ts`):
 
-- `h` — the view factory (the compile target for `<...>` source
-  syntax) + `h.track`/`h.read` (compiler hooks)
+- `h` — the view factory for INTRINSIC elements only (the compile target
+  for lowercase `<div>` source syntax; component tags lower to direct
+  calls since #71) + `h.track`/`h.read` (compiler hooks)
 - `Component` — `Component.make`, the canonical component constructor
   (a thin seam over `Effect.fn`; see "`Component.make`" below)
 - `mount` — DOM renderer. **Requires `Effect<View<never>, never, R>`** (every
@@ -12,17 +13,23 @@ Public surface (from `index.ts`):
 - `list` — keyed reactive list helper (`View.List` IR node)
 - `Async` / `asyncRef` / `AsyncHandle` — async render boundary + primitive returning `{ state, refetch }` (errors-as-values; see "`asyncRef` / `Async`" below)
 - `Catch` — view-level error boundary (one overloaded helper: function 2nd-arg = catch-all, object 2nd-arg = tag-selective; mirrors `Effect.catch*`; see "`Catch`" below)
-- `Fragment` — `<>...</>` compile target
+- `Fragment` — `<>...</>` compile target (a direct-call component since
+  #71: `Fragment({ children: [...] })`, generic over the children tuple —
+  also the canonical pattern for effectful-children components)
 - `VerrexLive` — base Layer providing `AtomRegistry`
-- Types: `View<E>`, `Props`, `FoldE`/`FoldLiveE`/`FoldR`/`TagE`/`TagLiveE`/`TagR`/`TagProps`,
+- Types: `View<E>`, `Props`, `FoldE`/`FoldLiveE`/`FoldR` (the `Tag*`
+  families died with #71 — component channels are ordinary child folds),
   `IntrinsicProps`, `HtmlEventHandlers`
 
 This is where the **channel propagation contract lives** —
 `h()`'s signature uses the fold conditional types to union every child's
 channels into the result. Errors split by phase: **construction** errors
-(`FoldE`/`TagE`) ride the result Effect's `E`; **live** errors a rendered
-subtree can still produce (`FoldLiveE`/`TagLiveE`) ride the `View<E>` success.
-`R` unifies (`FoldR`/`TagR`). `mount` requires both error channels `never`;
+(`FoldE`) ride the result Effect's `E`; **live** errors a rendered
+subtree can still produce (`FoldLiveE`) ride the `View<E>` success.
+`R` unifies (`FoldR`). A component tag is not a fold case of its own:
+the compiler lowers `<MyComp/>` to the direct call `MyComp({...})`, so a
+component's channels surface as an ordinary Effect child of the
+surrounding `h()`. `mount` requires both error channels `never`;
 `Catch` discharges them. A forgotten boundary is a compile error that
 names the error — the runtime counterpart of a forgotten Layer naming a
 service. See [`types/Fold.ts`](./types/Fold.ts).
@@ -49,7 +56,7 @@ the editor margin. If you rename them, update the regex.
 | `index.ts` | Public exports + `list`, `Async`, `asyncRef`, `Catch` (overloaded catch-all + tag-selective, over an internal `makeBoundary`), `Fragment`, `VerrexLive` |
 | `coerce.test.ts` | Vitest suite for `coerceAsync` / `coerceSync` (parity + the sync/async asymmetry pin) |
 | `reconcile.test.ts` | Pure diff tests — an apply-to-array oracle (plan turns `prev` into `next`) plus exact op-sequence pins (move-minimality matches the old single-pass; index updates on shift) |
-| `types/Fold.ts` | `ChildE`/`ChildLiveE`/`ChildR` + `FoldE`/`FoldLiveE`/`FoldR` + `TagE`/`TagLiveE`/`TagR`/`TagProps` — the channel-fold conditional types. Two error families: construction (`*E`, Effect channel) vs live (`*LiveE`, `View<E>` channel) |
+| `types/Fold.ts` | `ChildE`/`ChildLiveE`/`ChildR` + `FoldE`/`FoldLiveE`/`FoldR` — the channel-fold conditional types. Two error families: construction (`*E`, Effect channel) vs live (`*LiveE`, `View<E>` channel). No `Tag*` family since #71 (component tags are direct calls) |
 | `types/Html.ts` | `IntrinsicProps`/`HtmlEventHandlers` — typed event handlers for HTML intrinsics |
 | `types/Fold.test-d.ts` | `assertEquals` matrix — every channel-fold shape |
 
@@ -652,33 +659,45 @@ typically) and keep it alive for the lifetime of the rendered UI.
 
 ## Known limits
 
-### Generic components don't survive JSX call sites
+### Generic components DO survive JSX tags (since #71) — one caveat
 
-A component declared as `<T>(props: {item: T}) => Effect<View, …>`
-loses its `T` when called as `<MyComp item={x} />` — the same
-higher-rank polymorphism limit React/Solid hit. `h()`'s outer
-generics infer once per call site and can't carry a component's
-inner type parameter through.
+Component tags lower to direct calls (`<Row item={x}/>` →
+`Row({ item: x })`), so a generic component's `T` infers natively at
+the call site — the old h()-mediated higher-rank erasure is gone, and
+`list()` is no longer a generics workaround (it remains the keyed
+reconciliation primitive; the compiler still rewrites
+`{coll.value.map(item => <Row/>)}` into `list(coll, …)`).
 
-**Workaround.** Keep generics on a regular function whose call
-site preserves `T`, and accept a function child instead of a JSX
-`<MyComp<T>>` tag. `list(coll, render)` is the canonical shape:
+The caveat: a **tracked attr** still erases. An attr value containing a
+`.value` read gets wrapped in `h.track(() => …)`, whose return type is
+`unknown` — so `<Row item={ref.value}/>` passes `item: unknown`. Static
+attrs pass through untouched (the empty-deps early return in `h.track`
+is what preserves them). Same trade-off as before #71, now scoped to
+reactive attrs only.
+
+Don't "fix" anything here by widening `h()`'s signature — `h` is
+intrinsic-only since #71 and the narrow signature is what makes child
+folding work (see the root [AGENTS.md](../../../../AGENTS.md)
+anti-pattern about pluggable JSX backends).
+
+### Children-accepting components: be generic, never `Child[]`
+
+A component that accepts arbitrary effectful children declares a
+GENERIC children tuple and folds it (Fragment in `index.ts` is the
+canonical implementation):
 
 ```ts
-list<T>(coll: AtomRef.Collection<T>, render: (item: AtomRef.AtomRef<T>, i: AtomRef.ReadonlyRef<number>) => …)
+const Layout = Component.make(<Cs extends ReadonlyArray<unknown>>(
+  props: { readonly children?: Cs },
+) => … /* embed {props.children}; folds Fold*<Cs> */)
 ```
 
-Users normally never write `list()` by hand — the compiler rewrites
-`{coll.value.map(item => <Row item={item} />)}` in JSX expression
-position into this call. The function is exported and stable so the
-generated code has something to link to (and so escape hatches like
-"call `list` from non-JSX code" stay possible).
-
-Don't "fix" generic erasure by widening `h()`'s signature — see the
-root [AGENTS.md](../../../../AGENTS.md) anti-pattern about pluggable JSX
-backends. The narrow `h()` signature is what makes channel folding
-work; carrying a component's inner generic would require
-higher-rank polymorphism TS doesn't have.
+Direct calls make the inference precise. Typing the prop as the
+non-generic `Child[]` is an anti-pattern: `Child` includes
+`Effect<View, any, any>`, and folding `any` poisons `E` — an `any`
+error channel is assignable to `never`, which silently defeats the
+`mount` gate. Children arrive RAW (any child shape `h` accepts) and
+coerce where embedded.
 
 ### `h.read` overload preserves arbitrary `.value` types
 

--- a/packages/core/src/runtime/Component.test-d.ts
+++ b/packages/core/src/runtime/Component.test-d.ts
@@ -11,7 +11,6 @@ import { Effect } from "effect"
 import * as Component from "./Component.ts"
 import { h } from "./h.ts"
 import type { View } from "./View.ts"
-import type { TagE, TagProps, TagR } from "./types/Fold.ts"
 
 // Test fixtures
 interface HttpService { readonly _tag: "HttpService" }
@@ -38,20 +37,17 @@ const Live = Component.make(liveBody, "Live")
 assertEquals<ReturnType<typeof Live>, Effect.Effect<View<HttpError>, never, never>>()
 
 // 2) A propless component needs NO props parameter at all — `function* ()`
-//    is the idiom; the `_props: {} = {}` boilerplate is gone. The zero-param
-//    shape stays directly callable AND usable as an h() tag (`<Counter />`
-//    compiles to `h(Counter, {})`): `TagProps` of a zero-param tag folds to
-//    the empty object, and the Tag* channel folds still extract.
+//    is the idiom; the `_props: {} = {}` boilerplate is gone. `<Counter />`
+//    compiles to the direct call `Counter()` (#71), and the component's
+//    channels fold into a surrounding `h()` as an ordinary Effect child.
 declare const counterBody: () => Generator<never, View, never>
 const Counter = Component.make(counterBody, "Counter")
 const _noArgs: Effect.Effect<View, never, never> = Counter()
-const _asTag = h(Counter, {})
-assertEquals<typeof _asTag, Effect.Effect<View<never>, never, never>>()
+const _inTree = h("div", {}, Counter())
+assertEquals<typeof _inTree, Effect.Effect<View<never>, never, never>>()
 
 declare const ProplessFailing: () => Effect.Effect<View, HttpError, HttpService>
-assertEquals<TagE<typeof ProplessFailing>, HttpError>()
-assertEquals<TagR<typeof ProplessFailing>, HttpService>()
-const _proplessFolded = h("div", {}, h(ProplessFailing, {}))
+const _proplessFolded = h("div", {}, ProplessFailing())
 assertEquals<typeof _proplessFolded, Effect.Effect<View<never>, HttpError, HttpService>>()
 
 // 3) A GENERIC Effect-returning component typechecks through the wrapper with
@@ -65,8 +61,11 @@ const Row = Component.make(
 const _rowCall = Row({ item: 1, render: (n) => n.toFixed(2) })
 assertEquals<typeof _rowCall, Effect.Effect<View, never, never>>()
 
-// 4) A made component still drives the Tag* folds when used as an h() tag.
-assertEquals<TagE<typeof Gen>, HttpError>()
-assertEquals<TagR<typeof Gen>, HttpService>()
-assertEquals<TagProps<typeof Gen>, { id: string }>()
+// 4) A made component composes as a child: its construction E/R and the live
+//    E riding its View success fold through the surrounding h() (FoldE /
+//    FoldLiveE / FoldR — no Tag* family since #71's direct-call lowering).
+const _genInTree = h("section", {}, Gen({ id: "1" }))
+assertEquals<typeof _genInTree, Effect.Effect<View<never>, HttpError, HttpService>>()
+const _liveInTree = h("section", {}, Live({ id: "1" }))
+assertEquals<typeof _liveInTree, Effect.Effect<View<HttpError>, never, never>>()
 

--- a/packages/core/src/runtime/Component.ts
+++ b/packages/core/src/runtime/Component.ts
@@ -42,9 +42,9 @@ type GenR<Eff> = [Eff] extends [never] ? never
  * left out until that issue proves the need.)
  *
  * The body takes at most one props object. A propless component takes no
- * parameter at all (`function* ()`): a zero-param function still satisfies
- * `h`'s tag position, and `TagProps` folds it to the empty object — no
- * `_props: {} = {}` boilerplate.
+ * parameter at all (`function* ()`): the compiler emits the zero-arg call
+ * `Counter()` for an attr-less, child-less tag — no `_props: {} = {}`
+ * boilerplate.
  *
  * ```tsx
  * export const Counter = Component.make(function* () {

--- a/packages/core/src/runtime/h.test.ts
+++ b/packages/core/src/runtime/h.test.ts
@@ -52,3 +52,11 @@ describe("h.read — non-AtomRef branch (faithful .value)", () => {
     expect(() => readUnsafe(undefined)).toThrow()
   })
 })
+
+describe("h() rejects function tags (post-#71 migration guard)", () => {
+  it("throws a TypeError naming the direct-call migration", () => {
+    const fakeComponent = () => "not a real component"
+    expect(() => (h as unknown as (...args: ReadonlyArray<unknown>) => unknown)(fakeComponent, {}))
+      .toThrowError(/direct calls since #71/)
+  })
+})

--- a/packages/core/src/runtime/h.ts
+++ b/packages/core/src/runtime/h.ts
@@ -1,7 +1,8 @@
 import { Effect } from "effect"
 import { AtomRef } from "effect/unstable/reactivity"
 import { coerceAsync, isAtomRef, recordDep, trackDeps } from "./coerce.ts"
-import type { FoldE, FoldLiveE, FoldR, TagE, TagLiveE, TagProps, TagR } from "./types/Fold.ts"
+import type { FoldE, FoldLiveE, FoldR } from "./types/Fold.ts"
+import type { IntrinsicProps } from "./types/Html.ts"
 import { type Props, View } from "./View.ts"
 
 // ─── Tracking scope for h.track / h.read ─────────────────────────────────
@@ -62,16 +63,19 @@ function readImpl(obj: unknown): unknown {
 }
 
 /**
- * The view factory.
+ * The view factory — **intrinsic elements only** since #71. Component tags
+ * (`<MyComp/>`) are lowered by the compiler to direct calls
+ * (`MyComp({...})`), so a component's channels surface as an ordinary
+ * Effect child of the surrounding `h()` — no tag-fold machinery.
  *
- * Takes a tag (intrinsic element name or a component function) and any
- * number of children. The return type carries the union of every child's
- * `E` and `R` channels via `FoldE`/`FoldR`. Children of arbitrary shape
- * (Effect, Option, Result, Atom, AtomRef, Array, Chunk, primitive) are
- * normalized via `coerceAsync` in `./coerce.ts`.
+ * Takes an intrinsic tag name and any number of children. The return type
+ * carries the union of every child's `E` and `R` channels via
+ * `FoldE`/`FoldR`. Children of arbitrary shape (Effect, Option, Result,
+ * Atom, AtomRef, Array, Chunk, primitive) are normalized via `coerceAsync`
+ * in `./coerce.ts`.
  */
 const _h = (
-  tag: string | ((props: Props) => Effect.Effect<View<any>, any, any>),
+  tag: string,
   props: Props,
   ...children: ReadonlyArray<unknown>
 ): Effect.Effect<View<any>, any, any> =>
@@ -80,30 +84,19 @@ const _h = (
     for (const c of children) {
       out.push(yield* coerceAsync(c))
     }
-    if (typeof tag === "function") {
-      // Component: pass props (children threaded as a prop)
-      return yield* tag({ ...props, children: out })
-    }
     return View.Element({ tag, props, children: out })
   })
 
 // Errors split by phase across the two channels: CONSTRUCTION errors
-// (`FoldE`/`TagE`) on the Effect `E` (a child's build failing fails this build),
-// LIVE errors (`FoldLiveE`/`TagLiveE`) on the `View<E>` success (errors the
+// (`FoldE`) on the Effect `E` (a child's build failing fails this build),
+// LIVE errors (`FoldLiveE`) on the `View<E>` success (errors the
 // rendered subtree can still produce). `mount` requires both `never`;
 // `Catch` discharges both. The position encodes the phase.
-type HFn = <
-  T extends string | ((props: any) => Effect.Effect<View<any>, any, any>),
-  Cs extends readonly unknown[],
->(
-  _tag: T,
-  _props: TagProps<T>,
+type HFn = <Cs extends readonly unknown[]>(
+  _tag: string,
+  _props: IntrinsicProps,
   ..._children: Cs
-) => Effect.Effect<
-  View<FoldLiveE<Cs> | TagLiveE<T>>,
-  FoldE<Cs> | TagE<T>,
-  FoldR<Cs> | TagR<T>
->
+) => Effect.Effect<View<FoldLiveE<Cs>>, FoldE<Cs>, FoldR<Cs>>
 
 /**
  * The view factory, plus two helper methods the compiler calls into:

--- a/packages/core/src/runtime/h.ts
+++ b/packages/core/src/runtime/h.ts
@@ -78,14 +78,25 @@ const _h = (
   tag: string,
   props: Props,
   ...children: ReadonlyArray<unknown>
-): Effect.Effect<View<any>, any, any> =>
-  Effect.gen(function* () {
+): Effect.Effect<View<any>, any, any> => {
+  // Stale pre-#71 compiled output (a bundler cache, a version-skewed
+  // artifact) still calls h(Component, props). Without this guard it builds
+  // View.Element({ tag: fn }) and dies much later in mount with a cryptic
+  // createElement DOMException — fail loud at the call instead.
+  if (typeof (tag as unknown) === "function") {
+    throw new TypeError(
+      "h() takes intrinsic tag names only — component tags compile to direct calls since #71. " +
+        "A function tag means stale compiled output: clear the bundler cache and recompile the .vx sources.",
+    )
+  }
+  return Effect.gen(function* () {
     const out: View<any>[] = []
     for (const c of children) {
       out.push(yield* coerceAsync(c))
     }
     return View.Element({ tag, props, children: out })
   })
+}
 
 // Errors split by phase across the two channels: CONSTRUCTION errors
 // (`FoldE`) on the Effect `E` (a child's build failing fails this build),

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -1,6 +1,7 @@
 import { Cause, Effect, Exit, Fiber, Layer, Option, Queue, Scope, type Types } from "effect"
 import { AsyncResult, AtomRef, AtomRegistry } from "effect/unstable/reactivity"
-import { type ErrorSink, isAtomRef, trackDeps } from "./coerce.ts"
+import { coerceAsync, type ErrorSink, isAtomRef, trackDeps } from "./coerce.ts"
+import type { FoldE, FoldLiveE, FoldR } from "./types/Fold.ts"
 import { type BoundaryState, type Props, View } from "./View.ts"
 
 export * as Component from "./Component.ts"
@@ -16,10 +17,6 @@ export type {
   FoldE,
   FoldLiveE,
   FoldR,
-  TagE,
-  TagLiveE,
-  TagProps,
-  TagR,
 } from "./types/Fold.ts"
 export type { HtmlEventHandlers, IntrinsicProps } from "./types/Html.ts"
 
@@ -638,13 +635,26 @@ export function Catch(
 /**
  * Fragment component — the compile target for JSX `<>...</>` syntax.
  *
- * `h(Fragment, props, ...children)` evaluates to a `View.Fragment` whose
- * children are whatever was nested inside.
+ * `<>...</>` lowers to the direct call `Fragment({ children: [...] })`
+ * (component tags don't route through `h` since #71). Children arrive RAW —
+ * any child shape `h` accepts — and are coerced here exactly as `h` coerces
+ * its variadic children.
+ *
+ * Fragment is also the canonical pattern for a component that accepts
+ * arbitrary effectful children: generic over the children TUPLE, folding its
+ * channels with `FoldE`/`FoldLiveE`/`FoldR`. Inference happens at the direct
+ * call site, so the folds are precise. Do NOT type such a prop as the
+ * non-generic `Child[]` — `Child` includes `Effect<View, any, any>`, and
+ * folding `any` poisons the channel (an `any` E defeats the `mount` gate).
  */
-export const Fragment = (
-  props: Props & { children?: ReadonlyArray<View> },
-): Effect.Effect<View, never, never> =>
-  Effect.succeed(View.Fragment({ children: props.children ?? [] }))
+export const Fragment = <Cs extends ReadonlyArray<unknown>>(
+  props: { readonly children?: Cs },
+): Effect.Effect<View<FoldLiveE<Cs>>, FoldE<Cs>, FoldR<Cs>> =>
+  Effect.gen(function* () {
+    const out: View<any>[] = []
+    for (const c of props.children ?? []) out.push(yield* coerceAsync(c))
+    return View.Fragment({ children: out })
+  }) as Effect.Effect<View<FoldLiveE<Cs>>, FoldE<Cs>, FoldR<Cs>>
 
 /**
  * The base Layer every verrex app needs. Provides the `AtomRegistry` so any

--- a/packages/core/src/runtime/types/Fold.test-d.ts
+++ b/packages/core/src/runtime/types/Fold.test-d.ts
@@ -7,7 +7,7 @@
  */
 import type { Effect } from "effect"
 import type { Atom, AtomRef } from "effect/unstable/reactivity"
-import type { ChildE, ChildLiveE, ChildR, FoldE, FoldLiveE, FoldR, TagE, TagLiveE, TagR } from "./Fold.ts"
+import type { ChildE, ChildLiveE, ChildR, FoldE, FoldLiveE, FoldR } from "./Fold.ts"
 import type { View } from "../View.ts"
 
 // Test fixtures
@@ -87,8 +87,3 @@ assertEquals<FoldLiveE<readonly [ViewErr, EffLive]>, HttpError>()
 assertEquals<ChildLiveE<View>, never>()
 assertEquals<ChildE<View>, never>()
 
-// 14) Component tag: construction E vs live View<E> split, R folds.
-type Comp = (props: {}) => Effect.Effect<View<HttpError>, NotFound, DbService>
-assertEquals<TagE<Comp>, NotFound>()
-assertEquals<TagLiveE<Comp>, HttpError>()
-assertEquals<TagR<Comp>, DbService>()

--- a/packages/core/src/runtime/types/Fold.ts
+++ b/packages/core/src/runtime/types/Fold.ts
@@ -1,7 +1,6 @@
 import type { Chunk, Effect, Option, Result } from "effect"
 import type { Atom, AtomRef } from "effect/unstable/reactivity"
 import type { View } from "../View.ts"
-import type { IntrinsicProps } from "./Html.ts"
 
 /**
  * Documentation-only type listing the leaf shapes a child can take. The
@@ -33,13 +32,16 @@ export type Child =
   | ReadonlyArray<unknown>
 
 // Errors live in two honest homes by phase, so the fold has two families:
-//  - ChildE / TagE → CONSTRUCTION errors, on the result Effect's `E` channel
+//  - ChildE → CONSTRUCTION errors, on the result Effect's `E` channel
 //    (a child's build Effect failing propagates as the parent build fails).
-//  - ChildLiveE / TagLiveE → LIVE errors, on the result `View<E>` channel
+//  - ChildLiveE → LIVE errors, on the result `View<E>` channel
 //    (errors a rendered subtree can still produce — they ride the child's
 //    `View<E>` success). `R` unifies (one Layer set serves both phases), so
-//    there is a single `ChildR` / `TagR`.
+//    there is a single `ChildR`.
 // A `Catch` boundary discharges both; `mount` requires both `never`.
+// Component tags need no fold family of their own: since #71 the compiler
+// lowers `<MyComp/>` to a direct `MyComp({...})` call, so a component's
+// channels surface as an ordinary Effect CHILD of the surrounding `h()`.
 
 /**
  * Walk a single child's type, extracting the union of every **construction**
@@ -105,38 +107,3 @@ export type FoldLiveE<Cs extends readonly unknown[]> = ChildLiveE<Cs[number]>
 
 /** Fold a tuple of children to the union of their `R` channels. */
 export type FoldR<Cs extends readonly unknown[]> = ChildR<Cs[number]>
-
-/**
- * When the JSX tag is a component function `(props) => Effect<View<EV>, E, R>`,
- * extract its **construction** `E` so `h(Component, ...)` contributes it to the
- * result Effect's `E`. String tags contribute `never`.
- */
-export type TagE<T> = T extends (props: any) => Effect.Effect<any, infer E, any> ? E : never
-
-/**
- * Same, for the tag's **live** `E` — the `EV` riding its `View<EV>` success,
- * contributed to the result `View<E>` channel.
- */
-export type TagLiveE<T> = T extends (props: any) => Effect.Effect<infer A, any, any>
-  ? ChildLiveE<A>
-  : never
-
-/**
- * Same, for the tag's `R` channel.
- */
-export type TagR<T> = T extends (props: any) => Effect.Effect<any, any, infer R> ? R : never
-
-/**
- * The props shape a component tag expects, with `children` stripped (the JSX
- * factory threads children separately).
- *
- * For string tags ("div", "span", …) we fall back to the loose `Props` type;
- * a future improvement could thread `JSX.IntrinsicElements`-style HTML
- * attribute typing here.
- */
-export type TagProps<T> =
-  T extends string
-    ? IntrinsicProps
-    : T extends (props: infer P) => any
-      ? Omit<P, "children">
-      : Readonly<Record<string, unknown>>

--- a/packages/core/src/runtime/types/Html.ts
+++ b/packages/core/src/runtime/types/Html.ts
@@ -1,7 +1,7 @@
 /**
  * Typed event handlers for HTML intrinsic elements. Mirrors the common
  * `on*` properties DOM elements expose, with the right event type per
- * handler. Used by `TagProps<string>` (in `Fold.ts`) so that
+ * handler. Used by `h()`'s `_props` parameter (`IntrinsicProps`) so that
  *
  *   <button onclick={(e) => …}>   // e: MouseEvent
  *   <form onsubmit={(e) => …}>    // e: SubmitEvent

--- a/packages/core/src/testing/AGENTS.md
+++ b/packages/core/src/testing/AGENTS.md
@@ -18,8 +18,8 @@ await ui.tick()
 await ui.unmount()
 ```
 
-- `render(app, layer?)` — `app` is a component result (`Component(props)`
-  or `h(Component, props)`), i.e. an `Effect<View, E, R>`. Creates a
+- `render(app, layer?)` — `app` is a component result (`Component(props)`,
+  what a component tag compiles to since #71), i.e. an `Effect<View, E, R>`. Creates a
   container on `document.body`, makes a Closeable `Scope`, and runs
   `mount(app, container)` with `VerrexLive` (AtomRegistry) + that scope
   provided. Returns once the DOM is attached.

--- a/packages/core/src/testing/index.ts
+++ b/packages/core/src/testing/index.ts
@@ -53,8 +53,8 @@ const el = (container: HTMLElement, selector: string): HTMLElement => {
 /**
  * Mount a component into an in-process DOM and return a handle to drive it.
  *
- * `app` is a component result — `Component(props)` or `h(Component, props)` —
- * i.e. an `Effect<View, E, R>`. Provide a `layer` covering every service the
+ * `app` is a component result — `Component(props)`, what a component tag
+ * compiles to since #71 — i.e. an `Effect<View, E, R>`. Provide a `layer` covering every service the
  * component needs (the harness adds `AtomRegistry` + `Scope`); omit it only
  * when the component requires nothing else. A missing service is a compile
  * error, exactly as it would be at a real `mount`.


### PR DESCRIPTION
Closes #71.

## What this ships

**Component tags compile to direct calls.** `<MyComp item={x}>kid</MyComp>` now emits `MyComp({ item: x, children: [...] })`; `<MyComp/>` emits the zero-arg `MyComp()` (so propless `function* ()` components typecheck). `h()` is **intrinsic-only** — lowercase and namespaced tags route through it unchanged. Member-expression tags (`<X.Y/>`) lower to direct calls regardless of case (JSX convention).

**Why:** routing component tags through `h` was the sole reason generic components died at JSX call sites (TS higher-rank limit) and the sole reason the `Tag*` fold families existed. With direct calls:

- **Generics infer natively** — `<Row item={x}/>` preserves `T`; `list()` is no longer the generics workaround (it remains the keyed-reconciliation primitive). One caveat survives, now scoped to reactive attrs: a tracked attr (`item={ref.value}`) still erases through `h.track`'s `unknown`.
- **`TagE`/`TagLiveE`/`TagR`/`TagProps` are deleted** from `types/Fold.ts` (and the public exports). A component's channels are just its call's Effect type, folding into the surrounding `h()` as an ordinary child.
- **Props errors point at the component's own signature**, not `h`'s conditional types.

**Fragment is now itself a direct-call component** — `<>...</>` emits `Fragment({ children: [...] })`. Its new signature is generic over the children tuple, folding `FoldE`/`FoldLiveE`/`FoldR` precisely, and it coerces the raw children exactly as `h` does. This is also the documented canonical pattern for any effectful-children component. Anti-pattern called out in runtime AGENTS.md: typing children as the non-generic `Child[]` folds `any` into `E`, which is assignable to `never` and would silently defeat the `mount` gate.

**Children semantics:** children pass raw in a `children` array prop (coercion happens where the component embeds them); JSX children win over an explicit `children={...}` attr (React semantics); a spread child `{...items}` expands as a real spread (`children: [...items]` / `h(..., ...items)`) instead of nesting the array behind a Fragment wrapper. `h` is auto-imported per-emission — a component-only `.vx` file imports nothing.

**Migration guard:** `h()` throws a TypeError naming the direct-call migration if a function tag ever reaches it at runtime (stale pre-#71 compiled output, e.g. a bundler cache) — instead of dying later in `mount` with a cryptic `createElement` DOMException.

**Lowering key:** capitalization/member-expression (syntactic), not a runtime brand — the brand was dropped in #103 (noted on this issue).

## Breaking

- `h(Component, props)` no longer typechecks (`h` takes string tags only) — pre-1.0, all in-repo callers migrated.
- `TagE`/`TagLiveE`/`TagR`/`TagProps` exports removed.
- `Fragment`'s props type changed (generic children tuple; children arrive raw).

## Acceptance (from #71)

- ✅ A generic component used as a JSX tag typechecks with `T` inferred (`channels.test-d.ts`, `Component.test-d.ts`)
- ✅ `channels.test-d.ts` still proves E/R propagation through component tags (now as direct-call children)
- ✅ Demo passes the browser test — full probe suite green (`probe`, `probe-catch`, `probe-escalate`, `probe-liveuser`, `probe-async-userpage`, `probe-todos`, `probe-lifecycle`, `probe-hmr`)
- ✅ Compiler + runtime AGENTS.md updated (tag-dispatch rules, fold-type inventory, the generic-components limit rewritten as resolved-with-caveat, children-component pattern)

## Verification

- `pnpm -r test` — 244 core + 31 ts-plugin (incl. go-to-def/references over the new emission)
- `pnpm -r typecheck` — clean; demo via `verrex-check`: 0 errors
- 10 new compiler pins for the lowering shapes
