### PR TITLE
fix(runtime): tear down h.track derived subscriptions on subtree unmount

### DIFF
--- a/packages/core/src/runtime/AGENTS.md
+++ b/packages/core/src/runtime/AGENTS.md
@@ -166,7 +166,12 @@ derived→underlying-ref subscriptions outlived the subtree, re-running the
 thunk for the life of the underlying ref. Pinned by
 `testing/track-teardown.test.ts`. Assumes one derived is mounted at one
 site (one body-eval → one derived → one Reactive/prop node); a rebuild
-reruns the body and produces a fresh derived.
+reruns the body and produces a fresh derived. **Guarantee boundary:** the
+dispose only fires for deriveds that reach `subscribeRefScoped` — a
+derived that is created but never mounted (e.g. `buildDom` throws partway
+through a subtree after some `h.track` calls already ran) still leaks its
+subs. Acceptable for now; revisit if a tracked expression can be
+evaluated without its node attaching.
 
 ## View IR
 

--- a/packages/core/src/runtime/AGENTS.md
+++ b/packages/core/src/runtime/AGENTS.md
@@ -157,11 +157,16 @@ after teardown), and a `closed` gate so a retained `refetch`/derived is
 inert after its scope tears down. Each caller still runs its own
 `trackDeps` and handles its own result — only the subscription lifecycle
 lives behind the seam. Unit-tested directly in
-`dep-subscription.test.ts`. **Known asymmetry:** `asyncRef` calls
-`dispose()` in its finalizer; `h.track` has no scope to hang one on, so
-its derived's dep subscriptions are **not** torn down on subtree rebuild
-— a latent leak under reactive-subtree churn (tracked separately; fixing
-it needs a build-scope threaded into `h.track`).
+`dep-subscription.test.ts`. **Teardown asymmetry, resolved:** `asyncRef`
+calls `dispose()` in its finalizer; `h.track` has no scope to hang one
+on, so it stashes `dispose` on the derived via `setTrackDispose` and the
+mounting subtree's `subscribeRefScoped` (mount.ts) disposes it on scope
+close via `getTrackDispose`. Without this the derived's
+derived→underlying-ref subscriptions outlived the subtree, re-running the
+thunk for the life of the underlying ref. Pinned by
+`testing/track-teardown.test.ts`. Assumes one derived is mounted at one
+site (one body-eval → one derived → one Reactive/prop node); a rebuild
+reruns the body and produces a fresh derived.
 
 ## View IR
 

--- a/packages/core/src/runtime/coerce.ts
+++ b/packages/core/src/runtime/coerce.ts
@@ -58,6 +58,31 @@ export const recordDep = (ref: AtomRef.ReadonlyRef<unknown>): void => {
  * its scope tears down), and `closed` lets a caller surface that to its own
  * callers.
  */
+/**
+ * A `h.track` derived `AtomRef` stashes its `makeDepSubscription.dispose` here
+ * so the subtree that mounts it can tear down the derived→underlying-ref
+ * subscriptions on scope close. `h.track` has no scope of its own to register a
+ * finalizer on (it's a plain sync call in a compiled component body), so the
+ * one place that *does* scope the subscription — `subscribeRefScoped` in
+ * `mount.ts` — disposes it via `getTrackDispose`. User refs and `asyncRef`'s
+ * `state` (which owns its own teardown) carry no such tag, so the dispose is
+ * `h.track`-only by construction.
+ */
+const TrackDisposeId = Symbol.for("verrex/trackDispose")
+
+/** Tag `ref` with the `dispose` that tears down its tracked subscriptions. */
+export const setTrackDispose = (
+  ref: AtomRef.ReadonlyRef<unknown>,
+  dispose: () => void,
+): void => {
+  ;(ref as { [TrackDisposeId]?: () => void })[TrackDisposeId] = dispose
+}
+
+/** The tracked-subscription dispose for `ref`, if it is a `h.track` derived. */
+export const getTrackDispose = (
+  ref: AtomRef.ReadonlyRef<unknown>,
+): (() => void) | undefined => (ref as { [TrackDisposeId]?: () => void })[TrackDisposeId]
+
 export const makeDepSubscription = (
   onChange: () => void,
 ): {

--- a/packages/core/src/runtime/coerce.ts
+++ b/packages/core/src/runtime/coerce.ts
@@ -58,31 +58,6 @@ export const recordDep = (ref: AtomRef.ReadonlyRef<unknown>): void => {
  * its scope tears down), and `closed` lets a caller surface that to its own
  * callers.
  */
-/**
- * A `h.track` derived `AtomRef` stashes its `makeDepSubscription.dispose` here
- * so the subtree that mounts it can tear down the derived→underlying-ref
- * subscriptions on scope close. `h.track` has no scope of its own to register a
- * finalizer on (it's a plain sync call in a compiled component body), so the
- * one place that *does* scope the subscription — `subscribeRefScoped` in
- * `mount.ts` — disposes it via `getTrackDispose`. User refs and `asyncRef`'s
- * `state` (which owns its own teardown) carry no such tag, so the dispose is
- * `h.track`-only by construction.
- */
-const TrackDisposeId = Symbol.for("verrex/trackDispose")
-
-/** Tag `ref` with the `dispose` that tears down its tracked subscriptions. */
-export const setTrackDispose = (
-  ref: AtomRef.ReadonlyRef<unknown>,
-  dispose: () => void,
-): void => {
-  ;(ref as { [TrackDisposeId]?: () => void })[TrackDisposeId] = dispose
-}
-
-/** The tracked-subscription dispose for `ref`, if it is a `h.track` derived. */
-export const getTrackDispose = (
-  ref: AtomRef.ReadonlyRef<unknown>,
-): (() => void) | undefined => (ref as { [TrackDisposeId]?: () => void })[TrackDisposeId]
-
 export const makeDepSubscription = (
   onChange: () => void,
 ): {
@@ -111,6 +86,31 @@ export const makeDepSubscription = (
     },
   }
 }
