### PR TITLE
refactor(runtime): extract makeDepSubscription, shared by h.track and asyncRef

### DIFF
--- a/packages/core/src/runtime/AGENTS.md
+++ b/packages/core/src/runtime/AGENTS.md
@@ -53,7 +53,7 @@ and keeps its hint. If you rename a slot, update the regex.
 |---|---|
 | `h.ts` | `h()` factory + `track`/`read` reactivity-tracking machinery (built on `trackDeps`/`recordDep` from `coerce.ts`) |
 | `Component.ts` | `Component.make` — the canonical component constructor (traced `Effect.fn` seam + compiler-filled name slot). `Component.test.ts` pins the span-in-Cause; `Component.test-d.ts` pins the channel inference and generic preservation |
-| `coerce.ts` | `coerceAsync` (any child shape → `Effect<View>`) and `coerceSync` (render-time emission → `View`). Internal; not re-exported from `index.ts`. Owns `isAtomRef` (brand check against `AtomRef.TypeId`) and the shared dependency tracker `trackDeps`/`recordDep` (used by both `h.track` and `Async`) |
+| `coerce.ts` | `coerceAsync` (any child shape → `Effect<View>`) and `coerceSync` (render-time emission → `View`). Internal; not re-exported from `index.ts`. Owns `isAtomRef` (brand check against `AtomRef.TypeId`) and the shared dependency tracker `trackDeps`/`recordDep` and the subscription-lifecycle manager `makeDepSubscription` (both used by `h.track` and `Async`) |
 | `View.ts` | `View<E>` IR. The runtime shape is `ViewNode` — a hand-written union of 7 phantom-free named interfaces (`ViewText`…`ViewBoundary`, `ViewEmpty`); constructors via `Data.taggedEnum<ViewNode>()`. `View<E = never> = ViewNode & ViewErr<E>` layers the runtime-error channel on via a covariant phantom (`ViewErr`), so `View<HttpError>` ⊄ `View<never>` (mount can require it) while a `ViewNode` ⊂ any `View<E>` (constructors need no casts). Plus `isView`, `VIEW_TAGS` |
 | `mount.ts` | DOM renderer. `buildDom(view, ctx, scope) → Node` (`ctx: BuildCtx = { registry, context, sink }`), `mount(app, el)`. Cleanup is delegated to `Scope` — every subscription/listener/release registers a finalizer on the scope it was created in, and parent-fork cascade tears them down on close. Owns `buildScopedChild` (the one place a dynamic subtree gets a parent-linked child scope), the `List` **interpreter** that applies a `reconcile.ts` plan to real DOM + scopes, and the error **sink** (runs event-handler Effects + routes runtime failures) |
 | `reconcile.ts` | Pure keyed-list diff. `plan(prevKeys, nextKeys) → ReconcileOp[]` over opaque keys — no DOM, no `Scope`, no `Effect`. The runtime's highest-bug-density logic, made exhaustively unit-testable. `mount`'s `List` case interprets the ops |
@@ -148,6 +148,20 @@ The compiler wraps `{expr}` JSX expressions in `h.track(() => expr)`
 **Invariant: the empty-deps early return is load-bearing.** Without
 it, every `<Row item={item} />` would erase `item`'s generic type to
 `unknown`.
+
+**The resubscribe-fresh bookkeeping is `makeDepSubscription` (in
+`coerce.ts`), shared by `h.track` and `asyncRef`.** It owns the one
+thing both got identically wrong-prone: drop-all-then-resubscribe per
+run, the **non-idempotent AtomRef unsubscribe** guard (null the array
+after teardown), and a `closed` gate so a retained `refetch`/derived is
+inert after its scope tears down. Each caller still runs its own
+`trackDeps` and handles its own result — only the subscription lifecycle
+lives behind the seam. Unit-tested directly in
+`dep-subscription.test.ts`. **Known asymmetry:** `asyncRef` calls
+`dispose()` in its finalizer; `h.track` has no scope to hang one on, so
+its derived's dep subscriptions are **not** torn down on subtree rebuild
+— a latent leak under reactive-subtree churn (tracked separately; fixing
+it needs a build-scope threaded into `h.track`).
 
 ## View IR
 

