### PR TITLE
fix: suppress the name-slot inlay hint on Component.make in .vx files

### DIFF
--- a/packages/core/src/runtime/AGENTS.md
+++ b/packages/core/src/runtime/AGENTS.md
@@ -34,14 +34,18 @@ surrounding `h()`. `mount` requires both error channels `never`;
 names the error — the runtime counterpart of a forgotten Layer naming a
 service. See [`types/Fold.ts`](./types/Fold.ts).
 
-### `h()` parameter naming — coupled to the TS plugin
+### Compiler-slot parameter naming — coupled to the TS plugin
 
-The `HFn` type's parameters are `_tag`, `_props`, `_children`
-(underscore prefix, in `h.ts`). This is **coupled to
+The `HFn` type's parameters are `_tag`, `_props`, `_children` (in
+`h.ts`) and `Component.make`'s name slot is `_name` (in `Component.ts`)
+— underscore prefix marks a compiler-filled slot. This is **coupled to
 [`@verrex/ts-plugin`](../../../ts-plugin/AGENTS.md)** — the plugin's
 inlay-hint filter drops any hint matching
-`/^_?(tag|props|children):?$/i`, so these labels never appear in
-the editor margin. If you rename them, update the regex.
+`/^(?:_?(?:tag|props|children)|_name):?$/i`, so these labels never
+appear in the editor margin (without the filter, the injected name
+argument's `_name:` hint would render after the call's `})`). `_name`
+is matched underscore-only — bare `name:` is a common user parameter
+and keeps its hint. If you rename a slot, update the regex.
 
 ## Files
 
@@ -88,7 +92,8 @@ if it grows past these, it's grown too much:
    no name → no span (the anonymous `Effect.fn` form never calls
    `useSpan`), but failures still carry definition + call-site stack
    frames via `CurrentStackFrame`. In plain `.ts` (tests, harnesses) pass
-   the name explicitly.
+   the name explicitly. The parameter is `_name` — see "Compiler-slot
+   parameter naming" above for the inlay-hint coupling.
 
 Runtime: `Effect.fn` accepts both body shapes (it checks
 `isEffect(body(...))` before iterating), so one implementation serves both

--- a/packages/core/src/runtime/Component.ts
+++ b/packages/core/src/runtime/Component.ts
@@ -35,7 +35,11 @@ type GenR<Eff> = [Eff] extends [never] ? never
  *     `Component.make(fn, "Counter")` from the declared name (fails soft: no
  *     name → no span — anonymous `Effect.fn` never calls `useSpan` — but
  *     failures still carry definition + call-site stack frames). In plain
- *     `.ts` (tests, harnesses) pass the name yourself.
+ *     `.ts` (tests, harnesses) pass the name yourself. The parameter is
+ *     `_name` — underscore-prefixed like `h`'s `_tag`/`_props`/`_children`
+ *     because it's a compiler-filled slot, coupled by name to the
+ *     ts-plugin's inlay-hint filter so the injected argument never shows
+ *     a `_name:` label in the editor.
  *
  * If it ever grows beyond these three jobs, it's grown too much. (A runtime
  * brand was considered for #71's direct-call tag lowering and deliberately
@@ -55,7 +59,7 @@ type GenR<Eff> = [Eff] extends [never] ? never
  */
 export function make<F extends (props: any) => Effect.Effect<View<any>, any, any>>(
   f: F,
-  name?: string,
+  _name?: string,
 ): F
 export function make<
   Args extends [props?: any],
@@ -63,12 +67,12 @@ export function make<
   AView extends View<any>,
 >(
   body: (...args: Args) => Generator<Eff, AView, never>,
-  name?: string,
+  _name?: string,
 ): (...args: Args) => Effect.Effect<AView, GenE<Eff>, GenR<Eff>>
