### PR TITLE
chore(deps): pin typescript to 6.x and group it with Volar

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,7 +23,25 @@ updates:
         patterns:
           - "@babel/*"
           - "@types/babel__*"
+      # Same unit rule, different reason: @volar/* embed the TypeScript
+      # compiler API, so a Volar bump that outpaces its supported tsc (or the
+      # reverse) breaks the language plugin and verrex-check together. Also
+      # ANY level, so the pair can never split across two PRs.
+      typescript:
+        patterns:
+          - "typescript"
+          - "@volar/*"
       minor-and-patch:
         update-types:
           - minor
           - patch
+    ignore:
+      # TypeScript 7 is the Go port and ships NO compiler API — no
+      # createLanguageService, no IScriptSnapshot, and no extraFileExtensions,
+      # which is the hook that makes tsc accept .vx at all. Unblocking needs
+      # TS 7.1's API + Volar on top of it + CLI support for embedded
+      # languages; see #162 for the trigger conditions. Drop this entry when
+      # they land — the group above then moves typescript and Volar together.
+      - dependency-name: "typescript"
+        update-types:
+          - version-update:semver-major


### PR DESCRIPTION
Stops dependabot reopening the TypeScript 7 bump every week, and keeps
`typescript` and `@volar/*` moving as one unit for when they can move again.

## `ignore`: typescript majors

TypeScript 7 (GA 2026-07-08) is the Go native port and ships **no
programmatic compiler API**. Its root export is a version stub:

```json
"exports": { ".": "./lib/version.cjs", "./unstable/…": … }
```

Absent with no stable replacement: `createLanguageService`,
`IScriptSnapshot`, `ts.sys`, tsserver plugin loading, and —
decisively — **`extraFileExtensions`**, the hook that makes tsc accept
`.vx` at all.

Unblocking needs three upstream events, none of them ours: TS 7.1's API
(microsoft/TypeScript#63800), Volar on top of it, and CLI support for
embedded languages (microsoft/TypeScript#45886, a separate and less
advanced track — the one `verrex-check` needs). Vue and Svelte are stuck
at the same wall. Full trigger conditions and prior art in microsoft/typescript-go#162.

Remove this entry when they land; the group below then handles the move.

## `groups`: typescript + @volar/*

Same unit rule as the existing babel group, different reason: `@volar/*`
embed the TypeScript compiler API, so a Volar bump that outpaces its
supported tsc (or the reverse) breaks `@verrex/core/language` and
`verrex-check` together. Set at ANY level so the pair can't split across
two PRs — which is how microsoft/typescript-go#151 arrived alone and unmergeable.

Touches `.github/` only, so this releases nothing.

Refs microsoft/typescript-go#162