+
+/**
+ * A `h.track` derived `AtomRef` stashes its `makeDepSubscription.dispose` here
+ * so the subtree that mounts it can tear down the derived→underlying-ref
+ * subscriptions on scope close. `h.track` has no scope of its own to register a
+ * finalizer on (it's a plain sync call in a compiled component body), so the
+ * one place that *does* scope the subscription — `subscribeRefScoped` in
+ * `mount.ts` — disposes it via `getTrackDispose`. User refs and `asyncRef`'s
+ * `state` (which owns its own teardown) carry no such tag, so the dispose is
+ * `h.track`-only by construction.
+ */
+const TrackDisposeId = Symbol.for("verrex/trackDispose")
+
+/** Tag `ref` with the `dispose` that tears down its tracked subscriptions. */
+export const setTrackDispose = (
+  ref: AtomRef.ReadonlyRef<unknown>,
+  dispose: () => void,
+): void => {
+  ;(ref as { [TrackDisposeId]?: () => void })[TrackDisposeId] = dispose
+}
+
+/** The tracked-subscription dispose for `ref`, if it is a `h.track` derived. */
+export const getTrackDispose = (
+  ref: AtomRef.ReadonlyRef<unknown>,
+): (() => void) | undefined => (ref as { [TrackDisposeId]?: () => void })[TrackDisposeId]
 
 const Empty = View.Empty()
 

--- a/packages/core/src/runtime/h.ts
+++ b/packages/core/src/runtime/h.ts
@@ -1,6 +1,13 @@
 import { Effect } from "effect"
 import { AtomRef } from "effect/unstable/reactivity"
-import { coerceAsync, isAtomRef, makeDepSubscription, recordDep, trackDeps } from "./coerce.ts"
+import {
+  coerceAsync,
+  isAtomRef,
+  makeDepSubscription,
+  recordDep,
+  setTrackDispose,
+  trackDeps,
+} from "./coerce.ts"
 import type { FoldE, FoldLiveE, FoldR } from "./types/Fold.ts"
 import type { IntrinsicProps } from "./types/Html.ts"
 import { type Props, View } from "./View.ts"
@@ -35,6 +42,9 @@ const trackImpl = (thunk: () => unknown): unknown => {
     sub.resubscribe(nextDeps)
   }
   const sub = makeDepSubscription(rerun)
+  // h.track has no scope to register a finalizer on; stash dispose so the
+  // mounting subtree's scope (via subscribeRefScoped) tears these subs down.
+  setTrackDispose(derived, sub.dispose)
 
   sub.resubscribe(deps)
   return derived

--- a/packages/core/src/runtime/mount.ts
+++ b/packages/core/src/runtime/mount.ts
@@ -1,6 +1,6 @@
 import { Cause, Context, Effect, Exit, Scope } from "effect"
 import { Atom, AtomRef, AtomRegistry } from "effect/unstable/reactivity"
-import { coerceSync, type ErrorSink, isAtomRef } from "./coerce.ts"
+import { coerceSync, type ErrorSink, getTrackDispose, isAtomRef } from "./coerce.ts"
 import { plan } from "./reconcile.ts"
 import { type BoundaryState, type Props, View, type ViewNode } from "./View.ts"
 
