### PR TITLE
ci: PR preview deployments for the demo

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,8 @@ on:
 permissions:
   contents: read
 
-# One Pages deploy at a time; let an in-flight deploy finish.
+# One deploy to gh-pages at a time; let an in-flight deploy finish so it
+# isn't cut off mid-push (which could leave the branch inconsistent).
 concurrency:
   group: github-pages
   cancel-in-progress: false
@@ -21,12 +22,11 @@ jobs:
     if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deploy.outputs.page_url }}
+      # Publishing to the gh-pages branch is a git push, not a Pages-artifact
+      # upload — so we need contents:write here (and nothing else). The Pages
+      # source is set to "Deploy from a branch: gh-pages", which is what lets
+      # PR previews live as subpaths of the same site (see preview.yml).
+      contents: write
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -51,10 +51,19 @@ jobs:
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile
-      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
       - run: pnpm --filter verrex-demo exec vite build --base=/verrex/
-      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+
+      - name: Publish to gh-pages
+        uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4.8.0
         with:
-          path: apps/demo/dist
-      - id: deploy
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+          branch: gh-pages
+          folder: apps/demo/dist
+          # clean:true purges the branch of last deploy's stale hashed assets,
+          # but clean-exclude keeps the previews umbrella so a production
+          # deploy never deletes an open PR's preview. force:false rebases
+          # instead of force-pushing, so it doesn't clobber a preview push
+          # that landed concurrently.
+          clean: true
+          clean-exclude: |
+            pr-preview/
+          force: false

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,78 @@
+name: PR Preview
+
+# Deploys each PR's demo build to a subpath of the same GitHub Pages site
+# (gh-pages branch, pr-preview/pr-<N>/), comments the URL, and removes it
+# when the PR closes.
+#
+# Security model — external code can never gain write access:
+#   - Trigger is `pull_request`, NOT `pull_request_target`. Fork-PR runs get
+#     a read-only GITHUB_TOKEN with no repo secrets, enforced by GitHub at the
+#     token level (no permissions: block or edited-in-PR workflow can escalate
+#     it). Publishing a preview is a git push, so a fork simply cannot deploy
+#     — and we deliberately do NOT wire a PAT to let it.
+#   - The job is additionally gated to same-repo PRs (head repo == this repo),
+#     so fork PRs don't even build here. They still run ci.yml, which already
+#     executes PR code with no secrets — so this adds no new exec surface.
+#   - Only accounts with write access can push a same-repo branch, so every PR
+#     that deploys comes from someone already trusted with the repo.
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
+
+permissions:
+  contents: read
+
+# One preview run per PR ref; a fresh push supersedes an in-flight build.
+concurrency:
+  group: preview-${{ github.ref }}
+
+jobs:
+  preview:
+    # Same-repo PRs only (excludes forks), and skip release-please's
+    # version-bump PRs — mirrors ci.yml's exclusion; a preview of a changelog
+    # bump has no value.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      !startsWith(github.head_ref, 'release-please--')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write        # push/remove the preview on the gh-pages branch
+      pull-requests: write    # comment the preview URL on the PR
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      # Build only when deploying (open/reopen/synchronize); on `closed` the
+      # preview action just removes the subtree, no build needed.
+      - if: github.event.action != 'closed'
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        with:
+          version: 11.3.0
+          run_install: false
+
+      - if: github.event.action != 'closed'
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '24'
+          cache: pnpm
+
+      - if: github.event.action != 'closed'
+        run: pnpm install --frozen-lockfile
+
+      - if: github.event.action != 'closed'
+        run: pnpm --filter verrex-demo exec vite build --base=/verrex/pr-preview/pr-${{ github.event.number }}/
+
+      - name: Deploy or remove preview
+        uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9 # v1.8.1
+        with:
+          source-dir: apps/demo/dist
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview
+          # auto: deploy on open/reopen/synchronize, remove on close.
+          action: auto

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -22,9 +22,12 @@ on:
 permissions:
   contents: read
 
-# One preview run per PR ref; a fresh push supersedes an in-flight build.
+# One preview run per PR ref. cancel-in-progress so a fresh push supersedes
+# an in-flight build (only the latest commit's preview matters), and a close
+# supersedes any in-flight build before removing the preview.
 concurrency:
   group: preview-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   preview:
@@ -66,7 +69,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - if: github.event.action != 'closed'
-        run: pnpm --filter verrex-demo exec vite build --base=/verrex/pr-preview/pr-${{ github.event.number }}/
+        run: pnpm --filter verrex-demo exec vite build --base=/verrex/pr-preview/pr-${{ github.event.pull_request.number }}/
 
       - name: Deploy or remove preview
         uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9 # v1.8.1


### PR DESCRIPTION
Deploys every same-repo PR's demo build to a subpath of the existing GitHub Pages site and comments the URL, then removes it when the PR closes.

**Live preview for this PR:** https://m9tdev.github.io/verrex/pr-preview/pr-147/ (verified serving)

## What ships

- **`preview.yml`** (new) — on `pull_request` (opened/reopened/synchronize/closed), builds the demo with `--base=/verrex/pr-preview/pr-<N>/` and hands off to `rossjrw/pr-preview-action` (`action: auto`): deploy on open/update, remove on close, comment the URL. `cancel-in-progress` so a fresh push (or a close) supersedes an in-flight build.
- **`deploy.yml`** — production moves off the Pages **artifact flow** onto the **`gh-pages` branch**, published with `JamesIves/github-pages-deploy-action`. `clean-exclude: pr-preview/` + `force: false` mean a `main` deploy purges its own stale assets but never wipes an open PR's preview.

The live-demo URL (`m9tdev.github.io/verrex/`) is unchanged and verified still serving after cutover.

## Security — external code can't gain write access

- `preview.yml` uses `pull_request`, **never** `pull_request_target`. Fork-PR runs get a read-only `GITHUB_TOKEN` and no secrets, enforced at the token level — so a fork **cannot** push a preview even if it edits the workflow to drop the gate. No PAT is wired, so there's no bypass.
- The preview job is additionally gated to same-repo PRs (`head.repo.full_name == github.repository`), so fork PRs don't build here at all (they still hit `ci.yml`, which already runs PR code with no secrets — no new exec surface).
- Least-privilege: per-job `permissions` (`contents: write` to publish, `pull-requests: write` to comment) instead of loosening the repo-wide Actions setting. All actions SHA-pinned; harden-runner on every job. Release-please PRs skipped.

## Pages cutover — already done

The one-time source flip (Actions/artifact flow → `gh-pages` branch) has already been applied to the repo and verified: production root and this PR's preview both serve 200 from the branch, coexisting (`clean-exclude` preserves `pr-preview/`). No manual step remains on merge — the Deploy workflow republishes the root idempotently, and pushes to `gh-pages` auto-trigger the Pages build.