### PR TITLE
chore(releasing): trim title-pattern commentary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -220,9 +220,9 @@ re-render."
 ## Releasing
 
 Two packages publish to npm (`@verrex/core`, `@verrex/ts-plugin`) via
-release-please: pushes to `main` update one Release PR per package,
-titled `chore: release <component> <version>`; merging one tags and
-publishes that package (tokenless OIDC + provenance). The one rule that
+release-please: pushes to `main` update one Release PR per package;
+merging one tags and publishes that package (tokenless OIDC +
+provenance). The one rule that
 matters in every commit: **a commit bumps a package by the path of the
 files it changes, not by the commit scope** — keep a commit's edits
 inside one package dir to bump just that one; commits touching neither

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -4,20 +4,9 @@ Two packages publish to npm — **`@verrex/core`** and **`@verrex/ts-plugin`** �
 driven by conventional commits via release-please
 (`release-please-config.json` + `.release-please-manifest.json`,
 `.github/workflows/release.yml`). On every push to `main`, release-please
-opens/updates one **Release PR per package** (`separate-pull-requests`),
-titled with the version it releases
-(`pull-request-title-pattern: "chore: release${component} ${version}"` —
-no space before `${component}`: release-please expands it with a leading
-space built in, mirroring its default pattern `release${component}`);
-merging one tags that release and the publish job pushes it to npm
-(`pnpm -r publish` skips versions already on the registry, so merging one
-PR publishes only that package).
-
-> **Don't hand-edit a Release PR title.** release-please re-parses the
-> title of a *merged* Release PR against the configured patterns to build
-> the release — a title that doesn't match logs `Bad pull request title`
-> and skips tagging/publishing. Any title change must go through
-> `pull-request-title-pattern` in `release-please-config.json`.
+opens/updates one **Release PR per package**, titled with the version it
+releases; merging one tags that release and the publish job pushes just
+that package to npm.
 
 - **A commit bumps a package by the path of the files it changes, not by the
   commit scope** (the invariant also stated in the root


### PR DESCRIPTION
Drops the release-please title commentary from `docs/RELEASING.md` and `AGENTS.md` — the quoted `pull-request-title-pattern`, the no-space-before-`${component}` gotcha, and the don't-hand-edit warning. What remains is the one-line mechanics: one Release PR per package, titled with the version it releases; merging one publishes that package. Docs-only — releases nothing.