### PR TITLE
test(testing): shared Users fixture for the Async/asyncRef suites

### DIFF
--- a/packages/core/src/testing/AGENTS.md
+++ b/packages/core/src/testing/AGENTS.md
@@ -72,6 +72,27 @@ in `unmount()` — so a test can assert that finalizers fire on teardown
 `Effect.scoped` would close the scope as soon as `mount` returned, tearing
 the component down before you could drive it.
 
+## Shared fixtures (`fixtures.ts`)
+
+Test-only scaffolds for the Async/asyncRef suites (#98) — **not** exported
+from the package and excluded in `tsconfig.build.json`, so it never reaches
+`dist`. `makeUsersFixture(tagPrefix)` returns a fresh `Users` service per
+suite — a factory, not module constants, because suites customize the getter
+(gating, call counting, recovery flips) and a per-suite tag keeps service
+identity distinct. It returns:
+
+- `usersWith(get)` — a layer over a custom getter; build these **per test**
+  over test-local state (the shape #95 settled on), never a shared mutable db.
+- `UsersLive` — the canonical db-backed layer: `"42"`→Ada, `"7"`→Grace,
+  `"slow"` fails `Timeout`, anything else fails `NotFound`.
+
+The errors are module-level exports so they work as types too: `NotFound`
+(a `Data.TaggedError`) and `Timeout` (deliberately a plain hand-rolled `_tag`
+class — tag maps key on `_tag` alone, and both shapes must keep working).
+The service's error channel is always `NotFound | Timeout`, so a leaf tag map
+needs both tags to discharge to `View<never>`; suites exercising a *partial*
+map handle one tag and let the residual ride to a boundary.
+
 ## Setup
 
 - Each test file opts into happy-dom with a per-file
@@ -85,8 +106,13 @@ the component down before you could drive it.
 
 ## Anti-patterns
 
-- Don't add a `waitFor(predicate)` polling helper until a test needs it;
-  `tick()` + synchronous `AtomRef` reactivity covers the current cases.
+- Don't add a `waitFor(predicate)` variant until a test needs it; the
+  selector-based `waitFor` plus `tick()` covers the current cases (a test
+  needing text-level polling keeps a local helper, see
+  `async-refetch-regression.test.ts`).
+- Don't re-declare a per-suite `Users`/db scaffold in a test file — take it
+  from `fixtures.ts` (`makeUsersFixture`), and add to the fixture only what
+  at least two suites share.
 - Don't provide the component's real production layers here by default —
   tests pass their own (often test doubles). The harness only injects the
   framework infra (`VerrexLive` + scope).

--- a/packages/core/src/testing/async-autotrack.test.ts
+++ b/packages/core/src/testing/async-autotrack.test.ts
@@ -5,27 +5,20 @@
  * `.value`→h.read by calling read() inside the thunk.
  */
 import { describe, it, expect } from "vitest"
-import { Context, Effect, Layer, Scope } from "effect"
+import { Effect, Scope } from "effect"
 import { AtomRef } from "effect/unstable/reactivity"
 import { Async, h, type View } from "@verrex/core"
 import { render } from "./index.ts"
+import { makeUsersFixture, NotFound } from "./fixtures.ts"
 
-class Users extends Context.Service<Users, {
-  readonly get: (id: string) => Effect.Effect<string, GetErr>
-}>()("at/Users") {}
-class GetErr { readonly _tag = "GetErr"; constructor(readonly id: string) {} }
-const db: Record<string, string> = { "42": "Ada", "7": "Grace" }
-const UsersLive = Layer.succeed(Users, {
-  get: (id) => (db[id] ? Effect.succeed(db[id]) : Effect.fail(new GetErr(id))),
-})
-const read = (h as unknown as { read: (r: unknown) => string }).read
+const { Users, UsersLive } = makeUsersFixture("at")
 
 // folding: a thunk whose effect has no R → Async is Effect<View<E>, never, Scope>;
-// with no failure arm, GetErr rides the live channel instead of being discharged.
-const _folds = (userId: AtomRef.AtomRef<string>, get: (id: string) => Effect.Effect<string, GetErr>) =>
-  Async(() => get(read(userId)), {
+// with no failure arm, NotFound rides the live channel instead of being discharged.
+const _folds = (userId: AtomRef.AtomRef<string>, get: (id: string) => Effect.Effect<string, NotFound>) =>
+  Async(() => get(h.read(userId)), {
     success: (n) => h("span", {}, n),
-  }) satisfies Effect.Effect<View<GetErr>, never, Scope.Scope>
+  }) satisfies Effect.Effect<View<NotFound>, never, Scope.Scope>
 void _folds
 
 const Page = (userId: AtomRef.AtomRef<string>) =>
@@ -34,7 +27,7 @@ const Page = (userId: AtomRef.AtomRef<string>) =>
     return yield* h("div", { class: "page" },
       h("button", { class: "grace", onclick: () => userId.set("7") }, "Grace"),
       h("button", { class: "bad", onclick: () => userId.set("999") }, "Bad"),
-      yield* Async(() => client.get(read(userId)), {
+      yield* Async(() => client.get(h.read(userId)), {
         initial: h("span", { class: "loading" }, "…"),
         success: (n) => h("span", { class: "ok" }, n),
         failure: () => h("span", { class: "err" }, "not found"),
@@ -62,7 +55,7 @@ describe("auto-tracking Async", () => {
     const userId = AtomRef.make("42")
     const ExtractedPage = Effect.fn(function* () {
       const client = yield* Users
-      const get = () => client.get(read(userId)) // extracted thunk
+      const get = () => client.get(h.read(userId)) // extracted thunk
       return yield* h("div", { class: "page" },
         h("button", { class: "grace", onclick: () => userId.set("7") }, "Grace"),
         yield* Async(get, {

--- a/packages/core/src/testing/async-escalate.test.ts
+++ b/packages/core/src/testing/async-escalate.test.ts
@@ -7,23 +7,13 @@
  * (The handled form — `failure` provided — is covered by async-boundary.test.ts.)
  */
 import { describe, it, expect } from "vitest"
-import { Cause, Context, Effect, Layer, type Scope } from "effect"
+import { Cause, Effect, type Scope } from "effect"
 import { AtomRef } from "effect/unstable/reactivity"
 import { Async, Catch, h, type View } from "@verrex/core"
 import { render } from "./index.ts"
+import { makeUsersFixture, NotFound } from "./fixtures.ts"
 
-class Users extends Context.Service<Users, {
-  readonly get: (id: string) => Effect.Effect<string, FetchError>
-}>()("esc/Users") {}
-class FetchError {
-  readonly _tag = "FetchError"
-  constructor(readonly id: string) {}
-}
-const db: Record<string, string> = { "42": "Ada", "7": "Grace" }
-const UsersLive = Layer.succeed(Users, {
-  get: (id) => (db[id] ? Effect.succeed(db[id]) : Effect.fail(new FetchError(id))),
-})
-const read = (h as unknown as { read: (r: unknown) => string }).read
+const { Users, UsersLive } = makeUsersFixture("esc")
 
 // A page-level catch-all boundary around content that fetches via the open
 // form. The id-switching button lives OUTSIDE the boundary so it survives the
@@ -35,7 +25,7 @@ const Page = (userId: AtomRef.AtomRef<string>) =>
       h("button", { class: "bad", onclick: () => userId.set("999") }, "bad"),
       yield* Catch(
         h("section", { class: "content" },
-          Async(() => client.get(read(userId)), {
+          Async(() => client.get(h.read(userId)), {
             initial: h("span", { class: "loading" }, "…"),
             success: (n) => h("span", { class: "ok" }, n),
           }),
@@ -53,7 +43,7 @@ describe("Async without failure arm → nearest Catch", () => {
   it("routes an initial-fetch failure to the boundary fallback (cause included)", async () => {
     const ui = await render(Page(AtomRef.make("999")), UsersLive)
     const fallback = await ui.waitFor(".fallback")
-    expect(fallback.querySelector(".caught")?.textContent).toContain("FetchError")
+    expect(fallback.querySelector(".caught")?.textContent).toContain("NotFound")
     expect(ui.query(".ok")).toBeNull()
     await ui.unmount()
   })
@@ -89,7 +79,9 @@ describe("Async without failure arm → nearest Catch", () => {
           }),
         ),
         {
-          FetchError: (e, _reset) => h("p", { class: "tagged" }, `missing user ${e.id}`),
+          NotFound: (e, _reset) => h("p", { class: "tagged" }, `missing user ${e.id}`),
+          // Never fires here — present to fully discharge the fixture's error union.
+          Timeout: () => h("p", { class: "tagged" }, "timed out"),
         },
       )
     })()
@@ -101,11 +93,11 @@ describe("Async without failure arm → nearest Catch", () => {
   it("the open form still types R (service folds) and stamps View<E>", () => {
     // Compile-time pin, kept next to the runtime proof: omitting `failure`
     // stamps E on the View channel; providing it discharges to View<never>.
-    const open = (get: (id: string) => Effect.Effect<string, FetchError>) =>
+    const open = (get: (id: string) => Effect.Effect<string, NotFound>) =>
       Async(() => get("42"), {
         success: (n) => h("span", {}, n),
-      }) satisfies Effect.Effect<View<FetchError>, never, Scope.Scope>
-    const handled = (get: (id: string) => Effect.Effect<string, FetchError>) =>
+      }) satisfies Effect.Effect<View<NotFound>, never, Scope.Scope>
+    const handled = (get: (id: string) => Effect.Effect<string, NotFound>) =>
       Async(() => get("42"), {
         success: (n) => h("span", {}, n),
         failure: () => h("span", {}, "nope"),

--- a/packages/core/src/testing/async-handle.test.ts
+++ b/packages/core/src/testing/async-handle.test.ts
@@ -8,19 +8,12 @@
  * documented composition is `() => { handle.refetch(); reset() }`.
  */
 import { describe, it, expect } from "vitest"
-import { Context, Effect, Layer, type Scope } from "effect"
+import { Effect, type Scope } from "effect"
 import { Async, asyncRef, h, Catch, type AsyncHandle, type View } from "@verrex/core"
 import { render } from "./index.ts"
+import { makeUsersFixture, NotFound, type UsersError } from "./fixtures.ts"
 
-class Users extends Context.Service<Users, {
-  readonly get: (id: string) => Effect.Effect<string, NotFound>
-}>()("handle/Users") {}
-class NotFound {
-  readonly _tag = "NotFound"
-  constructor(readonly id: string) {}
-}
-const usersWith = (get: (id: string) => Effect.Effect<string, NotFound>) =>
-  Layer.succeed(Users, { get })
+const { Users, usersWith } = makeUsersFixture("handle")
 
 describe("AsyncHandle", () => {
   it("Async accepts a handle: renders its state, arms' retry is the handle's refetch", async () => {
@@ -39,7 +32,7 @@ describe("AsyncHandle", () => {
       )
     })()
     const ui = await render(Page, usersWith((id) =>
-      recovered ? Effect.succeed(`hi ${id}`) : Effect.fail(new NotFound(id))))
+      recovered ? Effect.succeed(`hi ${id}`) : Effect.fail(new NotFound({ id }))))
     try {
       await ui.waitFor(".retry")
       recovered = true
@@ -122,7 +115,7 @@ describe("AsyncHandle", () => {
       )
     })()
     const ui = await render(Page, usersWith((id) =>
-      recovered ? Effect.succeed(`hi ${id}`) : Effect.fail(new NotFound(id))))
+      recovered ? Effect.succeed(`hi ${id}`) : Effect.fail(new NotFound({ id }))))
     try {
       await ui.waitFor(".boundary-retry") // open form escalated to the boundary
       recovered = true
@@ -134,7 +127,7 @@ describe("AsyncHandle", () => {
   })
 
   it("refetch after the creating scope closed is a silent no-op returning false", async () => {
-    let captured!: AsyncHandle<string, NotFound>
+    let captured!: AsyncHandle<string, UsersError>
     let thunkRuns = 0
     const Page = Effect.fn(function* () {
       const client = yield* Users

--- a/packages/core/src/testing/async-refetch-regression.test.ts
+++ b/packages/core/src/testing/async-refetch-regression.test.ts
@@ -24,16 +24,13 @@
  *   catches), which is what this test exercises.
  */
 import { describe, expect, it } from "vitest"
-import { Context, Data, Effect, Fiber, Layer } from "effect"
+import { Effect, Fiber } from "effect"
 import { AsyncResult, AtomRef } from "effect/unstable/reactivity"
 import { asyncRef, h } from "@verrex/core"
 import { render } from "./index.ts"
+import { makeUsersFixture, type NotFound, type UsersError, type UsersService } from "./fixtures.ts"
 
-class NotFound extends Data.TaggedError("NotFound")<{ readonly id: string }> {}
-
-class Api extends Context.Service<Api, {
-  readonly get: (id: string) => Effect.Effect<string, NotFound>
-}>()("test/Api") {}
+const { Users: Api, usersWith } = makeUsersFixture("refetch")
 
 // A gated Api: each `get(id)` blocks on a per-id promise the test controls, so a
 // refetch can be held in-flight while the DOM is inspected at a chosen tick.
@@ -49,13 +46,12 @@ const gatedApi = () => {
     }
     return entry
   }
-  const layer = Layer.succeed(Api, {
-    get: (id) =>
-      Effect.gen(function* () {
-        yield* Effect.promise(() => gate(id).promise)
-        return `user-${id}`
-      }),
-  })
+  const layer = usersWith((id) =>
+    Effect.gen(function* () {
+      yield* Effect.promise(() => gate(id).promise)
+      return `user-${id}`
+    }),
+  )
   return { layer, release: (id: string) => gate(id).release() }
 }
 
@@ -64,7 +60,7 @@ const gatedApi = () => {
 // vs "surfaced a failure" are each observable in the DOM.
 const Widget = (
   id: AtomRef.AtomRef<string>,
-  get: (api: Api["Service"], id: string) => Effect.Effect<string, NotFound>,
+  get: (api: UsersService, id: string) => Effect.Effect<string, UsersError>,
 ) =>
   Effect.fn(function* () {
     const api = yield* Api
@@ -82,7 +78,7 @@ const Widget = (
     )
   })
 
-const passthrough = (api: Api["Service"], id: string) => api.get(id)
+const passthrough = (api: UsersService, id: string) => api.get(id)
 const settle = () => new Promise<void>((r) => setTimeout(r, 30))
 
 // Poll for `.out` to reach `text` (the harness `waitFor` is selector-only). Used

--- a/packages/core/src/testing/async-retry.test.ts
+++ b/packages/core/src/testing/async-retry.test.ts
@@ -10,21 +10,14 @@
  * pinned by the gated test below.
  */
 import { describe, it, expect } from "vitest"
-import { Context, Effect, Layer } from "effect"
+import { Effect } from "effect"
 import { Async, h } from "@verrex/core"
 import { render } from "./index.ts"
+import { makeUsersFixture, NotFound } from "./fixtures.ts"
 
-class Users extends Context.Service<Users, {
-  readonly get: (id: string) => Effect.Effect<string, NotFound>
-}>()("retry/Users") {}
-class NotFound {
-  readonly _tag = "NotFound"
-  constructor(readonly id: string) {}
-}
-// Each test builds its own layer over test-local state — nothing shared to
-// leak between tests.
-const usersWith = (get: (id: string) => Effect.Effect<string, NotFound>) =>
-  Layer.succeed(Users, { get })
+// Each test builds its own layer (usersWith) over test-local state — nothing
+// shared to leak between tests.
+const { Users, usersWith } = makeUsersFixture("retry")
 
 // Catch-all page, shared by tests 1 and 3.
 const CatchAllPage = Effect.fn(function* () {
@@ -44,7 +37,7 @@ describe("Async failure retry", () => {
     let recovered = false
     const ui = await render(
       CatchAllPage(),
-      usersWith((id) => (recovered ? Effect.succeed(`hi ${id}`) : Effect.fail(new NotFound(id)))),
+      usersWith((id) => (recovered ? Effect.succeed(`hi ${id}`) : Effect.fail(new NotFound({ id })))),
     )
     try {
       await ui.waitFor(".retry")
@@ -67,13 +60,15 @@ describe("Async failure retry", () => {
           failure: {
             NotFound: (e, retry) =>
               h("button", { class: "retry", onclick: () => retry() }, `missing ${e.id}`),
+            // Never fires here — present to fully discharge the fixture's error union.
+            Timeout: () => h("span", {}, "timed out"),
           },
         }),
       )
     })()
     const ui = await render(
       Page,
-      usersWith((id) => (recovered ? Effect.succeed(`hi ${id}`) : Effect.fail(new NotFound(id)))),
+      usersWith((id) => (recovered ? Effect.succeed(`hi ${id}`) : Effect.fail(new NotFound({ id })))),
     )
     try {
       expect((await ui.waitFor(".retry")).textContent?.trim()).toBe("missing 9")
@@ -101,7 +96,7 @@ describe("Async failure retry", () => {
         Effect.gen(function* () {
           attempts++
           if (attempts > 1) yield* Effect.promise(() => gate)
-          return yield* Effect.fail(new NotFound(id))
+          return yield* Effect.fail(new NotFound({ id }))
         }),
       ),
     )

--- a/packages/core/src/testing/async-tagmap.test.ts
+++ b/packages/core/src/testing/async-tagmap.test.ts
@@ -9,31 +9,13 @@
  * (async-escalate.test.ts).
  */
 import { describe, it, expect } from "vitest"
-import { Context, Effect, Layer, type Scope } from "effect"
+import { Effect, type Scope } from "effect"
 import { AtomRef } from "effect/unstable/reactivity"
 import { Async, Catch, h, type View } from "@verrex/core"
 import { render } from "./index.ts"
+import { makeUsersFixture, NotFound, Timeout } from "./fixtures.ts"
 
-class Users extends Context.Service<Users, {
-  readonly get: (id: string) => Effect.Effect<string, NotFound | Timeout>
-}>()("tagmap/Users") {}
-class NotFound {
-  readonly _tag = "NotFound"
-  constructor(readonly id: string) {}
-}
-class Timeout {
-  readonly _tag = "Timeout"
-}
-const db: Record<string, string> = { "42": "Ada", "7": "Grace" }
-const UsersLive = Layer.succeed(Users, {
-  get: (id) =>
-    id === "slow"
-      ? Effect.fail(new Timeout())
-      : db[id]
-        ? Effect.succeed(db[id])
-        : Effect.fail(new NotFound(id)),
-})
-const read = (h as unknown as { read: (r: unknown) => string }).read
+const { Users, UsersLive } = makeUsersFixture("tagmap")
 
 // NotFound is handled at the leaf; Timeout is not — it escalates to the
 // page-level catch-all.
@@ -43,7 +25,7 @@ const Page = (userId: AtomRef.AtomRef<string>) =>
     return yield* h("div", { class: "page" },
       yield* Catch(
         h("section", { class: "content" },
-          Async(() => client.get(read(userId)), {
+          Async(() => client.get(h.read(userId)), {
             initial: h("span", { class: "loading" }, "…"),
             success: (n) => h("span", { class: "ok" }, n),
             failure: {

--- a/packages/core/src/testing/async.test.ts
+++ b/packages/core/src/testing/async.test.ts
@@ -1,24 +1,20 @@
 // @vitest-environment happy-dom
 import { describe, expect, it } from "vitest"
-import { Context, Data, Effect, Layer } from "effect"
+import { Effect } from "effect"
 import { AsyncResult, AtomRef } from "effect/unstable/reactivity"
 import { asyncRef, h } from "@verrex/core"
 import { render } from "./index.ts"
+import { makeUsersFixture, NotFound } from "./fixtures.ts"
 
-class NotFound extends Data.TaggedError("NotFound")<{ readonly id: string }> {}
+const { Users: Api, usersWith } = makeUsersFixture("async")
 
-class Api extends Context.Service<Api, {
-  readonly get: (id: string) => Effect.Effect<string, NotFound>
-}>()("test/Api") {}
-
-const ApiLive = Layer.succeed(Api, {
-  get: (id) =>
-    Effect.gen(function* () {
-      yield* Effect.sleep("1 milli") // ensure a visible loading window
-      if (id === "bad") return yield* new NotFound({ id })
-      return `user-${id}`
-    }),
-})
+const ApiLive = usersWith((id) =>
+  Effect.gen(function* () {
+    yield* Effect.sleep("1 milli") // ensure a visible loading window
+    if (id === "bad") return yield* new NotFound({ id })
+    return `user-${id}`
+  }),
+)
 
 // Build with raw h(): `data.state.map(AsyncResult.match(...))` is a ReadonlyRef<string>
 // → coerces to a reactive node. No compiler needed.

--- a/packages/core/src/testing/fixtures.ts
+++ b/packages/core/src/testing/fixtures.ts
@@ -1,0 +1,53 @@
+/**
+ * Shared scaffolds for the Async/asyncRef suites (#98) — test-only, NOT part
+ * of the package surface (excluded in tsconfig.build.json, never reaches
+ * `dist`; nothing here is exported from `@verrex/core/testing`).
+ *
+ * `makeUsersFixture(tagPrefix)` returns a FRESH `Users` service per suite — a
+ * factory, not module constants, because suites customize the getter (gating,
+ * call counting, recovery flips) and a per-suite tag keeps service identity
+ * distinct across test files. Build per-test layers over test-local state with
+ * `usersWith` (the shape #95 settled on) — never a shared mutable db that can
+ * leak between tests.
+ */
+import { Context, Data, Effect, Layer } from "effect"
+
+/**
+ * The two live-channel test errors. Deliberately different shapes — `NotFound`
+ * is a `Data.TaggedError`, `Timeout` a plain hand-rolled `_tag` class — because
+ * tag maps key on `_tag` alone, and both shapes must keep working.
+ */
+export class NotFound extends Data.TaggedError("NotFound")<{ readonly id: string }> {}
+export class Timeout {
+  readonly _tag = "Timeout"
+}
+
+export type UsersError = NotFound | Timeout
+
+/**
+ * The service shape, named so tests can annotate parameters without the
+ * factory-local class type in scope (e.g. `(users: UsersService, id: string)`).
+ */
+export interface UsersService {
+  readonly get: (id: string) => Effect.Effect<string, UsersError>
+}
+
+const db: Record<string, string> = { "42": "Ada", "7": "Grace" }
+
+export const makeUsersFixture = (tagPrefix: string) => {
+  class Users extends Context.Service<Users, UsersService>()(`${tagPrefix}/Users`) {}
+
+  /** A layer over a custom getter — getters failing with a subset of `UsersError` fit as-is. */
+  const usersWith = (get: UsersService["get"]) => Layer.succeed(Users, { get })
+
+  /** The canonical db-backed layer: known ids resolve, "slow" times out, the rest are NotFound. */
+  const UsersLive = usersWith((id) =>
+    id === "slow"
+      ? Effect.fail(new Timeout())
+      : db[id]
+        ? Effect.succeed(db[id])
+        : Effect.fail(new NotFound({ id })),
+  )
+
+  return { Users, UsersLive, usersWith }
+}

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -9,5 +9,5 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "exclude": ["src/**/*.test.ts", "src/**/*.test-d.ts"]
+  "exclude": ["src/**/*.test.ts", "src/**/*.test-d.ts", "src/testing/fixtures.ts"]
 }


### PR DESCRIPTION
Closes #98.

## What this ships

`packages/core/src/testing/fixtures.ts` — a test-only scaffold module for the Async/asyncRef suites, **not** exported from the package and excluded in `tsconfig.build.json` (verified: `dist/testing/` contains only `index.*` after a build).

- **`makeUsersFixture(tagPrefix)`** returns a fresh `Users` service per suite — a factory, not module constants, since suites customize the getter (gating, call counting, recovery flips) and a per-suite tag keeps service identity distinct. It also returns:
  - `usersWith(get)` — a layer over a custom getter, built per test over test-local state (the shape #95 settled on; getters failing with a subset of the error union fit as-is).
  - `UsersLive` — the canonical db-backed layer: `"42"`→Ada, `"7"`→Grace, `"slow"`→`Timeout`, anything else →`NotFound`.
- **Module-level errors** (so they work as types in pins and annotations): `NotFound` is a `Data.TaggedError`; `Timeout` is deliberately a plain hand-rolled `_tag` class — tag maps key on `_tag` alone, and both shapes must keep working.
- **`UsersService` / `UsersError`** named types for parameter annotations where only the factory's value-level class is in scope.

## Suites migrated (7)

`async-escalate`, `async-tagmap`, `async-autotrack`, `async-retry`, `async-handle`, `async`, `async-refetch-regression` — each now one `makeUsersFixture(...)` line instead of a private service + error class(es) + db + layer copy. A change to the test-service contract is now one edit, not six.

Notes on intentional behavior-visible deltas:

- The fixture's service error channel is always `NotFound | Timeout`, so the two previously-full leaf/boundary tag maps (`async-retry`, `async-escalate`) gain a `Timeout` handler to keep discharging to `View<never>` — commented at both sites. Partial-map residual semantics stay pinned by `async-tagmap`.
- The vestigial `(h as unknown as { read ... }).read` shim in three suites is gone — `h.read` has been publicly typed since the tracking work; calls go through `h.read(...)` directly.
- `async-escalate`'s `Cause.pretty` assertion now expects `NotFound` (was the file-local `FetchError`).
- The two `Api`/`"test/Api"` suites now draw distinct per-suite tags (`async/Users`, `refetch/Users`) instead of sharing one key across files.

`src/testing/AGENTS.md` documents the fixture contract and adds the anti-pattern (don't re-declare per-suite scaffolds; fixture only carries what ≥2 suites share).

## Verification

- `pnpm -r test` — all green (testing dir: 13 files, 55 tests)
- `pnpm -r typecheck` — clean (incl. `verrex-check` over the demo)
- `pnpm --filter @verrex/core build` — `fixtures.ts` absent from `dist`