-export function make(f: (props?: any) => any, name?: string): unknown {
+export function make(f: (props?: any) => any, _name?: string): unknown {
   // `Effect.fn`'s runtime accepts both body shapes — a generator (iterated)
   // and a plain Effect-returning function (`isEffect(iter) ? iter : …`) — so
   // one wrapper serves both overloads.
-  return name === undefined ? Effect.fn(f as never) : Effect.fn(name)(f as never)
+  return _name === undefined ? Effect.fn(f as never) : Effect.fn(_name)(f as never)
 }
 

--- a/packages/ts-plugin/AGENTS.md
+++ b/packages/ts-plugin/AGENTS.md
@@ -22,8 +22,8 @@ for tsserver to `require()`.
 | `src/index.ts` | Entry. Re-exports `pluginFactory` via `export =`. |
 | `src/jsx-tags.ts` | `findJsxTagPair` — takes a `JsxTagProvider` (the in-process seam) and uses its `jsxRanges` from the shared `VerrexVirtualCode` to find tag-pair partners for document highlights. The service-proxy builds the provider by resolving the `VerrexVirtualCode` from Volar's context. |
 | `src/classify-references.ts` | `classifyRefs` — decorates each ref with `{ isDef, isImport }` in one pass, with a per-call file-content cache so each source file is read at most once. Plus `refKey` (the `${fileName}:${textSpan.start}` identity), `dedupeRefs` (drop same-key hits, first-seen order), and `sortClassifiedRefs` (def→usages→imports ordering on the precomputed booleans). The two reference handlers compose these instead of inlining the key/sort logic. |
-| `src/hint-text.ts` | `hintText(hint)` — reads an inlay hint's label across the shapes different TS versions use (`hint.text` string, `hint.text` parts, `hint.displayParts`), returning the first non-empty. Plus `SUPPRESS_RE`, the `_tag`/`_props`/`_children` regex. Pure + unit-tested so the filter doesn't need a tsserver. |
-| `src/service-proxy.ts` | `pluginFactory` — instantiates the shared LanguagePlugin via `createVerrexLanguagePlugin<string>(identity)`, builds Volar's `createLanguageServicePlugin` (capturing the session `Language` through its `setup(language)` hook), then wraps the resulting `LanguageService` in a Proxy with a few method overrides (filter `verrex`'s `h.ts` from definition results, JSX tag-pair document highlights, `_tag`/`_props`/`_children` inlay-hint filter, reference dedup + sort). Resolves the per-`.vx` `VerrexVirtualCode` from `language.scripts` when it needs `jsxRanges` or `source`. |
+| `src/hint-text.ts` | `hintText(hint)` — reads an inlay hint's label across the shapes different TS versions use (`hint.text` string, `hint.text` parts, `hint.displayParts`), returning the first non-empty. Plus `SUPPRESS_RE`, the `_tag`/`_props`/`_children`/`_name` regex. Pure + unit-tested so the filter doesn't need a tsserver. |
+| `src/service-proxy.ts` | `pluginFactory` — instantiates the shared LanguagePlugin via `createVerrexLanguagePlugin<string>(identity)`, builds Volar's `createLanguageServicePlugin` (capturing the session `Language` through its `setup(language)` hook), then wraps the resulting `LanguageService` in a Proxy with a few method overrides (filter `verrex`'s `h.ts` from definition results, JSX tag-pair document highlights, `_tag`/`_props`/`_children`/`_name` inlay-hint filter, reference dedup + sort). Resolves the per-`.vx` `VerrexVirtualCode` from `language.scripts` when it needs `jsxRanges` or `source`. |
 | `src/classify-references.test.ts` | Unit tests for `classifyRefs` (injected fake `readFile`, no disk), plus `refKey`/`dedupeRefs`/`sortClassifiedRefs` — pins the dedup key, first-seen order, and the def→usages→imports ordering (incl. usage-tier stability) without a tsserver. |
 | `src/plugin.test.mjs` | Manual smoke test loading the built bundle (`dist/index.cjs`) and asserting plugin shape. Not run by `pnpm test` (vitest config only picks up `*.test.ts`); invoke directly with `node` after building. |
 | `vitest.config.ts` | Picks up `src/**/*.test.ts`. The package's `test` script runs vitest first, then builds and runs the integration harness. |
@@ -53,7 +53,7 @@ live in [`@verrex/core/language`](../core/src/language/AGENTS.md) — shared wit
                ▼  our Proxy wrapper
                │    filterRuntimeHit()         — drop hits in runtime/h.ts
                │    getDocumentHighlights()    — JSX tag pair custom path
-               │    provideInlayHints()        — filter _tag/_props/_children
+               │    provideInlayHints()        — filter _tag/_props/_children/_name
                │    getCompletionsAtPosition() — clamp cross-line replacementSpans
                │    get/findReferences()       — dedupe + sort
                ▼
@@ -128,7 +128,12 @@ hand-rolled.
 
 - **`provideInlayHints`** — `.vx`-only filter. Volar gives us all
   hints including the h() parameter labels (`_tag`, `_props`,
-  `_children`). We drop any hint whose label matches `SUPPRESS_RE`.
+  `_children`) and the `_name:` label for `Component.make`'s
+  compiler-injected name argument (the injected literal has no source
+  loc, so its hint rides the preceding mapping and would render at the
+  end of the call — `})name:`). We drop any hint whose label matches
+  `SUPPRESS_RE`. Bare `name:` is deliberately NOT matched — it's a
+  common user parameter; only the underscore form is suppressed.
   Label extraction (`hintText`) and the regex live in `hint-text.ts`
   (pure + unit-tested); `hintText` reads the first non-empty of
   `hint.text` (string), `hint.text` (parts), or `hint.displayParts`
@@ -180,12 +185,13 @@ index sees usages across files. No sibling `.ts` shim is involved.
 
 ## Coupling to other packages
 
