### PR TITLE
ci: per-package Release PRs titled with the version they release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,12 @@
 name: Release
 
 # Driven by conventional commits. On every push to main, release-please
-# opens/updates a "Release PR" (per-package version bumps + CHANGELOGs derived
-# from the commit history). Merging that PR tags the releases, and the publish
-# job below pushes `verrex` and `@verrex/ts-plugin` to npm with provenance.
+# opens/updates one Release PR per package (version bump + CHANGELOG derived
+# from the commit history, titled `chore: release <component> <version>`).
+# Merging a Release PR tags that release, and the publish job below pushes
+# the package to npm with provenance (`pnpm -r publish` skips packages whose
+# version is already on the registry, so per-package merges publish only the
+# merged package).
 on:
   push:
     branches: [main]
@@ -17,12 +20,12 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     permissions:
-      contents: write # create the Release PR + tags
-      pull-requests: write # open/update the Release PR
+      contents: write # create the Release PRs + tags
+      pull-requests: write # open/update the Release PRs
     outputs:
       releases_created: ${{ steps.rp.outputs.releases_created }}
       prs_created: ${{ steps.rp.outputs.prs_created }}
-      pr: ${{ steps.rp.outputs.pr }}
+      prs: ${{ steps.rp.outputs.prs }}
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -37,10 +40,10 @@ jobs:
           # below mirrors main's CI result onto it instead of re-running CI.
           token: ${{ secrets.GITHUB_TOKEN }}
 
-  # Show the status of main on the Release PR: wait for the CI run of the same
-  # push that updated the PR, then post its conclusion onto the PR head as a
-  # check run named `ci` — the same context branch protection requires, which
-  # the Release PR can't get any other way (GITHUB_TOKEN pushes never trigger
+  # Show the status of main on the Release PRs: wait for the CI run of the
+  # same push that updated them, then post its conclusion onto each PR head as
+  # a check run named `ci` — the same context branch protection requires, which
+  # a Release PR can't get any other way (GITHUB_TOKEN pushes never trigger
   # the pull_request CI workflow). Until it's posted, the required check shows
   # as "Expected — waiting", which doubles as the pending state.
   release-pr-status:
@@ -49,32 +52,38 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: read # read the CI run for this push
-      checks: write # post the mirrored `ci` check on the Release PR head
+      checks: write # post the mirrored `ci` check on the Release PR heads
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # Repo context for `gh run list` — this job has no checkout.
       GH_REPO: ${{ github.repository }}
-      PR_JSON: ${{ needs.release-please.outputs.pr }}
+      PRS_JSON: ${{ needs.release-please.outputs.prs }}
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
-      - name: Mirror main CI status onto the Release PR
+      - name: Mirror main CI status onto the Release PRs
         run: |
           set -euo pipefail
-          pr_number=$(jq -r '.number' <<<"$PR_JSON")
-          head_sha=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$pr_number" --jq '.head.sha')
           short=${GITHUB_SHA:0:7}
+
+          # With separate-pull-requests there can be one PR per package.
+          head_shas=()
+          for pr_number in $(jq -r '.[].number' <<<"$PRS_JSON"); do
+            head_shas+=("$(gh api "repos/$GITHUB_REPOSITORY/pulls/$pr_number" --jq '.head.sha')")
+          done
 
           # GITHUB_TOKEN is an Actions-app installation token, so this check
           # run satisfies the app-pinned `ci` required status check.
           post() { # conclusion title details_url
-            gh api "repos/$GITHUB_REPOSITORY/check-runs" \
-              -f name='ci' -f head_sha="$head_sha" \
-              -f status=completed -f conclusion="$1" \
-              -f "output[title]=$2" -f "output[summary]=$2" \
-              -f details_url="$3" >/dev/null
+            for head_sha in "${head_shas[@]}"; do
+              gh api "repos/$GITHUB_REPOSITORY/check-runs" \
+                -f name='ci' -f head_sha="$head_sha" \
+                -f status=completed -f conclusion="$1" \
+                -f "output[title]=$2" -f "output[summary]=$2" \
+                -f details_url="$3" >/dev/null
+            done
           }
 
           for _ in $(seq 1 60); do # up to ~30 min

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -220,8 +220,9 @@ re-render."
 ## Releasing
 
 Two packages publish to npm (`@verrex/core`, `@verrex/ts-plugin`) via
