### PR TITLE
feat(runtime): Atom-valued props — reactive attrs through the registry

### DIFF
--- a/apps/demo/src/channels.test-d.ts
+++ b/apps/demo/src/channels.test-d.ts
@@ -4,8 +4,9 @@
  * Each assertion either holds or produces a type error naming the
  * mismatched channel — this *is* the demonstration.
  */
-import type { Cause, Chunk, Effect, Option, Result, Scope } from "effect"
-import type { AtomRegistry } from "effect/unstable/reactivity"
+import type { Cause, Chunk, Option, Result, Scope } from "effect"
+import { Effect, Stream } from "effect"
+import { Atom, type AtomRegistry } from "effect/unstable/reactivity"
 import { Async, type AsyncHandle, Catch, h, mount, type View } from "@verrex/core"
 import { AsyncEscalate } from "./AsyncEscalate.vx"
 import { AsyncUserPage } from "./AsyncUserPage.vx"
@@ -220,6 +221,20 @@ mount(Caught, root)
 
 // A pure component needs no boundary — it's already `View<never>`, `never`.
 mount(Counter(), root)
+
+// ─── Atom carriers: the COMPONENT owns the requirements ──────────────────
+//     The service instance is extracted in the component body (`yield* Http`
+//     is what puts Http in R), and the Atom's stream source is built from
+//     that instance — so the source itself is context-free, `Atom.runtime`
+//     (which would bake the Layer and discharge R) never appears, and a
+//     forgotten HttpLive is still a compile error at mount.
+
+const AtomCarrier = Effect.gen(function* () {
+  const http = yield* Http // Http rides the component's R
+  const user = Atom.make(Stream.fromEffect(http.getUser("42")))
+  return yield* h("p", { "data-user": user }, "·")
+})
+assertEquals<typeof AtomCarrier, Effect.Effect<View, never, Http>>()
 
 // ─── Catch tag-map form narrows the error channel by tag ────────────────
 //     Handle specific tags; the rest stay on the channel and must still be

--- a/packages/core/src/runtime/AGENTS.md
+++ b/packages/core/src/runtime/AGENTS.md
@@ -525,6 +525,23 @@ They register the `dispose` callback as a `Scope.addFinalizer`
 finalizer. Don't subscribe outside these helpers — the dispose
 function would have no scope to bind to and would leak on teardown.
 
