### PR TITLE
build: group effect + @effect/* dependabot bumps into one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,15 @@ updates:
         patterns:
           - "typescript"
           - "@volar/*"
+      # effect + @effect/* must move as a unit: two copies of the effect
+      # types in the workspace (e.g. @effect/vitest resolved against an older
+      # effect than apps/demo) break verrex-check on type-identity mismatch
+      # — seen for real when the demo bumped ahead of core's peer pin.
+      # Listed before minor-and-patch so these never land in separate PRs.
+      effect:
+        patterns:
+          - "effect"
+          - "@effect/*"
       minor-and-patch:
         update-types:
           - minor


### PR DESCRIPTION
Two copies of the `effect` types in the workspace break `verrex-check` on type-identity mismatch — this happened for real when `apps/demo` bumped ahead of `@verrex/core`'s peer pin and the demo's channel assertions failed CI. The effect family (`effect` + `@effect/*`, i.e. `@effect/vitest`) must move as a unit, same reasoning as the existing `babel` group.

Listed before `minor-and-patch` so these packages never fall through into the catch-all group. Grouping applies to future PRs; #176/#177 (the current beta.102 pair) will be merged together under the same rule.