### PR TITLE
refactor(runtime)!: mount owns its AtomRegistry

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,34 +103,22 @@ export const Counter = Component.make(function* () {
 
 ```ts
 // main.vx
-import { Effect, Layer, Scope } from "effect"
-import { VerrexLive, mount } from "@verrex/core"
+import { Effect } from "effect"
+import { mount } from "@verrex/core"
 import { Counter } from "./Counter.vx"
 
-// Build the layers INTO a scope that outlives the UI, and mount with the
-// resulting context. The `AtomRegistry` VerrexLive provides owns every live
-// subscription, so it has to outlive the mounted tree — see below.
+// `mount` owns its AtomRegistry (created per mount, disposed with the
+// mount's scope) — there is no framework layer to provide.
 const program = Effect.gen(function* () {
-  const context = yield* Layer.build(VerrexLive)
-  yield* Effect.provideContext(
-    mount(<Counter />, document.getElementById("root")!),
-    context,
-  )
+  yield* mount(<Counter />, document.getElementById("root")!)
   yield* Effect.never
 }).pipe(Effect.scoped)
 
 Effect.runFork(program)
 ```
 
-> **The registry must outlive the mount.** Don't write
-> `mount(...).pipe(Effect.provide(VerrexLive))`. That scopes the layer to the
-> mount effect, which completes the moment the DOM is attached — disposing the
-> `AtomRegistry` out from under the live UI. Everything renders once and then
-> silently stops updating. (The shape above survives only because
-> `Effect.never` holds the scope open; drop it, or mount from a function that
-> returns, and the freeze is immediate.) This is a runtime requirement the
-> types cannot express today: `mount`'s `R` says the registry is _required_,
-> not that it must _outlive_ the scope — so the broken shape type-checks.
+Closing the scope around a mount detaches the DOM and disposes the registry
+together, so the UI and its reactivity always die at the same moment.
 
 ## Layout
 

--- a/apps/demo/src/channels.test-d.ts
+++ b/apps/demo/src/channels.test-d.ts
@@ -6,7 +6,7 @@
  */
 import type { Cause, Chunk, Option, Result, Scope } from "effect"
 import { Effect, Stream } from "effect"
-import { Atom, type AtomRef } from "effect/unstable/reactivity"
+import { Atom, AtomRegistry, type AtomRef } from "effect/unstable/reactivity"
 import {
   Async,
   type AsyncHandle,
@@ -391,6 +391,26 @@ mount(Caught, root)
 
 // A pure component needs no boundary — it's already `View<never>`, `never`.
 mount(Counter(), root)
+
+// ─── mount owns the AtomRegistry (#167) ─────────────────────────────────
+//     A component that resolves `yield* AtomRegistry` carries it on R, and
+//     mount DISCHARGES it — the result needs no registry layer. This is the
+//     type-level half of the fix: the registry no longer rides `mount`'s R,
+//     so it can no longer be provided with the wrong lifetime.
+
+const RegistryUser = Effect.gen(function* () {
+  const registry = yield* AtomRegistry.AtomRegistry
+  return yield* h("p", {}, `${typeof registry}`)
+})
+assertEquals<
+  typeof RegistryUser,
+  Effect.Effect<View, never, AtomRegistry.AtomRegistry>
+>()
+assertEquals<
+  ReturnType<typeof mount<AtomRegistry.AtomRegistry>>,
+  Effect.Effect<void, never, Scope.Scope>
+>()
+mount(RegistryUser, root)
 
 // ─── Atom carriers: the COMPONENT owns the requirements ──────────────────
 //     The service instance is extracted in the component body (`yield* Http`

--- a/apps/demo/src/main.vx
+++ b/apps/demo/src/main.vx
@@ -1,6 +1,6 @@
 import { Cause, Effect, Exit, Fiber, Layer, Scope } from "effect"
 import { AtomRegistry } from "effect/unstable/reactivity"
-import { VerrexLive, Catch, mount, type View } from "@verrex/core"
+import { Catch, mount, type View } from "@verrex/core"
 import { Counter } from "./Counter.vx"
 import { AsyncUserPage } from "./AsyncUserPage.vx"
 import { AsyncEscalate } from "./AsyncEscalate.vx"
@@ -417,10 +417,10 @@ if (!rootEl) throw new Error("missing #root")
 // provides — `setupDemo`'s signature enforces it, so forgetting (say) HttpLive
 // is a compile error at the UserPage/AsyncUserPage/LiveUser call sites, not a
 // runtime crash. That's the thesis, now enforced per-mount.
-const APP_LAYER = Layer.mergeAll(VerrexLive, HttpLive, ThemeLive)
+const APP_LAYER = Layer.mergeAll(HttpLive, ThemeLive)
 
-// Everything the demos may require, after VerrexLive/HttpLive/ThemeLive: the
-// reactivity registry, the two services, and a Scope.
+// Everything the demos may require, after HttpLive/ThemeLive: the reactivity
+// registry (discharged by `mount`, which owns it), the two services, and a Scope.
 type DemoR = AtomRegistry.AtomRegistry | Http | Theme | Scope.Scope
 
 /**
@@ -450,9 +450,8 @@ const setupDemo = <E,>(
     // through unchanged; this is also where the boundary itself gets exercised.
     // Build APP_LAYER INTO the demo's scope (not `Effect.provide`, which scopes
     // it to the mount effect — an effect that completes once the DOM attaches).
-    // The AtomRegistry must outlive the mounted UI: reactive expressions
-    // (`h.track` deriveds) and Atom sources live in it, and disposing it severs
-    // every subscription. Closing the demo scope on ↻ reset disposes it.
+    // The AtomRegistry needs no layer: `mount` owns one per mount and disposes
+    // it with the same scope close that detaches the DOM.
     Effect.runFork(
       Scope.provide(
         Effect.flatMap(Layer.build(APP_LAYER), (ctx) =>

--- a/packages/core/src/runtime/AGENTS.md
+++ b/packages/core/src/runtime/AGENTS.md
@@ -21,7 +21,7 @@ Public surface (from `index.ts`):
 - `Fragment` — `<>...</>` compile target (a direct-call component since
   #71: `Fragment({ children: [...] })`, generic over the children tuple —
   also the canonical pattern for effectful-children components)
-- `VerrexLive` — base Layer providing `AtomRegistry`
+- `VerrexLive` — deprecated no-op compat Layer (`mount` owns the registry)
 - Types: `View<E>`, `Props`, `FoldE`/`FoldLiveE`/`FoldR` (the `Tag*`
   families died with #71 — component channels are ordinary child folds),
   `FoldPropsLiveE`/`FoldPropsR` (the props fold, #72),
@@ -138,7 +138,10 @@ ship our own atom/signal primitive.
 - `AtomRef.Collection<T>` — reactive array; rows are
   `AtomRef.AtomRef<T>` so each row is its own subscribable cell.
 
-`mount` requires `AtomRegistry` in `R`. `VerrexLive` provides it.
+`mount` owns its `AtomRegistry` — it creates one per mount, provides it
+to the app effect (discharging `AtomRegistry` from the app's `R`), and
+disposes it on scope close. `VerrexLive` is deprecated (a no-op compat
+layer); nothing needs to provide a registry.
 
 ## The track/read dance
 
@@ -239,28 +242,17 @@ only ever construct deriveds with **`Atom.readable` over a sync thunk**.
 there anyway — is never called. Nothing tests this; the guard is that
 one call site.
 
-**Invariant: the `AtomRegistry` must outlive the mount's `Scope`.**
-`h.track` deriveds and Atom sources live in the registry; disposing it
-severs every subscription silently. `Effect.provide(VerrexLive)` around
-a mount effect is WRONG — the mount effect completes once the DOM
-attaches, and the layer's finalizer disposes the registry out from
-under the live UI. Build the layer into the long-lived scope instead
-(`Layer.build` under `Scope.provide`; see `testing/index.ts` and the
-demo's `setupDemo`).
-
-**This is the sharpest edge in the whole design, and the types do not
-catch it.** `mount`'s `R` says the registry is REQUIRED; it cannot say it
-must OUTLIVE the scope — so the broken shape type-checks and fails at
-runtime, which is precisely the trade this framework exists to avoid.
-Before #153 it was harmless (`h.track` held its own subscriptions, so
-registry lifetime wasn't load-bearing) and it silently became fatal.
-Two symptoms, one cause: the UI renders once then **silently** stops
-updating; or a rebuild that constructs a new derived post-dispose throws
-out of an innocent `.set(...)` — `readAtomOrExplain` in `mount.ts`
-rewrites that one into an actionable message, since it is the only
-symptom we can intercept. The silent-freeze case has no runtime guard
-today. `README.md` documents the correct shape; expressing the lifetime
-requirement in the type is open work.
+**Invariant: the mount owns the registry's lifetime.** `mount` creates
+its `AtomRegistry`, provides it to the app effect, and registers its
+disposal as a finalizer BEFORE `buildDom` — so LIFO scope close runs the
+DOM detach and every child-scope unsubscribe against a still-live
+registry, and disposes it last. The registry and the UI it drives die
+together; a mis-scoped provision freezing a live UI is no longer
+expressible, because callers never provide the registry at all. (Before
+this, `AtomRegistry` rode `mount`'s `R` and `Effect.provide(VerrexLive)`
+around the mount silently disposed it once the DOM attached — the type
+system could say "required" but not "must outlive"; making the mount the
+owner deleted the requirement rather than encoding it.)
 
 **Timing:** dep-change propagation (bridge `setSelf` → derived recompute
 → mount listener) is **synchronous** — DOM update timing is unchanged.

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -753,8 +753,11 @@ export const Fragment = <Cs extends ReadonlyArray<unknown>>(props: {
  * The base Layer every verrex app needs. Provides the `AtomRegistry` so any
  * reactive children in the view tree have somewhere to live.
  *
- * Merge this with your app-specific Layers (Http, Db, Theme, etc.) before
- * passing to `Effect.provide`.
+ * @deprecated No longer needed: `mount` creates and owns its registry (its
+ * lifetime is the mount's scope), and provides it to the app effect — a
+ * component's `yield* AtomRegistry.AtomRegistry` resolves to it. Providing
+ * this layer is now a harmless no-op; it will be removed in a future
+ * release.
  */
 export const VerrexLive: Layer.Layer<AtomRegistry.AtomRegistry> =
   AtomRegistry.layer

--- a/packages/core/src/runtime/mount.ts
+++ b/packages/core/src/runtime/mount.ts
@@ -123,34 +123,6 @@ const subscribeAtomScoped = <A>(
   Effect.runSync(Scope.addFinalizer(scope, Effect.sync(dispose)))
 }
 
-// A rebuild that constructs a new derived AFTER the registry was disposed
-// throws `Cannot access Atom <atom>: registry is disposed` — out of whatever
-// innocent `ref.set(...)` triggered the rebuild, naming no component and no
-// service, past `Catch` and the `ErrorSink` both. Since disposal-too-early has
-// exactly one cause, say so. Matching on effect's message is deliberately
-// best-effort: if it changes we rethrow the original untouched, losing only
-// the hint.
-const readAtomOrExplain = (
-  registry: AtomRegistry.AtomRegistry,
-  atom: Atom.Atom<unknown>,
-): unknown => {
-  try {
-    return registry.get(atom)
-  } catch (e) {
-    if (e instanceof Error && /registry is disposed/i.test(e.message)) {
-      throw new Error(
-        "[verrex] the AtomRegistry was disposed while the UI was still mounted. " +
-          "`Effect.provide(VerrexLive)` around a mount scopes the layer TO the mount " +
-          "effect, which completes as soon as the DOM attaches. Build the layer into a " +
-          "longer-lived scope instead (`Layer.build` under `Scope.provide`) — see the " +
-          "registry-outlives-mount invariant in runtime/AGENTS.md.",
-        { cause: e },
-      )
-    }
-    throw e
-  }
-}
-
 // The one seam where the two reactive source shapes converge: apply the
 // current value (immediately, or deferred to `deferInitial` drain time — the
 // deferred thunk re-reads the source THEN, so a write landing during the
@@ -169,7 +141,7 @@ const applyAndSubscribeSource = (
   deferInitial?: Array<() => void>,
 ): void => {
   const read = Atom.isAtom(source)
-    ? () => readAtomOrExplain(registry, source as Atom.Atom<unknown>)
+    ? () => registry.get(source as Atom.Atom<unknown>)
     : isAtomRef(source)
       ? () => source.value
       : null
@@ -577,6 +549,13 @@ const buildDom = (view: ViewNode, ctx: BuildCtx, scope: Scope.Scope): Node => {
  * fails) that aren't caught by a `Catch` boundary are routed to a root
  * error sink that logs via `Effect.logError` on the captured context.
  *
+ * **The `AtomRegistry` is owned by the mount, not required from context.**
+ * `mount` creates a registry and disposes it in the same scope close that
+ * detaches the DOM — the registry and the UI it drives always die together,
+ * so a mis-scoped provision can't freeze a live UI. A component's
+ * `yield* AtomRegistry.AtomRegistry` resolves to the mount's own registry
+ * (it is provided to the app effect, and discharged from `R` here).
+ *
  * **Requires `Effect<View<never>, never, R>`** — the app must have every error
  * discharged: construction failures off the Effect `E` channel (via
  * `Effect.catchCause` or a `Catch` boundary) and live failures off the
@@ -586,9 +565,13 @@ const buildDom = (view: ViewNode, ctx: BuildCtx, scope: Scope.Scope): Node => {
 export const mount = <R>(
   app: Effect.Effect<View<never>, never, R>,
   el: HTMLElement,
-): Effect.Effect<void, never, R | AtomRegistry.AtomRegistry | Scope.Scope> =>
+): Effect.Effect<
+  void,
+  never,
+  Exclude<R, AtomRegistry.AtomRegistry> | Scope.Scope
+> =>
   Effect.gen(function* () {
-    const registry = yield* AtomRegistry.AtomRegistry
+    const registry = AtomRegistry.make()
     // The real ambient context (carries the app's provided services). Typed
     // `never` so it threads without a generic — handler Effects are cast to
     // `R = never` at the run site; the services are present at runtime.
@@ -602,8 +585,15 @@ export const mount = <R>(
       sink,
       runSyncExit: Effect.runSyncExitWith(context),
     }
-    const view = yield* app
+    const view = yield* Effect.provideService(
+      app,
+      AtomRegistry.AtomRegistry,
+      registry,
+    )
     const scope = yield* Effect.scope
+    // Registered BEFORE buildDom so LIFO close runs it LAST: the DOM detach
+    // and every child-scope unsubscribe run against a still-live registry.
+    yield* Effect.addFinalizer(() => Effect.sync(() => registry.dispose()))
     const node = buildDom(view, ctx, scope)
     el.replaceChildren()
     el.appendChild(node)

--- a/packages/core/src/testing/AGENTS.md
+++ b/packages/core/src/testing/AGENTS.md
@@ -29,12 +29,13 @@ await ui.unmount()
 - `render(app, layer?)` — `app` is a component result (`Component(props)`,
   what a component tag compiles to since #71), i.e. an `Effect<View, E, R>`. Creates a
   container on `document.body`, makes a Closeable `Scope`, and runs
-  `mount(app, container)` with `VerrexLive` (AtomRegistry) + that scope
-  provided. Returns once the DOM is attached. The layers are built INTO
+  `mount(app, container)` with the caller's layer + that scope
+  provided. Returns once the DOM is attached. The layer is built INTO
   the harness scope via `Layer.build` — not `Effect.provide`, which would
-  dispose the `AtomRegistry` the moment the mount effect completes,
-  severing every `h.track`/Atom subscription (see the
-  registry-must-outlive-mount invariant in the runtime AGENTS.md).
+  run the services' finalizers the moment the mount effect completes.
+  The `AtomRegistry` needs no layer: `mount` owns one per mount and
+  disposes it with the same scope close (see the mount-owns-registry
+  invariant in the runtime AGENTS.md).
 - `RenderResult` — `get`/`query`/`all`/`text` (DOM queries),
   `click`/`fire` (dispatch bubbling events that hit the component's
   handlers — an `onClick` returning an `Effect` is forked on the mount
@@ -132,13 +133,13 @@ map handle one tag and let the residual ride to a boundary.
   at least two suites share.
 - Don't provide the component's real production layers here by default —
   tests pass their own (often test doubles). The harness only injects the
-  framework infra (`VerrexLive` + scope).
+  ambient scope (and `mount` brings its own registry).
 - Don't reach into `RenderResult.container` to mutate the DOM directly;
   drive the component through `click`/`fire` so the reactive path runs.
 
 ## Related context
 
-- [`verrex`](../runtime/AGENTS.md) — `mount`, `VerrexLive`, the View IR
+- [`verrex`](../runtime/AGENTS.md) — `mount`, the View IR
   this harness drives.
 - [`apps/demo/channels.test-d.ts`](../../../../apps/demo/src/channels.test-d.ts)
   — the type-level channel proof (compile-time peer to this runtime proof).

--- a/packages/core/src/testing/atom-attr.test.ts
+++ b/packages/core/src/testing/atom-attr.test.ts
@@ -7,8 +7,8 @@ import { render } from "./index.ts"
 
 // Atom-valued props: `applyProp` reads + subscribes through the registry
 // (mirroring the Reactive child case), so a derived Atom can drive a single
-// attribute. Components own the registry via `yield* AtomRegistry` — the
-// harness injects it through VerrexLive.
+// attribute. Components resolve the registry via `yield* AtomRegistry` —
+// `mount` owns and provides it.
 
 describe("Atom-valued attrs", () => {
   it("applies the registry value initially and re-applies on registry.set", async () => {

--- a/packages/core/src/testing/index.ts
+++ b/packages/core/src/testing/index.ts
@@ -1,14 +1,15 @@
 import { Cause, Effect, Exit, Layer, Scope } from "effect"
 import type { AtomRegistry } from "effect/unstable/reactivity"
-import { VerrexLive, mount, type View } from "@verrex/core"
+import { mount, type View } from "@verrex/core"
 
 /**
- * Services the harness provides for you: the `AtomRegistry` (via `VerrexLive`)
- * and the ambient `Scope` (held open across interaction, closed on `unmount`).
- * Everything else a component requires is `R` you must satisfy with `layer` —
- * if you forget one, `render` fails to type-check. That's deliberate: the
- * harness must NOT swallow the `E`/`R` channels, or it would defeat the whole
- * point of verrex at the test site.
+ * Services a component may require without a `layer`: the ambient `Scope`
+ * (held open across interaction, closed on `unmount`) and the `AtomRegistry`
+ * (owned by `mount` itself — created per mount, disposed with the mount's
+ * scope, provided to the app effect). Everything else a component requires
+ * is `R` you must satisfy with `layer` — if you forget one, `render` fails
+ * to type-check. That's deliberate: the harness must NOT swallow the `E`/`R`
+ * channels, or it would defeat the whole point of verrex at the test site.
  */
 type Injected = AtomRegistry.AtomRegistry | Scope.Scope
 
@@ -56,7 +57,7 @@ const el = (container: HTMLElement, selector: string): HTMLElement => {
  *
  * `app` is a component result — `Component(props)`, what a component tag
  * compiles to since #71 — i.e. an `Effect<View, E, R>`. Provide a `layer` covering every service the
- * component needs (the harness adds `AtomRegistry` + `Scope`); omit it only
+ * component needs (the harness adds the ambient `Scope`); omit it only
  * when the component requires nothing else. A missing service is a compile
  * error, exactly as it would be at a real `mount`.
  *
@@ -106,14 +107,14 @@ const renderImpl = async (
   const discharged = Effect.catchCause(app, (cause) =>
     Effect.die(Cause.squash(cause)),
   )
-  // Build the layers INTO the harness scope (not `Effect.provide`, which would
-  // scope them to the mount effect — an effect that completes as soon as the
-  // DOM attaches). The AtomRegistry must outlive the mounted UI: `h.track`
-  // deriveds and Atom sources live in it, and disposing it severs every
-  // subscription. Closing the harness scope in `unmount()` disposes it.
+  // Build the caller's layer INTO the harness scope (not `Effect.provide`,
+  // which would scope it to the mount effect — an effect that completes as
+  // soon as the DOM attaches), so service finalizers fire on `unmount()`.
+  // The AtomRegistry needs no layer at all: `mount` owns one per mount and
+  // disposes it with the same scope.
   await Effect.runPromise(
     Scope.provide(
-      Effect.flatMap(Layer.build(Layer.merge(layer, VerrexLive)), (ctx) =>
+      Effect.flatMap(Layer.build(layer), (ctx) =>
         Effect.provideContext(mount(discharged, container), ctx),
       ),
       scope,

--- a/packages/core/src/testing/registry-lifetime.test.ts
+++ b/packages/core/src/testing/registry-lifetime.test.ts
@@ -1,0 +1,109 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from "vitest"
+import { Effect, Exit, Scope } from "effect"
+import { Atom, AtomRef, AtomRegistry } from "effect/unstable/reactivity"
+import { h, mount, VerrexLive } from "@verrex/core"
+
+// Regression pins for #167: `mount` owns its AtomRegistry.
+//
+// Before this change the registry rode `mount`'s R, and the natural
+// `mount(...).pipe(Effect.provide(VerrexLive))` scoped the layer to the
+// mount effect — which completes as soon as the DOM attaches, disposing the
+// registry out from under the live UI. Everything rendered once, then
+// silently froze. Now mount creates, provides, and disposes the registry
+// itself, so the footgun shape is a no-op and NO registry provision is
+// needed at all.
+
+const trackedSpan = (dep: AtomRef.AtomRef<string>) =>
+  Effect.gen(function* () {
+    return yield* h(
+      "span",
+      {},
+      h.track(() => h.read(dep)),
+    )
+  })
+
+// Mount under a held-open scope (as a real app's long-lived scope would),
+// returning a close function for teardown.
+const mountHeld = async <R>(
+  app: Effect.Effect<void, never, R>,
+): Promise<() => Promise<void>> => {
+  const scope = Scope.makeUnsafe()
+  await Effect.runPromise(
+    Scope.provide(app as Effect.Effect<void, never, never>, scope),
+  )
+  return () => Effect.runPromise(Scope.close(scope, Exit.void))
+}
+
+describe("mount owns the AtomRegistry (#167)", () => {
+  it("mounts and stays reactive with no registry provided", async () => {
+    const dep = AtomRef.make("a")
+    const el = document.createElement("div")
+    const close = await mountHeld(mount(trackedSpan(dep), el))
+    expect(el.querySelector("span")!.textContent).toBe("a")
+    dep.set("b")
+    expect(el.querySelector("span")!.textContent).toBe("b")
+    await close()
+  })
+
+  it("the old footgun shape — Effect.provide(VerrexLive) around mount — is now a no-op", async () => {
+    const dep = AtomRef.make("a")
+    const el = document.createElement("div")
+    // The provided registry dies when the mount effect completes; the UI
+    // must keep reacting because it lives on mount's OWN registry.
+    const close = await mountHeld(
+      mount(trackedSpan(dep), el).pipe(Effect.provide(VerrexLive)),
+    )
+    expect(el.querySelector("span")!.textContent).toBe("a")
+    dep.set("b")
+    expect(el.querySelector("span")!.textContent).toBe("b")
+    await close()
+  })
+
+  it("a component's `yield* AtomRegistry` resolves to the mount's own live registry", async () => {
+    const el = document.createElement("div")
+    let seen: AtomRegistry.AtomRegistry | undefined
+    const close = await mountHeld(
+      mount(
+        Effect.gen(function* () {
+          seen = yield* AtomRegistry.AtomRegistry
+          return yield* h("span", {}, "x")
+        }),
+        el,
+      ),
+    )
+    expect(seen).toBeDefined()
+    // It is live — usable for reads — not a disposed layer instance.
+    const atom = Atom.make(1)
+    expect(() => seen!.get(atom)).not.toThrow()
+    expect(seen!.get(atom)).toBe(1)
+    await close()
+  })
+
+  it("closing the mount scope detaches the DOM and disposes the registry together", async () => {
+    const dep = AtomRef.make("a")
+    const el = document.createElement("div")
+    document.body.appendChild(el)
+    let registry: AtomRegistry.AtomRegistry | undefined
+    const close = await mountHeld(
+      mount(
+        Effect.gen(function* () {
+          registry = yield* AtomRegistry.AtomRegistry
+          return yield* h(
+            "span",
+            {},
+            h.track(() => h.read(dep)),
+          )
+        }),
+        el,
+      ),
+    )
+    expect(el.querySelector("span")!.textContent).toBe("a")
+    await close()
+    expect(el.querySelector("span")).toBeNull()
+    // The registry is disposed: touching it now is a loud error, not a
+    // silent freeze of a still-visible UI (the UI is gone).
+    expect(() => registry!.get(Atom.make(1))).toThrow(/disposed/i)
+    el.remove()
+  })
+})


### PR DESCRIPTION
Closes #167.

## The problem

`mount`'s `R` could say the `AtomRegistry` is **required** but not that it must **outlive** the mount effect. The natural `mount(...).pipe(Effect.provide(VerrexLive))` type-checked, disposed the registry the moment the DOM attached, and silently froze the live UI — the sharpest known edge in the design, in the framework whose thesis is that lifecycle mistakes are compile errors.

## The fix

Delete the requirement rather than encode it:

- `mount` creates its own registry, provides it to the app effect (a component's `yield* AtomRegistry.AtomRegistry` resolves to it), and discharges it from the app's `R` via `Exclude`.
- Disposal is a finalizer registered **before** `buildDom`, so LIFO scope close detaches the DOM and tears down child subscriptions against a still-live registry, disposing it last — the UI and its reactivity always die together.
- The footgun shape becomes a no-op: `VerrexLive` is deprecated (kept as a compat layer), and the disposed-registry error rewrite from #153 goes away with the failure mode it guarded.

## Pins

- `testing/registry-lifetime.test.ts` — no provision needed; the old footgun shape stays reactive; `yield* AtomRegistry` resolves to mount's live registry; scope close detaches the DOM and disposes the registry together. All four fail under the old shape (mutation-verified).
- `channels.test-d.ts` — `mount` discharges `AtomRegistry` from `R` at the type level.

## Verification

format / lint / `pnpm -r typecheck` (incl. `verrex-check`) / 302 core + 32 ts-plugin tests green; all eight browser probes green against the demo, which no longer provides `VerrexLive` at all.

**BREAKING CHANGE:** `mount` no longer accepts an externally provided `AtomRegistry`. `Effect.provide(VerrexLive)` around a mount is now harmless but unused; `VerrexLive` is deprecated and will be removed in a future release.