--- a/packages/core/src/runtime/coerce.ts
+++ b/packages/core/src/runtime/coerce.ts
@@ -44,6 +44,49 @@ export const recordDep = (ref: AtomRef.ReadonlyRef<unknown>): void => {
   if (currentTracker) currentTracker.add(ref)
 }
 
+/**
+ * Owns the subscribe/resubscribe/teardown bookkeeping that `h.track` and
+ * `asyncRef` both need: a fresh set of dependency subscriptions on every run,
+ * each firing `onChange`. Both callers re-run a thunk under `trackDeps` and
+ * must re-subscribe to whatever refs that run read (a ternary's other branch,
+ * an effect's new deps), so the prior subscriptions are dropped first.
+ *
+ * The `unsubs` array is nulled after each teardown because `AtomRef`'s
+ * unsubscribe is **not idempotent** — replaying a stale unsubscriber would
+ * corrupt a later subscription's bookkeeping. Once `dispose`d the manager is
+ * inert: `resubscribe` is a no-op (a retained `refetch`/derived can fire after
+ * its scope tears down), and `closed` lets a caller surface that to its own
+ * callers.
+ */
+export const makeDepSubscription = (
+  onChange: () => void,
+): {
+  resubscribe: (deps: Iterable<AtomRef.ReadonlyRef<unknown>>) => void
+  dispose: () => void
+  readonly closed: boolean
+} => {
+  let unsubs: Array<() => void> = []
+  let closed = false
+  const unsubscribeAll = () => {
+    for (const u of unsubs) u()
+    unsubs = []
+  }
+  return {
+    resubscribe: (deps) => {
+      if (closed) return
+      unsubscribeAll()
+      for (const dep of deps) unsubs.push(dep.subscribe(onChange))
+    },
+    dispose: () => {
+      closed = true
+      unsubscribeAll()
+    },
+    get closed() {
+      return closed
+    },
+  }
+}
+
 const Empty = View.Empty()
 
 export function coerceAsync<C>(v: C): Effect.Effect<View, ChildE<C>, ChildR<C>>

--- a/packages/core/src/runtime/dep-subscription.test.ts
+++ b/packages/core/src/runtime/dep-subscription.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "@effect/vitest"
+import { AtomRef } from "effect/unstable/reactivity"
+import { makeDepSubscription } from "./coerce.ts"
+
+describe("makeDepSubscription", () => {
+  it("fires onChange when a subscribed dep changes", () => {
+    const ref = AtomRef.make(0)
+    let fired = 0
+    const sub = makeDepSubscription(() => fired++)
+    sub.resubscribe([ref])
+    ref.set(1)
+    expect(fired).toBe(1)
+  })
+
+  it("drops prior subscriptions on resubscribe (fresh deps per run)", () => {
+    const a = AtomRef.make(0)
+    const b = AtomRef.make(0)
+    let fired = 0
+    const sub = makeDepSubscription(() => fired++)
+    sub.resubscribe([a])
+    sub.resubscribe([b]) // a's subscription must be dropped
+    a.set(1)
+    expect(fired).toBe(0)
+    b.set(1)
+    expect(fired).toBe(1)
+  })
+
+  it("dispose unsubscribes all and flips closed; resubscribe is then a no-op", () => {
+    const ref = AtomRef.make(0)
+    let fired = 0
+    const sub = makeDepSubscription(() => fired++)
+    sub.resubscribe([ref])
+    sub.dispose()
+    expect(sub.closed).toBe(true)
+    ref.set(1)
+    expect(fired).toBe(0)
+    sub.resubscribe([ref]) // inert after dispose
+    ref.set(2)
+    expect(fired).toBe(0)
+  })
+})