+**Reactive props accept `Atom` or `AtomRef`.** `applyProp` dispatches the
+same way the Reactive child case does (Atom first: `registry.get` +
+`subscribeAtomScoped`; AtomRef: `.value` + `subscribeRefScoped`),
+re-applying the prop per emission inside a per-application child scope so a
+replaced value's listeners/finalizers are released. Atoms have no `.value`,
+so they never pass through `h.track`/`h.read` — pass the atom itself as the
+attr value, deriving the final attr string with `Atom.map`. When an Atom's
+source needs services, the **component owns the requirements**: extract
+instances up front (`const http = yield* Http`) or capture context
+(`yield* Effect.context<R>()` — the capture itself is what puts `R` on the
+component's channel), then build the Atom from those, so the source is
+context-free and a forgotten Layer is still a compile error at `mount`.
+`Atom.runtime` stays the anti-pattern (bakes the Layer, discharges `R` —
+see "Why NOT `Atom`/`Atom.runtime`" above). Pinned by
+`testing/atom-attr.test.ts` and the Atom-carrier pin in
+`apps/demo/src/channels.test-d.ts`.
+
 **Fragments wrap in `<span style="display: contents">`.** Not a
 `DocumentFragment`, because `DocumentFragment` is consumed on insert
 — a later `replaceChild(fragment, ...)` would fail. The wrapper

--- a/packages/core/src/runtime/mount.ts
+++ b/packages/core/src/runtime/mount.ts
@@ -71,9 +71,10 @@ const applyProp = (
   ctx: BuildCtx,
   scope: Scope.Scope,
 ): void => {
-  // Reactive prop: AtomRef → subscribe and re-apply on changes.
-  if (isAtomRef(value)) {
-    const ref = value as AtomRef.ReadonlyRef<unknown>
+  // Reactive prop: Atom or AtomRef → subscribe and re-apply on changes.
+  // Same dispatch order as the Reactive child case (Atom first); an Atom is
+  // read + subscribed through the registry, an AtomRef through itself.
+  if (Atom.isAtom(value) || isAtomRef(value)) {
     let lastChildScope: Scope.Closeable | null = null
     const apply = (v: unknown) => {
       if (lastChildScope) {
@@ -83,8 +84,15 @@ const applyProp = (
       lastChildScope = Scope.forkUnsafe(scope, "sequential")
       applyProp(el, key, v, ctx, lastChildScope)
     }
-    apply(ref.value)
-    subscribeRefScoped(ref, apply, scope)
+    if (Atom.isAtom(value)) {
+      const atom = value as Atom.Atom<unknown>
+      apply(ctx.registry.get(atom))
+      subscribeAtomScoped(ctx.registry, atom, apply, scope)
+    } else {
+      const ref = value as AtomRef.ReadonlyRef<unknown>
+      apply(ref.value)
+      subscribeRefScoped(ref, apply, scope)
+    }
     return
   }
 

--- a/packages/core/src/testing/AGENTS.md
+++ b/packages/core/src/testing/AGENTS.md
@@ -72,6 +72,13 @@ in `unmount()` — so a test can assert that finalizers fire on teardown
 `Effect.scoped` would close the scope as soon as `mount` returned, tearing
 the component down before you could drive it.
 
+The layers (caller `layer` + `VerrexLive`) are built with `Layer.build`
+INTO that same scope — not `Effect.provide`-d onto the mount effect, whose build
+scope closes when `mount` returns, disposing the `AtomRegistry` while the
+component is still live (any post-mount registry use — an Atom-driven attr
+or child — would throw "registry is disposed"). Service finalizers
+therefore fire on `unmount()`, alongside the component's.
+
 ## Shared fixtures (`fixtures.ts`)
 
 Test-only scaffolds for the Async/asyncRef suites (#98) — **not** exported

--- a/packages/core/src/testing/atom-attr.test.ts
+++ b/packages/core/src/testing/atom-attr.test.ts
@@ -1,0 +1,73 @@
+// @vitest-environment happy-dom
+import { describe, it, expect } from "vitest"
+import { Effect } from "effect"
+import { Atom, AtomRef, AtomRegistry } from "effect/unstable/reactivity"
+import { h } from "@verrex/core"
+import { render } from "./index.ts"
+
+// Atom-valued props: `applyProp` reads + subscribes through the registry
+// (mirroring the Reactive child case), so a derived Atom can drive a single
+// attribute. Components own the registry via `yield* AtomRegistry` — the
+// harness injects it through VerrexLive.
+
+describe("Atom-valued attrs", () => {
+  it("applies the registry value initially and re-applies on registry.set", async () => {
+    const size = Atom.make(1)
+    const cls = Atom.map(size, (n) => `box size-${n}`)
+
+    const Box = Effect.fn(function* () {
+      const registry = yield* AtomRegistry.AtomRegistry
+      return yield* h(
+        "div",
+        {},
+        h("button", { class: "grow", onclick: () => registry.set(size, 2) }, "+"),
+        h("span", { class: cls, id: "target" }, "x"),
+      )
+    })
+
+    const ui = await render(Box())
+    expect(ui.get("#target").getAttribute("class")).toBe("box size-1")
+
+    ui.click(".grow")
+    await ui.waitFor(".size-2")
+    expect(ui.get("#target").getAttribute("class")).toBe("box size-2")
+
+    await ui.unmount()
+  })
+
+  it("ties the subscription to the element scope: a swapped-away node stops receiving", async () => {
+    const n = Atom.make(0)
+    const show = AtomRef.make(true)
+    // Capture the component's own registry so the writes go through the SAME
+    // instance the attr subscribed on (a fresh registry would pass vacuously).
+    let reg!: AtomRegistry.AtomRegistry
+    const Probe = Effect.fn(function* () {
+      reg = yield* AtomRegistry.AtomRegistry
+      return yield* h(
+        "div",
+        {},
+        show.map((s) =>
+          s ? h("span", { "data-n": n, id: "probe" }, "x") : h("span", { class: "gone" }, "-"),
+        ),
+      )
+    })
+
+    const ui = await render(Probe())
+    const probe = ui.get("#probe")
+    expect(probe.getAttribute("data-n")).toBe("0")
+
+    reg.set(n, 1)
+    await ui.waitFor('[data-n="1"]')
+
+    // Swap the subtree away: the Reactive emit closes the old child scope,
+    // which holds the attr subscription as a finalizer. The registry is still
+    // alive — a further write must not reach the detached node.
+    show.set(false)
+    await ui.waitFor(".gone")
+    reg.set(n, 9)
+    await ui.tick()
+    expect(probe.getAttribute("data-n")).toBe("1")
+
+    await ui.unmount()
+  })
+})

--- a/packages/core/src/testing/index.ts
+++ b/packages/core/src/testing/index.ts
@@ -90,9 +90,18 @@ const renderImpl = async (
   // defect, so a component that fails to build (with no boundary) rejects the
   // `render(...)` promise loudly — exactly the failure a test wants to see.
   const discharged = Effect.catchCause(app, (cause) => Effect.die(Cause.squash(cause)))
+  // Build the layers INTO the held-open scope (not `Effect.provide`, whose
+  // build scope closes when the mount effect returns — disposing the
+  // AtomRegistry while the component is still live; any post-mount registry
+  // use, e.g. an Atom-driven attr or child, would then throw "registry is
+  // disposed"). Finalizers land on `scope`, so services live until unmount().
   await Effect.runPromise(
     Scope.provide(
-      mount(discharged, container).pipe(Effect.provide(layer), Effect.provide(VerrexLive)),
+      Layer.build(Layer.mergeAll(layer, VerrexLive)).pipe(
+        Effect.flatMap((services) =>
+          Effect.provideContext(mount(discharged, container), services),
+        ),
+      ),
       scope,
     ),
   )


### PR DESCRIPTION
Closes the Atom support asymmetry: `Atom` was already a first-class reactive source in **child** position (the `Reactive` IR node), but an Atom-valued **attr** fell through to `String(value)`. With this PR, `applyProp` dispatches `Atom` alongside `AtomRef`, mirroring the Reactive child case:

- **`Atom` first**: initial application via `registry.get`, re-application via `subscribeAtomScoped` — unsubscribe is a finalizer on the element scope, and each application runs in a per-application child scope so a replaced value's listeners are released.
- Atoms have no `.value`, so they never pass through `h.track`/`h.read`: pass the atom itself as the attr value, deriving the final attr string with `Atom.map`.
- **The component owns the requirements** (the pattern that keeps the thesis intact without `Atom.runtime`): extract service instances up front (`const http = yield* Http`) or capture context (`yield* Effect.context<R>()`), then build the Atom from those — the source is context-free, `R` rides the component's channel, and a forgotten Layer is still a compile error at `mount`. Pinned type-level by the new Atom-carrier assertion in `apps/demo/src/channels.test-d.ts`.

## Harness fix this surfaced

`render()` piped `Effect.provide(VerrexLive)` onto the mount effect, so the `AtomRegistry` was **disposed the moment `mount` returned** — any post-mount registry use (an Atom-driven attr, but equally an Atom *child*) threw `registry is disposed`. The harness now builds the layers with `Layer.build` into its held-open scope: services live until `unmount()`, and their finalizers fire there.

Both AGENTS nodes (runtime, testing) document the new contract and the component-owns-R pattern.

## Verification

- `pnpm -r test` — 256 core (2 new in `testing/atom-attr.test.ts`: registry-driven attr application, and subscription teardown via a Reactive swap while the registry stays live) + 32 ts-plugin.
- `pnpm -r typecheck` — clean, including the new `channels.test-d.ts` pin (`Effect<View, never, Http>` for an Atom-carrying component).