-- **`verrex` `h.ts`** — the `HFn` signature uses parameter
-  names `_tag`/`_props`/`_children` (with underscore prefix).
+- **`verrex` `h.ts` / `Component.ts`** — the `HFn` signature uses
+  parameter names `_tag`/`_props`/`_children`, and `Component.make`'s
+  compiler-filled name slot is `_name` (underscore prefix throughout).
   This is **coupled to the inlay-hint filter regex above**. If you
-  rename them in `h.ts`, update the regex in `provideInlayHints`.
-  The `_?` in the regex makes it tolerate both the prefixed and
-  unprefixed variants.
+  rename them, update the regex in `hint-text.ts`. The `_?` makes the
+  h() trio tolerate both prefixed and unprefixed variants; `_name` is
+  underscore-only so user `name:` hints survive.
 
 - **`@verrex/core/compiler` `copyLoc`** — the compiler preserves source
   locations on emitted nodes. Without that, Babel's source map
@@ -263,7 +269,7 @@ shape check.
 - Root [`AGENTS.md`](../../AGENTS.md) — the "JSX syntax, not JSX
   semantics" framing this plugin enforces
 - [`verrex`](../core/src/runtime/AGENTS.md) — the `_tag/_props/_children`
-  parameter naming
+  and `_name` parameter naming
 - [`@verrex/core/compiler`](../core/src/compiler/AGENTS.md) — the source-location
   preservation that the source map depends on
 - [`@verrex/core/language`](../core/src/language/AGENTS.md) — the shared Volar

--- a/packages/ts-plugin/src/hint-text.test.ts
+++ b/packages/ts-plugin/src/hint-text.test.ts
@@ -41,8 +41,16 @@ describe("SUPPRESS_RE", () => {
     }
   })
 
+  it("matches Component.make's compiler-filled _name slot (underscore only)", () => {
+    for (const s of ["_name", "_name:", "_Name:"]) {
+      expect(SUPPRESS_RE.test(s)).toBe(true)
+    }
+  })
+
+  // Bare `name:` is a common user parameter — its hint must survive; only
+  // the underscore-prefixed compiler slot is suppressed.
   it("does not match unrelated labels", () => {
-    for (const s of ["count:", "name:", "tagName:", "children2:"]) {
+    for (const s of ["count:", "name:", "tagName:", "children2:", "_named:"]) {
       expect(SUPPRESS_RE.test(s)).toBe(false)
     }
   })

--- a/packages/ts-plugin/src/hint-text.ts
+++ b/packages/ts-plugin/src/hint-text.ts
@@ -1,11 +1,15 @@
 /**
- * Matches the labels TypeScript emits for `h()`'s parameters — `_tag`,
- * `_props`, `_children` (and the un-prefixed `tag:`/`props:`/`children:`
- * forms). The TS plugin filters these inlay hints out of `.vx` files; see
- * `service-proxy.ts`. Coupled by name to `verrex`'s `h` parameter
- * names — documented in both packages' AGENTS.md.
+ * Matches the labels TypeScript emits for the compiler-filled parameters —
+ * `h()`'s `_tag`/`_props`/`_children` (and the un-prefixed
+ * `tag:`/`props:`/`children:` forms) plus `Component.make`'s `_name` slot
+ * (the compiler injects the name argument, so its hint lands on generated
+ * code and leaks to the end of the call). `_name` is matched ONLY with the
+ * underscore — bare `name:` is a common user parameter and must keep its
+ * hint. The TS plugin filters these inlay hints out of `.vx` files; see
+ * `service-proxy.ts`. Coupled by name to `verrex`'s `h` / `Component.make`
+ * parameter names — documented in both packages' AGENTS.md.
  */
-export const SUPPRESS_RE = /^_?(tag|props|children):?$/i
+export const SUPPRESS_RE = /^(?:_?(?:tag|props|children)|_name):?$/i
 
 /** The subset of an inlay hint we read a label string from. */
 export interface HintTextShape {


### PR DESCRIPTION
In `.vx` files the editor showed a stray `name:` parameter inlay hint after a `Component.make(...)` call's closing `})`. The compiler injects the declared name as a second argument (`Component.make(fn, "Counter")`); the injected literal has no source location, so its generated span rides the preceding mapping in `computeMappings`' consecutive-difference spans, and Volar mapped TS's parameter hint for it back into the source at the end of the call.

The slot now follows the existing compiler-filled-parameter convention:

- **`@verrex/core`** — `Component.make`'s name parameter is `_name` (underscore prefix, like `h()`'s `_tag`/`_props`/`_children`).
- **`@verrex/ts-plugin`** — `SUPPRESS_RE` also drops `_name` hints. Underscore-only on purpose: bare `name:` is a common user parameter and keeps its hint (pinned by a test).

Coupling is documented in both packages' AGENTS.md. Two commits, one per package, per the release path rule.

Verified with `pnpm -r test` (254 core tests + ts-plugin tsserver integration harness) and `pnpm -r typecheck` (incl. the .vx-aware demo check).