### PR TITLE
test(core): pin Atom-valued attr application and scoping

### DIFF
--- a/apps/demo/src/channels.test-d.ts
+++ b/apps/demo/src/channels.test-d.ts
@@ -5,8 +5,8 @@
  * mismatched channel — this *is* the demonstration.
  */
 import type { Cause, Chunk, Option, Result, Scope } from "effect"
-import { Effect } from "effect"
-import type { AtomRef } from "effect/unstable/reactivity"
+import { Effect, Stream } from "effect"
+import { Atom, type AtomRef } from "effect/unstable/reactivity"
 import {
   Async,
   type AsyncHandle,
@@ -391,6 +391,20 @@ mount(Caught, root)
 
 // A pure component needs no boundary — it's already `View<never>`, `never`.
 mount(Counter(), root)
+
+// ─── Atom carriers: the COMPONENT owns the requirements ──────────────────
+//     The service instance is extracted in the component body (`yield* Http`
+//     is what puts Http in R), and the Atom's stream source is built from
+//     that instance — so the source itself is context-free, `Atom.runtime`
+//     (which would bake the Layer and discharge R) never appears, and a
+//     forgotten HttpLive is still a compile error at mount.
+
+const AtomCarrier = Effect.gen(function* () {
+  const http = yield* Http // Http rides the component's R
+  const user = Atom.make(Stream.fromEffect(http.getUser("42")))
+  return yield* h("p", { "data-user": user }, "·")
+})
+assertEquals<typeof AtomCarrier, Effect.Effect<View, never, Http>>()
 
 // ─── Catch tag-map form narrows the error channel by tag ────────────────
 //     Handle specific tags; the rest stay on the channel and must still be

--- a/packages/core/src/runtime/AGENTS.md
+++ b/packages/core/src/runtime/AGENTS.md
@@ -733,6 +733,18 @@ Consumers don't call them directly either:
 both reactive consumers (`applyProp`, the Reactive child case) share;
 a third source shape extends it, not a new dispatch site.
 
+**Reactive props accept `Atom` or `AtomRef`.** An Atom passed directly
+as an attr value never goes through `h.track`/`h.read` (it has no
+`.value`) — pass the atom itself, deriving the final attr string with
+`Atom.map`. When an Atom's source needs services, the **component owns
+the requirements**: extract instances up front (`const http = yield* Http`)
+or capture context (`yield* Effect.context<R>()`), then build the Atom
+from those, so the source is context-free and a forgotten Layer is
+still a compile error at `mount`. `Atom.runtime` stays the anti-pattern
+(bakes the Layer, discharges `R`). Pinned by
+`testing/atom-attr.test.ts` and the Atom-carrier pin in
+`apps/demo/src/channels.test-d.ts`.
+
 **Fragments wrap in `<span style="display: contents">`.** Not a
 `DocumentFragment`, because `DocumentFragment` is consumed on insert
 — a later `replaceChild(fragment, ...)` would fail. The wrapper

--- a/packages/core/src/testing/atom-attr.test.ts
+++ b/packages/core/src/testing/atom-attr.test.ts
@@ -1,0 +1,79 @@
+// @vitest-environment happy-dom
+import { describe, it, expect } from "vitest"
+import { Effect } from "effect"
+import { Atom, AtomRef, AtomRegistry } from "effect/unstable/reactivity"
+import { h } from "@verrex/core"
+import { render } from "./index.ts"
+
+// Atom-valued props: `applyProp` reads + subscribes through the registry
+// (mirroring the Reactive child case), so a derived Atom can drive a single
+// attribute. Components own the registry via `yield* AtomRegistry` — the
+// harness injects it through VerrexLive.
+
+describe("Atom-valued attrs", () => {
+  it("applies the registry value initially and re-applies on registry.set", async () => {
+    const size = Atom.make(1)
+    const cls = Atom.map(size, (n) => `box size-${n}`)
+
+    const Box = Effect.fn(function* () {
+      const registry = yield* AtomRegistry.AtomRegistry
+      return yield* h(
+        "div",
+        {},
+        h(
+          "button",
+          { class: "grow", onclick: () => registry.set(size, 2) },
+          "+",
+        ),
+        h("span", { class: cls, id: "target" }, "x"),
+      )
+    })
+
+    const ui = await render(Box())
+    expect(ui.get("#target").getAttribute("class")).toBe("box size-1")
+
+    ui.click(".grow")
+    await ui.waitFor(".size-2")
+    expect(ui.get("#target").getAttribute("class")).toBe("box size-2")
+
+    await ui.unmount()
+  })
+
+  it("ties the subscription to the element scope: a swapped-away node stops receiving", async () => {
+    const n = Atom.make(0)
+    const show = AtomRef.make(true)
+    // Capture the component's own registry so the writes go through the SAME
+    // instance the attr subscribed on (a fresh registry would pass vacuously).
+    let reg!: AtomRegistry.AtomRegistry
+    const Probe = Effect.fn(function* () {
+      reg = yield* AtomRegistry.AtomRegistry
+      return yield* h(
+        "div",
+        {},
+        show.map((s) =>
+          s
+            ? h("span", { "data-n": n, id: "probe" }, "x")
+            : h("span", { class: "gone" }, "-"),
+        ),
+      )
+    })
+
+    const ui = await render(Probe())
+    const probe = ui.get("#probe")
+    expect(probe.getAttribute("data-n")).toBe("0")
+
+    reg.set(n, 1)
+    await ui.waitFor('[data-n="1"]')
+
+    // Swap the subtree away: the Reactive emit closes the old child scope,
+    // which holds the attr subscription as a finalizer. The registry is still
+    // alive — a further write must not reach the detached node.
+    show.set(false)
+    await ui.waitFor(".gone")
+    reg.set(n, 9)
+    await ui.tick()
+    expect(probe.getAttribute("data-n")).toBe("1")
+
+    await ui.unmount()
+  })
+})


### PR DESCRIPTION
Salvage of #123, whose runtime and harness changes were subsumed by #153's `applyAndSubscribeSource` seam. What main still lacked is the coverage:

- **`testing/atom-attr.test.ts`** — an Atom driving a single attr applies initially, re-applies on `registry.set`, and the subscription dies with the element's scope when the node is swapped away (writes no longer reach the detached node).
- **`channels.test-d.ts`** — the Atom-carrier pin: the component extracts the service instance (`yield* Http` is what puts `Http` on `R`), builds the Atom from it, and a forgotten `HttpLive` remains a compile error at `mount`.
- **`runtime/AGENTS.md`** — the component-owns-requirements guidance for Atom-valued props, pointing at both pins.

Verified: format, lint, `pnpm -r typecheck` (incl. `verrex-check`), 298 core + 32 ts-plugin tests green.

Closes #123.