### PR TITLE
fix(compiler): scope-correct + cast-transparent self-tracking-helper skip

### DIFF
--- a/packages/core/src/compiler/AGENTS.md
+++ b/packages/core/src/compiler/AGENTS.md
@@ -53,7 +53,15 @@ Every JSX expression `{...}` triggers up to three local rewrites:
    (#3) also does **not** trigger a wrap — `list()` subscribes inside
    `mount`, so wrapping in `h.track` would be a redundant layer. Same
    for `Async(...)` and `Catch(...)` calls (`isSelfTrackingCall`):
-   they self-track and must reach the `h()` fold un-erased.
+   they self-track and must reach the `h()` fold un-erased. **Which
+   calls skip is decided scope-correctly** by `resolveHelperCalls` —
+   only a call whose callee binds to the `@verrex/core` import (by
+   *imported* name, so `import { Async as A }` ⇒ `A(...)` skips); a
+   call bound to the user's own `Async`/`Catch` (a local `const`, an
+   import from elsewhere) keeps its wrap, so its reactivity survives.
+   The skip looks through type-only wrappers (`as`/`satisfies`/`!`,
+   see `peelTypeWrappers`), so `{Async(…) satisfies X}` keeps its
+   channels too.
 
 2. **`x.value` → `h.read(x)`** inside the wrapped expression. Tracks
    AtomRef reads. (The *same* read rewrite also runs over the whole
@@ -177,7 +185,8 @@ visitor in `transformVerrex`). Deliberately narrow and additive:
   argument, bound by a plain identifier declarator (`const X = …`,
   exported or not). A second argument already present (an explicit name)
   is left alone.
-- Matched by name, like `isSelfTrackingCall` — an aliased import
+- Matched by name on the `Component.make` member shape (unlike
+  `isSelfTrackingCall`, which is scope-correct) — an aliased import
   (`import { Component as C }`) defeats it, which **fails soft**: the
   component still works, its span is just anonymous. No diagnostic.
 - `Component` is NOT auto-imported (it only appears in this rewrite when

--- a/packages/core/src/compiler/transform.test.ts
+++ b/packages/core/src/compiler/transform.test.ts
@@ -356,6 +356,65 @@ describe("Catch calls are not h.track-wrapped", () => {
   })
 })
 