-release-please: pushes to `main` update a combined Release PR; merging
-it tags and publishes (tokenless OIDC + provenance). The one rule that
+release-please: pushes to `main` update one Release PR per package,
+titled `chore: release <component> <version>`; merging one tags and
+publishes that package (tokenless OIDC + provenance). The one rule that
 matters in every commit: **a commit bumps a package by the path of the
 files it changes, not by the commit scope** — keep a commit's edits
 inside one package dir to bump just that one; commits touching neither

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -4,8 +4,18 @@ Two packages publish to npm — **`@verrex/core`** and **`@verrex/ts-plugin`** �
 driven by conventional commits via release-please
 (`release-please-config.json` + `.release-please-manifest.json`,
 `.github/workflows/release.yml`). On every push to `main`, release-please
-opens/updates one combined **Release PR**; merging it tags the releases and
-the publish job pushes to npm.
+opens/updates one **Release PR per package** (`separate-pull-requests`),
+titled with the version it releases
+(`pull-request-title-pattern: "chore: release ${component} ${version}"`);
+merging one tags that release and the publish job pushes it to npm
+(`pnpm -r publish` skips versions already on the registry, so merging one
+PR publishes only that package).
+
+> **Don't hand-edit a Release PR title.** release-please re-parses the
+> title of a *merged* Release PR against the configured patterns to build
+> the release — a title that doesn't match logs `Bad pull request title`
+> and skips tagging/publishing. Any title change must go through
+> `pull-request-title-pattern` in `release-please-config.json`.
 
 - **A commit bumps a package by the path of the files it changes, not by the
   commit scope** (the invariant also stated in the root

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
-  "separate-pull-requests": false,
+  "separate-pull-requests": true,
+  "pull-request-title-pattern": "chore: release ${component} ${version}",
   "include-component-in-tag": true,
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,


### PR DESCRIPTION
Release PRs are now opened one per package and titled with the release they carry — e.g. `chore: release @verrex/core 0.3.0` — instead of a single grouped PR titled `chore: release main`.

## What ships

- **`release-please-config.json`** — `separate-pull-requests: true` + `pull-request-title-pattern: "chore: release ${component} ${version}"`. The version-in-title cannot be done on the grouped PR: release-please's `group-pull-request-title-pattern` only resolves `${version}` from a root-path (`.`) package, which this repo doesn't have, and release-please **re-parses the merged PR title** to build the release — an unparseable title (e.g. one listing two versions) logs `Bad pull request title` and skips tagging/publishing. Per-package PRs are the only shape where a version-bearing title is both generatable and round-trippable.
- **`.github/workflows/release.yml`** — the `release-pr-status` job mirrors main's CI conclusion onto **every** open Release PR head (loops the `prs` output) instead of the single `pr`. The `publish` job is unchanged: `pnpm -r publish` skips versions already on the registry, so merging one package's PR publishes only that package.
- **`AGENTS.md` / `docs/RELEASING.md`** — describe the per-package Release PRs and warn that Release PR titles must never be hand-edited (release-time title parsing).

`ci.yml`'s skip condition matches the `release-please--` branch prefix, which per-package branches (`release-please--branches--main--components--…`) still carry — no change needed.

## After merging

The currently open grouped Release PR #90 (`chore: release main`) sits on the old branch and won't be updated further — close it; the next push to main opens the per-package replacement(s).

Root-only paths (`.github/`, docs, config) — this PR itself releases nothing.