--- a/packages/core/src/runtime/h.ts
+++ b/packages/core/src/runtime/h.ts
@@ -25,6 +25,11 @@ const trackImpl = (thunk: () => unknown): unknown => {
   const derived = AtomRef.make<unknown>(result)
 
   const rerun = () => {
+    // Ordering: run thunk → publish → drop-old-and-resubscribe (consolidated
+    // in `resubscribe`). The old code dropped old subs *before* the run; both
+    // orders leave a symmetric re-entrancy window (a dep written synchronously
+    // during `derived.set`'s notify) that no render path reaches — the mount
+    // listener rebuilds DOM, it doesn't write deps.
     const { result: next, deps: nextDeps } = trackDeps(thunk)
     derived.set(next as never)
     sub.resubscribe(nextDeps)

--- a/packages/core/src/runtime/h.ts
+++ b/packages/core/src/runtime/h.ts
@@ -1,6 +1,6 @@
 import { Effect } from "effect"
 import { AtomRef } from "effect/unstable/reactivity"
-import { coerceAsync, isAtomRef, recordDep, trackDeps } from "./coerce.ts"
+import { coerceAsync, isAtomRef, makeDepSubscription, recordDep, trackDeps } from "./coerce.ts"
 import type { FoldE, FoldLiveE, FoldR } from "./types/Fold.ts"
 import type { IntrinsicProps } from "./types/Html.ts"
 import { type Props, View } from "./View.ts"
@@ -21,23 +21,17 @@ const trackImpl = (thunk: () => unknown): unknown => {
   // At least one ref was read — wrap in a derived AtomRef that re-runs
   // the thunk whenever any tracked ref changes. Deps may change between
   // runs (a ternary's "other branch" reads different refs), so we
-  // re-subscribe fresh on each run.
+  // re-subscribe fresh on each run; `makeDepSubscription` owns that.
   const derived = AtomRef.make<unknown>(result)
-  let unsubs: Array<() => void> = []
-
-  const subscribeAll = (set: Set<AtomRef.ReadonlyRef<unknown>>) => {
-    for (const dep of set) unsubs.push(dep.subscribe(rerun))
-  }
 
   const rerun = () => {
-    for (const u of unsubs) u()
-    unsubs = []
     const { result: next, deps: nextDeps } = trackDeps(thunk)
     derived.set(next as never)
-    subscribeAll(nextDeps)
+    sub.resubscribe(nextDeps)
   }
+  const sub = makeDepSubscription(rerun)
 
-  subscribeAll(deps)
+  sub.resubscribe(deps)
   return derived
 }
 

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -1,6 +1,6 @@
 import { Cause, Effect, Exit, Fiber, Layer, Option, Queue, Scope, type Types } from "effect"
 import { AsyncResult, AtomRef, AtomRegistry } from "effect/unstable/reactivity"
-import { coerceAsync, type ErrorSink, isAtomRef, trackDeps } from "./coerce.ts"
+import { coerceAsync, type ErrorSink, isAtomRef, makeDepSubscription, trackDeps } from "./coerce.ts"
 import type { FoldE, FoldLiveE, FoldR } from "./types/Fold.ts"
 import { type BoundaryState, type Props, View } from "./View.ts"
 
@@ -116,17 +116,20 @@ export const asyncRef = <A, E, R>(
     // running the thunk under dep-tracking; each tracked ref's change enqueues
     // a fresh run (re-running the thunk to pick up new ref values + deps).
     const runs = yield* Queue.unbounded<Effect.Effect<A, E, R>>()
-    let unsubs: Array<() => void> = []
-    let closed = false
+    // `sub` owns the dep-subscription bookkeeping (resubscribe-fresh per run,
+    // the non-idempotent-unsubscribe guard, the closed-after-teardown gate);
+    // its `onChange` fires `schedule`, defined below.
+    let schedule: () => boolean
+    const sub = makeDepSubscription(() => schedule())
 
-    const schedule = (): boolean => {
+    schedule = (): boolean => {
       // `schedule` escapes this scope as `refetch`/`retry` (handed to failure
       // arms), so a retained reference can fire after teardown — a stashed
       // retry in a setTimeout, a click racing a boundary swap. Once the scope
       // closes this must be a no-op: re-subscribing would register
       // subscriptions the (already-run) finalizer can never clean, and the
       // queue's only consumer is dead. `false` is the caller's only signal.
-      if (closed) return false
+      if (sub.closed) return false
       // Flip to waiting SYNCHRONOUSLY, before the run is even enqueued: a
       // rebuild in the same tick — `refetch(); reset()` in either order —
       // must observe waiting, not re-escalate the stale non-waiting Failure.
@@ -135,24 +138,13 @@ export const asyncRef = <A, E, R>(
       // between. At construction the state is already Initial(waiting) — the
       // set dedups to a no-op.)
       state.set(AsyncResult.waitingFrom(Option.some(state.value)))
-      for (const u of unsubs) u()
-      unsubs = []
       const { result: eff, deps } = trackDeps(effect)
-      for (const dep of deps) unsubs.push(dep.subscribe(schedule))
+      sub.resubscribe(deps)
       Queue.offerUnsafe(runs, eff)
       return true
     }
     schedule() // initial run + dep subscriptions
-    yield* Scope.addFinalizer(
-      scope,
-      Effect.sync(() => {
-        closed = true
-        for (const u of unsubs) u()
-        // Cleared so nothing can ever replay the already-run unsubscribers —
-        // AtomRef's unsubscribe is not idempotent.
-        unsubs = []
-      }),
-    )
+    yield* Scope.addFinalizer(scope, Effect.sync(() => sub.dispose()))
 
     // Supervisor loop on the mount fiber: one child at a time; a new run
     // interrupts the prior. Scope close interrupts loop + live child.


### PR DESCRIPTION
## What

Extracts `makeDepSubscription` in `coerce.ts` — a single home for the dependency-subscription lifecycle that `h.track` and `asyncRef` previously each open-coded.

The duplicated bookkeeping was:
- drop-all → resubscribe-fresh on every run (deps can change between runs — a ternary's other branch, an effect's new deps)
- the **non-idempotent AtomRef unsubscribe** guard (null the array after teardown)
- the `closed`-after-teardown gate so a retained `refetch`/derived is inert once its scope tears down

A bug in any of those had to be fixed in two places.

## Shape

The manager owns *only* the subscription lifecycle. Each caller keeps its own `trackDeps` call and result-handling — those legitimately differ (`h.track` sets a derived `AtomRef`; `asyncRef` flips to `waiting`, enqueues an Effect, and returns a boolean closed-signal).

```ts
makeDepSubscription(onChange: () => void): {
  resubscribe(deps: Iterable<ReadonlyRef<unknown>>): void
  dispose(): void
  readonly closed: boolean
}
```

## Behavior-preserving

- `asyncRef` calls `dispose()` in its finalizer (as before)
- `h.track` still never disposes (the pre-existing leak is **documented, not changed** — see below)
- No public or type-surface change; no channel-fold impact
- One ordering nuance: the drop-old-subscriptions step moves from *before* the thunk run to *after* `derived.set` (now consolidated inside `resubscribe`). Old and new each leave a symmetric re-entrancy window (a dep written synchronously during notify) that no render path reaches — the mount listener rebuilds DOM, it doesn't write deps. Noted in a code comment rather than re-widening the interface to restore drop-first.

## Tests

- New `dep-subscription.test.ts` unit-tests the bookkeeping directly (resubscribe fires; resubscribe drops prior subs; dispose is terminal). It was previously only reachable through a mounted DOM.
- All 13 `src/testing` async/catch integration files (55 tests) pass — behavior preserved.
- `pnpm -r typecheck` clean (core, ts-plugin, demo via verrex-check).

## Follow-up (not in this PR)

The extraction surfaced a latent leak: `h.track` has no scope to hang a `dispose()` on, so its derived's dep subscriptions are **not** torn down on reactive-subtree rebuild (mount cleans *mount→derived*, nothing cleans *derived→underlying refs*). Documented in `runtime/AGENTS.md`; fixing it needs a build-scope threaded into `h.track` — its own design question, tracked separately.