+describe("self-tracking-helper skip is scope-correct + cast-transparent", () => {
+  // The skip resolves each Async/Catch callee's binding in its own scope
+  // (resolveHelperCalls), so it keys on what the name ACTUALLY refers to, not
+  // the bare string.
+
+  it("an ALIASED @verrex/core import still skips (binding-resolved, not name-matched)", () => {
+    const out = compile(`
+      import { Async as A } from "@verrex/core"
+      const x = <div>{A(() => client.get(id.value), { success: (v) => <span>{v}</span> })}</div>
+    `)
+    expect(out).toContain(`h.read(id)`)
+    expect(out).not.toMatch(/h\.track\(\(\)\s*=>\s*A\(/)
+  })
+
+  it("a LOCAL function named Async/Catch keeps its h.track wrap (user's own, stays reactive)", () => {
+    const local = compile(`
+      const Async = (x) => x
+      const y = <p>{Async(tag.value)}</p>
+    `)
+    expect(local).toContain(`h.track(() =>`)
+    expect(local).toContain(`h.read(tag)`)
+
+    // An import of the name from ELSEWHERE is likewise the user's function.
+    const imported = compile(`
+      import { Catch } from "some-other-lib"
+      const y = <p>{Catch(tag.value)}</p>
+    `)
+    expect(imported).toContain(`h.track(() =>`)
+  })
+
+  it("an unrelated local `Async` binding does not disable a real verrex Async elsewhere in the file", () => {
+    // Scope-correct: a binding in one scope never touches a call in another.
+    const out = compile(`
+      import { Async } from "@verrex/core"
+      const handlers = items.map(Async => Async.id)
+      const x = <div>{Async(() => client.get(id.value), { success: (v) => <span>{v}</span> })}</div>
+    `)
+    expect(out).not.toMatch(/h\.track\(\(\)\s*=>\s*Async\(\(\)/)
+  })
+
+  it("a cast/satisfies-wrapped Async/Catch keeps the skip (peeled before the check)", () => {
+    // `{Async(…) satisfies Effect<View<E>, …>}` is how a user pins a boundary's
+    // channel — the wrap would erase the very channel being asserted.
+    const sat = compile(`
+      import { Async } from "@verrex/core"
+      const x = <div>{Async(() => client.get(id.value), { success: (v) => <p>{v}</p> }) satisfies E}</div>
+    `)
+    expect(sat).toContain(`h.read(id)`)
+    expect(sat).not.toMatch(/h\.track\(\(\)\s*=>\s*Async\(/)
+
+    const asCast = compile(`
+      import { Catch } from "@verrex/core"
+      const x = <div>{Catch(<Child />, (c) => <span>{label.value}</span>) as C}</div>
+    `)
+    expect(asCast).toContain(`h.read(label)`)
+    expect(asCast).not.toMatch(/h\.track\(\(\)\s*=>\s*Catch\(/)
+  })
+})
+
 describe("whole-body `.value` reads (tracking outside JSX)", () => {
   // The JSX pass only rewrites `.value` inside JSX expressions. A third pass
   // rewrites `.value` reads that survive in *statements* — extracted Async

--- a/packages/core/src/compiler/transform.ts
+++ b/packages/core/src/compiler/transform.ts
@@ -110,29 +110,101 @@ interface RewriteState {
   wroteList: boolean
   usedH: boolean
   usedFragment: boolean
+  /**
+   * The exact `Async`/`Catch` CALL NODES that resolve to the `@verrex/core`
+   * helper (scope-correct — see `resolveHelperCalls`). Only these skip the
+   * `h.track` wrap; a same-named call bound to the user's own function (a
+   * local `const Async = …`, an import from elsewhere) is absent and keeps
+   * its wrap. Identity is stable: the JSX→`h()` transform mutates a call's
+   * children but never the call node itself, so the node marked here is the
+   * one `wrapTracked` later peels to.
+   */
+  verrexHelperCalls: ReadonlySet<t.Node>
 }
 
 /**
- * True when `expr` is a top-level call to a self-tracking boundary helper —
- * `Async(...)` or `Catch(...)`. Both return an `Effect<View, never, R | …>`
- * that must reach the `h()` fold intact, and both manage their own reactivity
- * (`Async` tracks its `from` thunk; `Catch` drives its state from a forked
- * loop). Wrapping either in `h.track` is redundant *and* harmful: `h.track` is
- * typed `(thunk) => unknown`, which erases the channels and drops them from the
- * fold. Same reason `.value.map(...)` → `list(...)` is left unwrapped. The inner
- * `.value` reads are still rewritten to `h.read` (e.g. a `.value` read in a
- * `Catch` fallback or an `Async` thunk).
+ * Strip expression wrappers that change only the TYPE of their operand, never
+ * its runtime value: `x as T`, `x satisfies T`, `x!`. Used by `wrapTracked`'s
+ * skip check so a cast-wrapped boundary (`{Async(…) satisfies …}` — how a user
+ * pins its channel) is recognized for the call it is at runtime. (No `<T>x`
+ * branch — the jsx parser plugin makes angle-bracket assertions unparseable;
+ * no ParenthesizedExpression — Babel only emits those under
+ * `createParenthesizedExpressions`, which we don't set: parens arrive as the
+ * bare inner node.)
+ */
+const peelTypeWrappers = (expr: t.Expression): t.Expression => {
+  let cur = expr
+  while (
+    t.isTSAsExpression(cur) ||
+    t.isTSSatisfiesExpression(cur) ||
+    t.isTSNonNullExpression(cur)
+  ) {
+    cur = cur.expression
+  }
+  return cur
+}
+
+/**
+ * Calls that must NOT be `h.track`-wrapped: `Async(...)` and `Catch(...)` each
+ * return an `Effect<View, never, R | …>` that has to reach the `h()` fold
+ * intact, and each manages its own reactivity (`Async` tracks its `from`
+ * thunk; `Catch` drives its state from a forked loop). Wrapping either is
+ * redundant *and* harmful: `h.track` is typed `(thunk) => unknown`, which
+ * erases the channels from the fold. (Same reason `.value.map(...)` →
+ * `list(...)` is left unwrapped.) The inner `.value` reads are still rewritten
+ * to `h.read` (a read in a `Catch` fallback or an `Async` thunk).
  *
- * Matched purely by callee name (the compiler has no types). So
- * `import { Async as A }` defeats the skip — `A(...)` would be wrongly
- * `h.track`-wrapped and lose its channels (a loud type error at the call site).
- * Import these unaliased.
+ * WHICH calls skip is decided SCOPE-CORRECTLY, up front, by
+ * `resolveHelperCalls`: only a call whose callee binds to the `@verrex/core`
+ * import is the real helper. So an ALIASED import (`import { Async as A }`)
+ * skips correctly, and a same-named call bound to the user's own function (a
+ * local `const Async = …`, an import from elsewhere) keeps its wrap — its
+ * reactivity survives.
  */
 const SELF_TRACKING_HELPERS: ReadonlySet<string> = new Set(["Async", "Catch"])
-const isSelfTrackingCall = (expr: t.Expression): boolean =>
-  t.isCallExpression(expr) &&
-  t.isIdentifier(expr.callee) &&
-  SELF_TRACKING_HELPERS.has(expr.callee.name)
+
+const isSelfTrackingCall = (expr: t.Expression, state: RewriteState): boolean =>
+  t.isCallExpression(expr) && state.verrexHelperCalls.has(expr)
+
+/**
+ * The self-tracking helper a binding refers to (by its IMPORTED name, so an
+ * alias resolves correctly), or `null`. Only a NAMED import from
+ * `@verrex/core` qualifies — a default/namespace import isn't one of these
+ * helpers, and a local binding (const/function/param) is the user's own.
+ */
+const importedHelperName = (path: NodePath): string | null => {
+  if (!path.isImportSpecifier()) return null
+  const decl = path.parentPath
+  if (!decl.isImportDeclaration() || decl.node.source.value !== "@verrex/core") return null
+  const imported = path.node.imported
+  const name = t.isIdentifier(imported) ? imported.name : imported.value
+  return SELF_TRACKING_HELPERS.has(name) ? name : null
+}
+
+/**
+ * Collect the exact `Async`/`Catch` call NODES that resolve to the
+ * `@verrex/core` helper, resolving each callee's binding in its own scope
+ * (`path.scope.getBinding`). A call is the helper when its callee binds to a
+ * `@verrex/core` import of a helper name (by IMPORTED name — `import { Async
+ * as A }` ⇒ `A(...)` qualifies), OR is UNRESOLVED with a helper name (a
+ * forgotten import — a TS error regardless, so skip-vs-wrap is moot). A LOCAL
+ * binding, or an import of the name from elsewhere, is the user's own
+ * function: not a helper, keeps its `h.track` wrap.
+ */
+const resolveHelperCalls = (ast: t.Node): Set<t.Node> => {
+  const helpers = new Set<t.Node>()
+  traverse(ast, {
+    CallExpression(path: NodePath<t.CallExpression>) {
+      const callee = path.node.callee
+      if (!t.isIdentifier(callee)) return
+      const binding = path.scope.getBinding(callee.name)
+      if (binding ? importedHelperName(binding.path) !== null : SELF_TRACKING_HELPERS.has(callee.name)) {
+        helpers.add(path.node)
+      }
+    },
+  })
+  return helpers
+}
 
 /**
  * Wrap a JSX-expression's value in a `h.track(() => expr)` call **only when
@@ -146,15 +218,20 @@ const isSelfTrackingCall = (expr: t.Expression): boolean =>
  *   - `.value.map(arrow → JSX)` → `list(...)` (flips `state.wroteList` for the
  *     `list` auto-import; subscribes inside `mount`).
  *   - `Async(() => …, arms)` and `Catch(child, …)` calls — these
- *     self-track (see `isSelfTrackingCall`).
+ *     self-track (see `isSelfTrackingCall` / `resolveHelperCalls`). The skip
+ *     looks through type-only wrappers (`peelTypeWrappers`), so
+ *     `{Async(…) satisfies X}` keeps its channels too.
  */
 const wrapTracked = (expr: t.Expression, state: RewriteState): t.Expression => {
   const { expr: rewritten, rewroteRead } = rewriteTrackedExpression(expr, state)
   if (!rewroteRead) return rewritten
   state.usedH = true // the rewrite emitted h.read (and below, possibly h.track)
   // Async / Catch self-track; the `.value`→`h.read` rewrite inside them is
-  // kept, but the outer `h.track` wrap is skipped so their channels survive the fold.
-  if (isSelfTrackingCall(rewritten)) return rewritten
+  // kept, but the outer `h.track` wrap is skipped so their channels survive the
+  // fold. Peel type-only wrappers first: `{Async(…) satisfies X}` evaluates to
+  // the bare call at runtime, and wrapping it would erase the channels the
+  // assertion was written to pin.
+  if (isSelfTrackingCall(peelTypeWrappers(rewritten), state)) return rewritten
   return t.callExpression(
     t.memberExpression(t.identifier("h"), t.identifier("track")),
     [t.arrowFunctionExpression([], rewritten)],
@@ -671,7 +748,12 @@ export const transformVerrex = (
     },
   })
 
-  const state: RewriteState = { wroteList: false, usedH: false, usedFragment: false }
+  const state: RewriteState = {
+    wroteList: false,
+    usedH: false,
+    usedFragment: false,
+    verrexHelperCalls: resolveHelperCalls(ast),
+  }
 
   traverse(ast, {
     JSXElement(path: NodePath<t.JSXElement>) {

--- a/packages/core/src/runtime/AGENTS.md
+++ b/packages/core/src/runtime/AGENTS.md
@@ -368,7 +368,10 @@ captures a snapshot and won't refetch — ordinary eager-read semantics.
 in the compiler — the same guard covers `Catch`) — `Async` self-tracks, and
 `h.track`'s `unknown` return would erase its `Effect<View, never, R | Scope>`
 channels from the `h()` fold. The inner `.value`→`h.read` rewrite is kept (the
-tracker needs it). Matched by callee name, so import `Async`/`Catch` unaliased.
+tracker needs it). Which calls skip is decided **scope-correctly**
+(`resolveHelperCalls`): a call whose callee binds to the `@verrex/core` import
+skips *regardless of alias* (`import { Async as A }` → `A(...)` skips); a
+same-named call bound to the user's own function keeps its wrap.
 
 Neither is a View IR variant. `asyncRef` builds an `AtomRef<AsyncResult>`; `Async`
 maps it through `AsyncResult.match` and returns a `View.Reactive` — the existing
@@ -476,7 +479,8 @@ overloads that front it.
 Unlike `Async`, this **is** a View IR variant (`Boundary`) — the sink-swap for
 the child subtree is a `buildDom`-time concern an existing `Reactive` can't
 express. The compiler skips the `h.track` wrap for `Catch(...)` calls (in
-`isSelfTrackingCall` alongside `Async`); import `Catch` unaliased.
+`isSelfTrackingCall` alongside `Async`; scope-correct, so an aliased
+`@verrex/core` import is fine — see the `Async` section above).
 
 **Scope/fiber lifetime is uniform across the runtime** — internalize this when
 touching any of it: construction effects bind to a per-build scope (above),


### PR DESCRIPTION
## What

The compiler skips the `h.track` wrap for `{Async(...)}` / `{Catch(...)}` JSX expressions so their `Effect<View, never, R | …>` channels reach the `h()` fold un-erased (`h.track` returns `unknown`, which would drop them). That skip was matched by **bare callee name**, which had two real holes:

1. **Aliased imports were silently broken.** `import { Async as A } from "@verrex/core"; {A(() => fetch(id.value), arms)}` — the local name `A` isn't in the helper set, so the call got `h.track`-wrapped and its channels erased. This is what forced the "import these unaliased" caveat in the docs.
2. **Type-only wrappers broke the skip.** `{Async(() => fetch(id.value), arms) satisfies Effect<View<E>, never, R>}` — exactly how a user pins a boundary's channel — was wrapped, erasing the very channel the `satisfies` was asserting.

## How

- **`resolveHelperCalls`** resolves each `Async`/`Catch` callee's binding in its own scope (`path.scope.getBinding`) and keys on the **imported** name, so:
  - an aliased `@verrex/core` import skips correctly (`import { Async as A }` ⇒ `A(...)` skips);
  - a user's **own** `const Async`/`Catch` (or an import of the name from another package) keeps its `h.track` wrap and stays reactive — scope-correct, so a binding in one scope never affects a call in another.
- **`peelTypeWrappers`** looks through `as` / `satisfies` / `!` before the skip check.

The skip decision is now a set-membership check on the exact call nodes, computed once up front.

## Scope

Pure compiler correctness — **no runtime behavior change**. This hardens the *existing* `Async`/`Catch` primitives (it does not touch `list`, the type fold, or any runtime path).

## Why separate

Carved out of the typed-event-handlers branch (#110), which builds on this by adding `list` to the same skip set. This piece stands alone: it fixes channel-erasure that affects `Async`/`Catch` users on `main` today, independent of the typed-handler thesis.

## Tests

`transform.test.ts` adds: aliased-import skip, local-`Async`/`Catch`-shadow keeps wrap, import-from-elsewhere keeps wrap, cross-scope non-interference, and the `satisfies`/`as` cast forms. Full suite green (258 core + 32 ts-plugin); `pnpm -r typecheck` clean.

https://claude.ai/code/session_01Y828yx3SCgGRC2amrsuqEv