### PR TITLE
ci: drop doubled space in Release PR titles

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -6,7 +6,9 @@ driven by conventional commits via release-please
 `.github/workflows/release.yml`). On every push to `main`, release-please
 opens/updates one **Release PR per package** (`separate-pull-requests`),
 titled with the version it releases
-(`pull-request-title-pattern: "chore: release ${component} ${version}"`);
+(`pull-request-title-pattern: "chore: release${component} ${version}"` —
+no space before `${component}`: release-please expands it with a leading
+space built in, mirroring its default pattern `release${component}`);
 merging one tags that release and the publish job pushes it to npm
 (`pnpm -r publish` skips versions already on the registry, so merging one
 PR publishes only that package).

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
   "separate-pull-requests": true,
-  "pull-request-title-pattern": "chore: release ${component} ${version}",
+  "pull-request-title-pattern": "chore: release${component} ${version}",
   "include-component-in-tag": true,
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,


### PR DESCRIPTION
Release PR titles render as `chore: release core 0.3.0` — single space. release-please expands `${component}` with a leading space built in (its own default pattern is `release${component}`), so the explicit space in our `pull-request-title-pattern` doubled it (#108 currently reads `chore: release  core 0.3.0`).

`docs/RELEASING.md` notes the no-space-before-`${component}` gotcha next to the quoted pattern.

Merging this retitles #108 automatically: the merge push re-runs release-please, which rewrites open Release PR titles from the updated pattern. (If #108 is merged first, that's fine too — the double-space title parses under the config it was created with.)