@@ -48,7 +48,19 @@ const subscribeRefScoped = <A>(
   scope: Scope.Scope,
 ): void => {
   const dispose = ref.subscribe(fn)
-  Effect.runSync(Scope.addFinalizer(scope, Effect.sync(dispose)))
+  // If `ref` is a `h.track` derived, also tear down its own
+  // derived→underlying-ref subscriptions on scope close — `h.track` has no
+  // scope to do it itself. No-op for user refs / asyncRef state (untagged).
+  const trackDispose = getTrackDispose(ref as AtomRef.ReadonlyRef<unknown>)
+  Effect.runSync(
+    Scope.addFinalizer(
+      scope,
+      Effect.sync(() => {
+        dispose()
+        trackDispose?.()
+      }),
+    ),
+  )
 }
 
 // AtomRegistry uses a different subscribe shape (registry.subscribe(atom, fn))

--- a/packages/core/src/testing/track-teardown.test.ts
+++ b/packages/core/src/testing/track-teardown.test.ts
@@ -1,0 +1,45 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from "@effect/vitest"
+import { AtomRef } from "effect/unstable/reactivity"
+import { h } from "@verrex/core"
+import { render } from "@verrex/core/testing"
+
+// Regression: a reactive expression compiles to `h.track(() => …)`, which
+// returns a derived AtomRef subscribed to whatever refs the thunk reads. When
+// the mounting subtree tears down, those derived→underlying-ref subscriptions
+// must be disposed too — not just the mount→derived one. Otherwise the thunk
+// keeps re-running (and the derived stays retained) for the life of the
+// underlying ref, every time it changes.
+
+describe("h.track subscription teardown", () => {
+  it("stops re-running the tracked thunk after the subtree unmounts", async () => {
+    const dep = AtomRef.make(0)
+    let runs = 0
+
+    // <div>{ String(dep.value) }</div>, hand-compiled. `h()` already returns
+    // an Effect<View>, which is exactly what `render` takes.
+    const app = h(
+      "div",
+      {},
+      h.track(() => {
+        runs++
+        return String(h.read(dep))
+      }),
+    )
+
+    const ui = await render(app)
+    const afterMount = runs
+
+    // Live update while mounted: the thunk re-runs.
+    dep.set(1)
+    expect(runs).toBe(afterMount + 1)
+
+    await ui.unmount()
+    const afterUnmount = runs
+
+    // After teardown, changing the underlying ref must NOT re-run the thunk.
+    dep.set(2)
+    dep.set(3)
+    expect(runs).toBe(afterUnmount)
+  })
+})


### PR DESCRIPTION
## What

Fixes a subscription leak in `h.track`. A reactive expression compiles to `h.track(() => …)`, which returns a derived `AtomRef` subscribed to every ref its thunk reads. mount's `subscribeRefScoped` only disposed the **mount→derived** subscription; the derived's own **derived→underlying-ref** subscriptions were never torn down.

Result: when a reactive subtree rebuilds or is removed (e.g. a conditional inside a list row that gets removed), the derived's thunk keeps re-running — and the derived stays retained — for the entire life of the underlying ref, every time it changes.

## Why it existed

`h.track` is a plain sync call in a compiled component body — it has no `Scope` to register a finalizer on. `asyncRef` doesn't have this problem because it runs inside an Effect and disposes in its scope finalizer.

## Fix

`h.track` stashes its `makeDepSubscription.dispose` on the derived (`setTrackDispose`); the one seam that already scopes ref subscriptions — `subscribeRefScoped` in `mount.ts` — calls it on scope close (`getTrackDispose`). One seam covers **both** AtomRef subscription sites (the Reactive node and reactive props). The tag is `h.track`-only by construction, so user refs and `asyncRef`'s self-managed `state` ref are untouched.

**Assumption** (noted in `runtime/AGENTS.md`): one derived is mounted at one site — one body-eval → one derived → one Reactive/prop node. A rebuild reruns the body and produces a fresh derived. True today.

## Tests

- New `testing/track-teardown.test.ts` — mounts a tracked expression, unmounts, then mutates the underlying ref and asserts the thunk does **not** re-run. **Fails without the fix** (the thunk fires post-unmount), passes with it.
- Full `src/runtime` + `src/testing` suites green (128 tests); `pnpm -r typecheck` clean.

## Stacking

Built on #135 (`refactor/dep-subscription-manager`) — it needs that PR's `sub.dispose`. **Base is `refactor/dep-subscription-manager`, not `main`**; GitHub will retarget to `main` automatically once #135 merges. Review/merge #135 first.
