### PR TITLE
feat(runtime,testing): RootSink reference + ui.sinkCauses; handler interrupts reach the sink

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,20 @@ JSX expression is automatically wrapped in a tracking scope.
 | `pnpm build`     | Production build via Vite (`@verrex/core/vite` owns the transform)                                                                              |
 | `pnpm test`      | All package suites — compiler, runtime, language, vite-plugin, testing, ts-plugin (incl. its tsserver integration probe) + `@verrex/core/check` |
 
+### Developing against a local checkout
+
+If your app references this repo with `"@verrex/core": "link:../verrex/packages/core"`,
+the link pulls in verrex's own `node_modules/effect` next to your app's copy. Two
+physical `effect` copies break `Context`/`Layer` identity **silently** (a service you
+provided reads as missing). Dedupe in both configs:
+
+```ts
+// vite.config.ts and vitest.config.ts
+export default { resolve: { dedupe: ["effect"] } };
+```
+
+Installs from npm do not have this problem — pnpm hoists one `effect`.
+
 ## Bundle size
 
 `pnpm build` on the demo produces:

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ provided reads as missing). Dedupe in both configs:
 
 ```ts
 // vite.config.ts and vitest.config.ts
-export default { resolve: { dedupe: ["effect"] } };
+export default { resolve: { dedupe: ["effect"] } }
 ```
 
 Installs from npm do not have this problem — pnpm hoists one `effect`.

--- a/packages/core/src/runtime/AGENTS.md
+++ b/packages/core/src/runtime/AGENTS.md
@@ -671,13 +671,15 @@ per-dispatch child for resources (`runHandlerEffect`; the full contract is
 sinks guard `Cause.hasInterruptsOnly` so a teardown interrupt isn't surfaced
 as a failure. **Handler dispatch is the exception (#186):** `runHandlerEffect`
 observes every non-success exit via `onExit` and hands an interrupt-only
-cause to the sink too — `Catch.report` still drops it, and mount's default
-root sink logs it at debug level with a hint (a `MountOptions.onError` sink
-gets it raw; the testing harness collects it on `ui.sinkCauses`). The reason:
-a handler interrupted mid-flight by its own element's teardown was invisible
-(#160 cost a downstream user an hour of bisecting) — teardown is not an
-error, but "the handler never finished" must be observable. Anything forked
-must be tied to a scope that closes when its owning subtree does.
+cause to the sink too. `Catch.report` does not flip on it; it escalates it
+to the ambient sink unchanged. Mount's default root sink logs it at debug
+level with a hint (below the default `Info` level, so raise the log level to
+see it). A `MountOptions.onError` sink gets it raw. The testing harness
+collects it on `ui.sinkCauses`. The reason: a handler interrupted mid-flight
+by its element's teardown was invisible (#160 cost a downstream user an hour
+of bisecting). Teardown is not an error, but "the handler never finished"
+must be observable. Anything forked must be tied to a scope that closes when
+its owning subtree does.
 
 ## mount internals — invariants
 

--- a/packages/core/src/runtime/AGENTS.md
+++ b/packages/core/src/runtime/AGENTS.md
@@ -674,7 +674,8 @@ observes every non-success exit via `onExit` and hands an interrupt-only
 cause to the sink too. `Catch.report` does not flip on it; it escalates it
 to the ambient sink unchanged. Mount's default root sink logs it at debug
 level with a hint (below the default `Info` level, so raise the log level to
-see it). A `MountOptions.onError` sink gets it raw. The testing harness
+see it). A user-provided `RootSink` (a `Context.Reference`, so it never
+shows in `R`) gets it raw. The testing harness
 collects it on `ui.sinkCauses`. The reason: a handler interrupted mid-flight
 by its element's teardown was invisible (#160 cost a downstream user an hour
 of bisecting). Teardown is not an error, but "the handler never finished"

--- a/packages/core/src/runtime/AGENTS.md
+++ b/packages/core/src/runtime/AGENTS.md
@@ -667,10 +667,17 @@ touching any of it: construction effects bind to a per-build scope (above),
 event-handler fibers are `forkIn`'d into their OWNER scope with a
 per-dispatch child for resources (`runHandlerEffect`; the full contract is
 "Handler-scope semantics" below), reactive/list subtrees go through
-`buildScopedChild`, and `asyncRef`'s supervisor is `forkScoped`. Every sink
-also guards `Cause.hasInterruptsOnly` so a teardown interrupt isn't surfaced
-as a failure. Anything forked must be tied to a scope that closes when its
-owning subtree does.
+`buildScopedChild`, and `asyncRef`'s supervisor is `forkScoped`. Render-path
+sinks guard `Cause.hasInterruptsOnly` so a teardown interrupt isn't surfaced
+as a failure. **Handler dispatch is the exception (#186):** `runHandlerEffect`
+observes every non-success exit via `onExit` and hands an interrupt-only
+cause to the sink too — `Catch.report` still drops it, and mount's default
+root sink logs it at debug level with a hint (a `MountOptions.onError` sink
+gets it raw; the testing harness collects it on `ui.sinkCauses`). The reason:
+a handler interrupted mid-flight by its own element's teardown was invisible
+(#160 cost a downstream user an hour of bisecting) — teardown is not an
+error, but "the handler never finished" must be observable. Anything forked
+must be tied to a scope that closes when its owning subtree does.
 
 ## mount internals — invariants
 
@@ -751,6 +758,9 @@ that re-renders an ANCESTOR dynamic node; a list-row handler that removes
 its OWN row (confirm-then-remove); a `Catch` fallback handler that keeps
 running after calling `reset` (the flip closes the fallback's content
 scope). Rule of thumb: do the async work first, then flip/remove/reset.
+Each of those interrupts reaches the root sink as an interrupt-only cause
+(debug log by default; `ui.sinkCauses` in tests) — see "Runtime error
+routing".
 
 Don't revert any of this to
 bare runners or to mount's root context: the types promise all of it.

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -26,7 +26,7 @@ import { type BoundaryState, View } from "./View.ts"
 
 export * as Component from "./Component.ts"
 export { h } from "./h.ts"
-export { mount } from "./mount.ts"
+export { mount, type MountOptions } from "./mount.ts"
 export { type Props, View } from "./View.ts"
 // `Async`, `asyncRef`, `Catch`, `list`, `Fragment`, `VerrexLive` are declared + exported below.
 export type {

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -696,9 +696,11 @@ const makeBoundary = <R>(
 
     // Live failures: accepted → error state (via the queue, off the render stack —
     // a synchronous mutation would close the child scope mid-render); non-accepted
-    // → escalate to the ambient sink. Interrupts (teardown) dropped.
+    // → escalate to the ambient sink. An interrupt-only cause (a handler torn
+    // down mid-flight, #186) is not an error, so it never flips the boundary;
+    // it escalates unchanged so the root sink can still observe it.
     const report = (cause: Cause.Cause<unknown>): void => {
-      if (Cause.hasInterruptsOnly(cause)) return
+      if (Cause.hasInterruptsOnly(cause)) return ambient(cause)
       if (accepts(cause)) Queue.offerUnsafe(runs, { _tag: "error", cause })
       else ambient(cause)
     }

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -26,7 +26,7 @@ import { type BoundaryState, View } from "./View.ts"
 
 export * as Component from "./Component.ts"
 export { h } from "./h.ts"
-export { mount, type MountOptions } from "./mount.ts"
+export { mount, RootSink } from "./mount.ts"
 export { type Props, View } from "./View.ts"
 // `Async`, `asyncRef`, `Catch`, `list`, `Fragment`, `VerrexLive` are declared + exported below.
 export type {

--- a/packages/core/src/runtime/mount.ts
+++ b/packages/core/src/runtime/mount.ts
@@ -597,10 +597,10 @@ const buildDom = (view: ViewNode, ctx: BuildCtx, scope: Scope.Scope): Node => {
  *
  * Post-mount failures (a reactive re-render or an event-handler Effect that
  * fails) that aren't caught by a `Catch` boundary are routed to a root
- * error sink: `options.onError` when given, else `Effect.logError` on the
- * captured context. A handler interrupted mid-flight by its element's teardown
- * reaches the same sink as an interrupt-only `Cause` (the default sink logs
- * that at debug level, since teardown is not an error).
+ * error sink — the {@link RootSink} reference read from the captured context
+ * (default: log). A handler interrupted mid-flight by its element's teardown
+ * reaches the same sink as an interrupt-only `Cause` (the default logs that
+ * at debug level, since teardown is not an error).
  *
  * **The `AtomRegistry` is owned by the mount, not required from context.**
  * `mount` creates a registry and disposes it in the same scope close that
@@ -615,20 +615,36 @@ const buildDom = (view: ViewNode, ctx: BuildCtx, scope: Scope.Scope): Node => {
  * `View<E>` channel (via `Catch`). A leftover error is a compile error here
  * that names it — the runtime counterpart of a forgotten `Layer` naming a service.
  */
-/** Options for {@link mount}. */
-export interface MountOptions {
-  /**
-   * Root error sink. Receives every live `Cause` no `Catch` boundary caught —
-   * a failing handler or re-render — and interrupt-only causes from handlers
-   * torn down mid-flight. Replaces the default `Effect.logError` logging.
-   */
-  readonly onError?: (cause: Cause.Cause<unknown>) => void
-}
+/**
+ * The root error sink, as a `Context.Reference` (a service with a default, so
+ * it never shows up in `R`). It receives every live `Cause` no `Catch`
+ * boundary caught — a failing handler or re-render — and the interrupt-only
+ * cause of a handler torn down mid-flight (#186). The default logs: errors via
+ * `Effect.logError`, interrupts via `Effect.logDebug` with a hint (below the
+ * default `Info` level; raise it to see them).
+ *
+ * Override it like any Effect service:
+ * `Effect.provideService(mount(app, el), RootSink, (cause) => report(cause))`
+ * or `Layer.succeed(RootSink, …)`. The testing harness provides one that
+ * collects into `ui.sinkCauses`.
+ */
+export const RootSink = Context.Reference<
+  (cause: Cause.Cause<unknown>) => Effect.Effect<void>
+>("verrex/RootSink", {
+  defaultValue:
+    () =>
+    (cause): Effect.Effect<void> =>
+      Cause.hasInterruptsOnly(cause)
+        ? Effect.logDebug(
+            "verrex: an event handler was interrupted before it completed",
+            cause,
+          )
+        : Effect.logError(cause),
+})
 
 export const mount = <R>(
   app: Effect.Effect<View<never>, never, R>,
   el: HTMLElement,
-  options?: MountOptions,
 ): Effect.Effect<
   void,
   never,
@@ -640,20 +656,9 @@ export const mount = <R>(
     // `never` so it threads without a generic — handler Effects are cast to
     // `R = never` at the run site; the services are present at runtime.
     const context = yield* Effect.context<never>()
-    const onError = options?.onError
+    const rootSink = yield* RootSink
     const sink: ErrorSink = (cause) => {
-      if (onError) return onError(cause)
-      Effect.runForkWith(context)(
-        Cause.hasInterruptsOnly(cause)
-          ? Effect.logDebug(
-              "verrex: an event handler was interrupted before it completed " +
-                "— usually its element was torn down while it was in flight " +
-                "(a write that re-renders an ancestor, a row removal, a Catch " +
-                "flip); do the async work first, then flip/remove/reset",
-              cause,
-            )
-          : Effect.logError(cause),
-      )
+      Effect.runForkWith(context)(rootSink(cause))
     }
     const view = yield* Effect.provideService(
       app,

--- a/packages/core/src/runtime/mount.ts
+++ b/packages/core/src/runtime/mount.ts
@@ -647,7 +647,9 @@ export const mount = <R>(
         Cause.hasInterruptsOnly(cause)
           ? Effect.logDebug(
               "verrex: an event handler was interrupted before it completed " +
-                "(its element was torn down while the handler was in flight)",
+                "— usually its element was torn down while it was in flight " +
+                "(a write that re-renders an ancestor, a row removal, a Catch " +
+                "flip); do the async work first, then flip/remove/reset",
               cause,
             )
           : Effect.logError(cause),

--- a/packages/core/src/runtime/mount.ts
+++ b/packages/core/src/runtime/mount.ts
@@ -106,10 +106,11 @@ interface HandlerDeps {
 // Every non-success exit routes to the sink — INCLUDING an interrupt-only
 // cause (#186). Owner teardown interrupts an in-flight handler without running
 // `matchCause`, so the observation point is `onExit` (a finalizer, which does
-// run). An interrupt is not an error: `Catch.report` drops it, and mount's root
-// sink logs it at debug level with a hint — the "handler never finished and
-// nothing said so" symptom (#160) is the one this exists to make visible. The
-// testing harness collects it on `ui.sinkCauses` (#127).
+// run). An interrupt is not an error. `Catch.report` does not flip on it; it
+// escalates it to the ambient sink. Mount's default `RootSink` logs it at
+// debug level. This exists to make one symptom visible: "the handler never
+// finished and nothing said so" (#160). The testing harness collects it on
+// `ui.sinkCauses` (#127).
 const runHandlerEffect = (
   effect: Effect.Effect<unknown, unknown, never>,
   deps: HandlerDeps,
@@ -588,6 +589,36 @@ const buildDom = (view: ViewNode, ctx: BuildCtx, scope: Scope.Scope): Node => {
 }
 
 /**
+ * The root error sink, as a `Context.Reference` (a service with a default, so
+ * it never shows up in `R`). It receives every live `Cause` no `Catch`
+ * boundary caught — a failing handler or re-render — and the interrupt-only
+ * cause of a handler torn down mid-flight (#186). The default logs: errors via
+ * `Effect.logError`, interrupts via `Effect.logDebug` with a hint (below the
+ * default `Info` level; raise it to see them).
+ *
+ * Override it like any Effect service, provided AROUND `mount` (it is read
+ * once, from mount's context — not from a subtree's):
+ * `Effect.provideService(mount(app, el), RootSink, (cause) => report(cause))`
+ * or `Layer.succeed(RootSink, …)`. The sink runs forked and unsupervised:
+ * keep it infallible (a sink that fails is dropped without a trace), and
+ * note an async sink is not awaited by teardown. The testing harness provides
+ * one that collects into `ui.sinkCauses`.
+ */
+export const RootSink = Context.Reference<
+  (cause: Cause.Cause<unknown>) => Effect.Effect<void>
+>("verrex/RootSink", {
+  defaultValue:
+    () =>
+    (cause): Effect.Effect<void> =>
+      Cause.hasInterruptsOnly(cause)
+        ? Effect.logDebug(
+            "verrex: an event handler was interrupted before it completed",
+            cause,
+          )
+        : Effect.logError(cause),
+})
+
+/**
  * Run the app Effect, build the DOM, and attach to the target element.
  *
  * Cleanup is handled entirely through the ambient `Scope`. Every subscription,
@@ -615,33 +646,6 @@ const buildDom = (view: ViewNode, ctx: BuildCtx, scope: Scope.Scope): Node => {
  * `View<E>` channel (via `Catch`). A leftover error is a compile error here
  * that names it — the runtime counterpart of a forgotten `Layer` naming a service.
  */
-/**
- * The root error sink, as a `Context.Reference` (a service with a default, so
- * it never shows up in `R`). It receives every live `Cause` no `Catch`
- * boundary caught — a failing handler or re-render — and the interrupt-only
- * cause of a handler torn down mid-flight (#186). The default logs: errors via
- * `Effect.logError`, interrupts via `Effect.logDebug` with a hint (below the
- * default `Info` level; raise it to see them).
- *
- * Override it like any Effect service:
- * `Effect.provideService(mount(app, el), RootSink, (cause) => report(cause))`
- * or `Layer.succeed(RootSink, …)`. The testing harness provides one that
- * collects into `ui.sinkCauses`.
- */
-export const RootSink = Context.Reference<
-  (cause: Cause.Cause<unknown>) => Effect.Effect<void>
->("verrex/RootSink", {
-  defaultValue:
-    () =>
-    (cause): Effect.Effect<void> =>
-      Cause.hasInterruptsOnly(cause)
-        ? Effect.logDebug(
-            "verrex: an event handler was interrupted before it completed",
-            cause,
-          )
-        : Effect.logError(cause),
-})
-
 export const mount = <R>(
   app: Effect.Effect<View<never>, never, R>,
   el: HTMLElement,

--- a/packages/core/src/runtime/mount.ts
+++ b/packages/core/src/runtime/mount.ts
@@ -103,10 +103,13 @@ interface HandlerDeps {
 //   is the owner per node, and what still interrupts, is in AGENTS.md
 //   "Handler-scope semantics".
 //
-// Failures route to the sink; an interrupt-only cause is dropped. (On owner
-// teardown the runtime skips `matchCause` entirely — only finalizers run — so
-// the guard's actual subject is a handler that raises an interrupt cause
-// itself, `yield* Effect.interrupt`. Not an error either way.)
+// Every non-success exit routes to the sink — INCLUDING an interrupt-only
+// cause (#186). Owner teardown interrupts an in-flight handler without running
+// `matchCause`, so the observation point is `onExit` (a finalizer, which does
+// run). An interrupt is not an error: `Catch.report` drops it, and mount's root
+// sink logs it at debug level with a hint — the "handler never finished and
+// nothing said so" symptom (#160) is the one this exists to make visible. The
+// testing harness collects it on `ui.sinkCauses` (#127).
 const runHandlerEffect = (
   effect: Effect.Effect<unknown, unknown, never>,
   deps: HandlerDeps,
@@ -114,12 +117,11 @@ const runHandlerEffect = (
   const dispatchScope = Scope.forkUnsafe(deps.ownerScope, "sequential")
   Effect.runForkWith(deps.context)(
     Effect.forkIn(
-      Effect.matchCause(Scope.use(effect, dispatchScope), {
-        onFailure: (cause) => {
-          if (!Cause.hasInterruptsOnly(cause)) deps.sink(cause)
-        },
-        onSuccess: () => {},
-      }),
+      Effect.onExit(Scope.use(effect, dispatchScope), (exit) =>
+        Effect.sync(() => {
+          if (Exit.isFailure(exit)) deps.sink(exit.cause)
+        }),
+      ),
       deps.ownerScope,
     ),
   )
@@ -595,7 +597,10 @@ const buildDom = (view: ViewNode, ctx: BuildCtx, scope: Scope.Scope): Node => {
  *
  * Post-mount failures (a reactive re-render or an event-handler Effect that
  * fails) that aren't caught by a `Catch` boundary are routed to a root
- * error sink that logs via `Effect.logError` on the captured context.
+ * error sink: `options.onError` when given, else `Effect.logError` on the
+ * captured context. A handler interrupted mid-flight by its element's teardown
+ * reaches the same sink as an interrupt-only `Cause` (the default sink logs
+ * that at debug level, since teardown is not an error).
  *
  * **The `AtomRegistry` is owned by the mount, not required from context.**
  * `mount` creates a registry and disposes it in the same scope close that
@@ -610,9 +615,20 @@ const buildDom = (view: ViewNode, ctx: BuildCtx, scope: Scope.Scope): Node => {
  * `View<E>` channel (via `Catch`). A leftover error is a compile error here
  * that names it — the runtime counterpart of a forgotten `Layer` naming a service.
  */
+/** Options for {@link mount}. */
+export interface MountOptions {
+  /**
+   * Root error sink. Receives every live `Cause` no `Catch` boundary caught —
+   * a failing handler or re-render — and interrupt-only causes from handlers
+   * torn down mid-flight. Replaces the default `Effect.logError` logging.
+   */
+  readonly onError?: (cause: Cause.Cause<unknown>) => void
+}
+
 export const mount = <R>(
   app: Effect.Effect<View<never>, never, R>,
   el: HTMLElement,
+  options?: MountOptions,
 ): Effect.Effect<
   void,
   never,
@@ -624,8 +640,18 @@ export const mount = <R>(
     // `never` so it threads without a generic — handler Effects are cast to
     // `R = never` at the run site; the services are present at runtime.
     const context = yield* Effect.context<never>()
+    const onError = options?.onError
     const sink: ErrorSink = (cause) => {
-      Effect.runForkWith(context)(Effect.logError(cause))
+      if (onError) return onError(cause)
+      Effect.runForkWith(context)(
+        Cause.hasInterruptsOnly(cause)
+          ? Effect.logDebug(
+              "verrex: an event handler was interrupted before it completed " +
+                "(its element was torn down while the handler was in flight)",
+              cause,
+            )
+          : Effect.logError(cause),
+      )
     }
     const view = yield* Effect.provideService(
       app,

--- a/packages/core/src/testing/AGENTS.md
+++ b/packages/core/src/testing/AGENTS.md
@@ -42,7 +42,18 @@ await ui.unmount()
   context with its services, and its failures route to the error sink, so
   a failing handler is contained rather than thrown; `event-handlers.test.ts`
   pins this), `tick()` (flush a macrotask so async/atom updates settle),
-  `unmount()` (close the scope → fire every finalizer → detach).
+  `unmount()` (close the scope → fire every finalizer → detach),
+  `sinkCauses` (every `Cause` the root sink received, via `mount`'s
+  `onError` option: uncaught live failures AND handlers interrupted
+  mid-flight, #127/#186).
+- **Assert the continuation, not the stub.** A test that only checks a
+  stub's side effect (`sink.push` inside `http.send`) goes green even when
+  the handler is interrupted right after its first `yield*` — the stub ran
+  synchronously, the rest never did. Assert on state only the post-`yield`
+  code produces (the "saved" text, `pending` back to false) and add
+  `expect(ui.sinkCauses).toEqual([])`, which fails on any interrupt or
+  uncaught failure. `unmount()` itself interrupts in-flight handlers, so
+  read `sinkCauses` before it (`handler-scope.test.ts` pins both shapes).
 
 ## The load-bearing invariant: do NOT swallow E/R
 

--- a/packages/core/src/testing/AGENTS.md
+++ b/packages/core/src/testing/AGENTS.md
@@ -46,7 +46,7 @@ await ui.unmount()
   pins this), `tick()` (flush a macrotask so async/atom updates settle),
   `unmount()` (close the scope → fire every finalizer → detach),
   `sinkCauses` (every `Cause` the root sink received, via `mount`'s
-  `onError` option: uncaught live failures AND handlers interrupted
+  `RootSink` reference: uncaught live failures AND handlers interrupted
   mid-flight, #127/#186).
 - **Assert the continuation, not the stub.** A test that only checks a
   stub's side effect (`sink.push` inside `http.send`) goes green even when

--- a/packages/core/src/testing/AGENTS.md
+++ b/packages/core/src/testing/AGENTS.md
@@ -11,7 +11,9 @@ Public surface: `render(app, layer?)` returning a `RenderResult`, plus
 with an undischarged LIVE error (`View<E≠never>`), needed by sink-containment
 tests ("a failing handler is contained, the app keeps working"). Route every
 such test through it; an ad-hoc `as unknown as` cast on a handler effect or
-app is a smell — the hatch exists to be greppable.
+app is a smell — the hatch exists to be greppable. Pair it with
+`ui.sinkCauses` to assert WHAT the sink received (`Cause.squash`), never a
+logger string-match.
 
 ## What it does
 

--- a/packages/core/src/testing/event-handlers.test.ts
+++ b/packages/core/src/testing/event-handlers.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 import { describe, expect, it } from "vitest"
-import { Cause, Effect, Logger } from "effect"
+import { Cause, Effect } from "effect"
 import { AtomRef } from "effect/unstable/reactivity"
 import { h } from "@verrex/core"
 import { stepClick, stepLayer } from "./fixtures.ts"
@@ -91,15 +91,6 @@ describe("event handlers — Effect-returning", () => {
   })
 
   it("contains a failing handler — routed to the sink, app keeps working", async () => {
-    // Capture the routed failure via a custom logger (the root sink logs the
-    // Cause through Effect.logError on the captured context).
-    const logged: Array<unknown> = []
-    const CapturingLogger = Logger.layer([
-      Logger.make((options) => {
-        logged.push(options)
-      }),
-    ])
-
     const Mixed = Effect.fn("Mixed")(function* (_props: {} = {}) {
       const count = AtomRef.make(0)
       // The handler is typed HONESTLY (it fails with a string, so this
@@ -127,30 +118,13 @@ describe("event handlers — Effect-returning", () => {
       )
     })
 
-    const ui = await render(untracked(Mixed()), CapturingLogger)
+    const ui = await render(untracked(Mixed()))
 
     // A failing handler must not throw out of dispatch nor break the app, and the
-    // ACTUAL cause must reach the sink (not just "something logged"). The sink logs
-    // the Cause via Effect.logError, so it surfaces in the logger options' message
-    // and/or cause field.
+    // ACTUAL cause must reach the root sink — the harness collects it (#127).
     ui.click(".bad")
     await ui.tick()
-    const mentionsMarker = (v: unknown): boolean =>
-      Cause.isCause(v)
-        ? Cause.pretty(v).includes("boom-marker")
-        : typeof v === "string"
-          ? v.includes("boom-marker")
-          : Array.isArray(v)
-            ? v.some(mentionsMarker)
-            : false
-    const found = logged.some((o) => {
-      const opts = o as {
-        readonly message?: unknown
-        readonly cause?: unknown
-      }
-      return mentionsMarker(opts.message) || mentionsMarker(opts.cause)
-    })
-    expect(found).toBe(true)
+    expect(ui.sinkCauses.map(Cause.squash)).toEqual(["boom-marker"])
 
     // The app still works after a handler failure.
     ui.click(".good")

--- a/packages/core/src/testing/handler-scope.test.ts
+++ b/packages/core/src/testing/handler-scope.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 import { describe, expect, it } from "vitest"
-import { Data, Deferred, Effect, Logger } from "effect"
+import { Cause, Data, Deferred, Effect } from "effect"
 import { AtomRef } from "effect/unstable/reactivity"
 import { Catch, h, list } from "@verrex/core"
 import { Step, stepLayer } from "./fixtures.ts"
@@ -26,15 +26,10 @@ describe("per-dispatch handler scope", () => {
     // awaits async work, then settles. Pre-#161 the swap closed the build
     // scope the fiber was forked into — everything after the first suspension
     // was silently dropped. Now the owner (the Reactive NODE's scope)
-    // survives the emit, so the work completes. The sink must stay SILENT
-    // throughout: a fix that "works" by routing the interrupt to the sink
-    // would pass the DOM assertions but fail this.
-    const logged: Array<unknown> = []
-    const CapturingLogger = Logger.layer([
-      Logger.make((options) => {
-        logged.push(options)
-      }),
-    ])
+    // survives the emit, so the work completes. `sinkCauses` must stay EMPTY
+    // throughout: an interrupted handler now reaches the sink (#186), so this
+    // is the direct assertion that the continuation ran — not just that the
+    // first write landed.
     const gate = Deferred.makeUnsafe<void>()
     const done = AtomRef.make("no")
     const slot = AtomRef.make<unknown>(null)
@@ -63,7 +58,7 @@ describe("per-dispatch handler scope", () => {
       )
     })
 
-    const ui = await render(App(), CapturingLogger)
+    const ui = await render(App())
     ui.click(".save")
     await ui.tick()
     // The optimistic write landed (button replaced) and the handler is parked.
@@ -76,7 +71,7 @@ describe("per-dispatch handler scope", () => {
     // settled back to idle.
     expect(done.value).toBe("yes")
     expect(ui.text(".idle")).toBe("saved")
-    expect(logged).toEqual([])
+    expect(ui.sinkCauses).toEqual([])
     await ui.unmount()
   })
 
@@ -259,15 +254,10 @@ describe("per-dispatch handler scope", () => {
     await ui.unmount()
   })
 
-  it("app unmount interrupts an in-flight handler and releases exactly once — silently", async () => {
-    // Also pins the interrupt-only-cause drop: a teardown interrupt is NOT an
-    // error and must not reach the sink (captured here via a logger layer).
-    const logged: Array<unknown> = []
-    const CapturingLogger = Logger.layer([
-      Logger.make((options) => {
-        logged.push(options)
-      }),
-    ])
+  it("app unmount interrupts an in-flight handler and releases exactly once — visibly (#186)", async () => {
+    // Also pins the interrupt routing: a teardown interrupt is NOT an error,
+    // but it DOES reach the sink as an interrupt-only cause, so a test (or a
+    // dev-mode log) can see the handler never completed.
     const log: string[] = []
     const gate = Deferred.makeUnsafe<void>()
     const App = Effect.fn("UnmountInterrupt")(function* (_props: {} = {}) {
@@ -289,7 +279,7 @@ describe("per-dispatch handler scope", () => {
       )
     })
 
-    const ui = await render(App(), CapturingLogger)
+    const ui = await render(App())
     ui.click(".btn")
     await ui.tick()
     expect(log).toEqual(["acquire"])
@@ -301,24 +291,16 @@ describe("per-dispatch handler scope", () => {
     openGate(gate)
     await new Promise((r) => setTimeout(r, 0))
     expect(log).toEqual(["acquire", "release"])
-    expect(logged).toEqual([])
+    expect(ui.sinkCauses).toHaveLength(1)
+    expect(Cause.hasInterruptsOnly(ui.sinkCauses[0]!)).toBe(true)
   })
 
-  it("a handler that interrupts ITSELF still releases, silently (#160)", async () => {
+  it("a handler that interrupts ITSELF still releases, and the interrupt is visible (#160, #186)", async () => {
     // Pins two things the owner-teardown tests can't (there the owner→child
     // cascade would close the dispatch scope anyway): (1) the dispatch-scope
     // close (`Scope.use`, onExit-based) runs on an INTERRUPT exit too — the
-    // owner stays alive here, so nothing else could fire the release; (2) an
-    // interrupt-only cause never reaches the sink. Note `Effect.interrupt` is
-    // a plain interrupt-cause failure — it does run error continuations,
-    // unlike an external `Fiber.interrupt` — so this is the one shape where
-    // the `hasInterruptsOnly` guard is actually exercised.
-    const logged: Array<unknown> = []
-    const CapturingLogger = Logger.layer([
-      Logger.make((options) => {
-        logged.push(options)
-      }),
-    ])
+    // owner stays alive here, so nothing else could fire the release; (2) the
+    // interrupt-only cause reaches the sink AS an interrupt, not an error.
     const log: string[] = []
     const App = Effect.fn("SelfInterrupt")(function* (_props: {} = {}) {
       return yield* h(
@@ -339,11 +321,12 @@ describe("per-dispatch handler scope", () => {
       )
     })
 
-    const ui = await render(App(), CapturingLogger)
+    const ui = await render(App())
     ui.click(".btn")
     await ui.tick()
     expect(log).toEqual(["acquire", "release"])
-    expect(logged).toEqual([])
+    expect(ui.sinkCauses).toHaveLength(1)
+    expect(Cause.hasInterruptsOnly(ui.sinkCauses[0]!)).toBe(true)
     await ui.unmount()
     expect(log).toEqual(["acquire", "release"])
   })

--- a/packages/core/src/testing/handler-scope.test.ts
+++ b/packages/core/src/testing/handler-scope.test.ts
@@ -331,6 +331,46 @@ describe("per-dispatch handler scope", () => {
     expect(log).toEqual(["acquire", "release"])
   })
 
+  it("a handler interrupted under a Catch still reaches the root sink (#186)", async () => {
+    // Catch.report must not swallow the interrupt: it is not an error (the
+    // boundary must not flip), but "the handler never finished" has to stay
+    // observable through a boundary — else `sinkCauses` lies for any app
+    // with a root Catch.
+    const gate = Deferred.makeUnsafe<void>()
+    const log: string[] = []
+    const App = Effect.fn("CatchInterrupt")(function* (_props: {} = {}) {
+      return yield* Catch(
+        h(
+          "button",
+          {
+            class: "btn",
+            onClick: () =>
+              Effect.gen(function* () {
+                log.push("start")
+                yield* Deferred.await(gate)
+                log.push("done")
+              }),
+          },
+          "go",
+        ),
+        () => h("p", { class: "fallback" }, "failed"),
+      )
+    })
+
+    const ui = await render(App())
+    ui.click(".btn")
+    await ui.tick()
+    expect(log).toEqual(["start"])
+    expect(ui.sinkCauses).toEqual([])
+
+    await ui.unmount()
+    expect(log).toEqual(["start"])
+    expect(ui.sinkCauses).toHaveLength(1)
+    expect(Cause.hasInterruptsOnly(ui.sinkCauses[0]!)).toBe(true)
+    // The boundary did not flip on the interrupt.
+    expect(ui.query(".fallback")).toBeNull()
+  })
+
   it("re-binding a REACTIVE handler prop does not interrupt an in-flight dispatch", async () => {
     // An AtomRef-valued `onClick` re-applies under a rolling child scope: the
     // LISTENER is swapped per binding, but a dispatch is owned by the node,

--- a/packages/core/src/testing/index.ts
+++ b/packages/core/src/testing/index.ts
@@ -44,11 +44,13 @@ export interface RenderResult {
   /** Close the scope (firing every finalizer) and detach the container. */
   unmount(): Promise<void>
   /**
-   * Every `Cause` that reached the root error sink (`RootSink`), in order: a live failure no
-   * `Catch` caught, and any handler interrupted mid-flight by its element's
-   * teardown (an interrupt-only cause). Assert `toEqual([])` to prove a handler
-   * ran to completion — a stub's side effect only proves it *started*.
-   * `unmount()` itself interrupts in-flight handlers, so read this before it.
+   * Every `Cause` that reached the root error sink (`RootSink`), in order: a
+   * live failure no `Catch` caught, and any handler that exited with an
+   * interrupt-only cause (torn down mid-flight, or `Effect.interrupt`).
+   * Assert `toEqual([])` to prove a handler ran to completion — a stub's side
+   * effect only proves it *started*. `unmount()` itself interrupts in-flight
+   * handlers, so read this before it. The harness always installs its own
+   * `RootSink`; a `RootSink` in the `layer` argument is not used.
    */
   readonly sinkCauses: ReadonlyArray<Cause.Cause<unknown>>
 }

--- a/packages/core/src/testing/index.ts
+++ b/packages/core/src/testing/index.ts
@@ -43,6 +43,14 @@ export interface RenderResult {
   waitFor(selector: string, timeoutMs?: number): Promise<HTMLElement>
   /** Close the scope (firing every finalizer) and detach the container. */
   unmount(): Promise<void>
+  /**
+   * Every `Cause` that reached the root error sink, in order: a live failure no
+   * `Catch` caught, and any handler interrupted mid-flight by its element's
+   * teardown (an interrupt-only cause). Assert `toEqual([])` to prove a handler
+   * ran to completion — a stub's side effect only proves it *started*.
+   * `unmount()` itself interrupts in-flight handlers, so read this before it.
+   */
+  readonly sinkCauses: ReadonlyArray<Cause.Cause<unknown>>
 }
 
 const el = (container: HTMLElement, selector: string): HTMLElement => {
@@ -112,10 +120,18 @@ const renderImpl = async (
   // soon as the DOM attaches), so service finalizers fire on `unmount()`.
   // The AtomRegistry needs no layer at all: `mount` owns one per mount and
   // disposes it with the same scope.
+  const sinkCauses: Array<Cause.Cause<unknown>> = []
   await Effect.runPromise(
     Scope.provide(
       Effect.flatMap(Layer.build(layer), (ctx) =>
-        Effect.provideContext(mount(discharged, container), ctx),
+        Effect.provideContext(
+          mount(discharged, container, {
+            onError: (cause) => {
+              sinkCauses.push(cause)
+            },
+          }),
+          ctx,
+        ),
       ),
       scope,
     ),
@@ -123,6 +139,7 @@ const renderImpl = async (
 
   return {
     container,
+    sinkCauses,
     get: (s) => el(container, s),
     query: (s) => container.querySelector(s) as HTMLElement | null,
     all: (s) => Array.from(container.querySelectorAll(s)) as HTMLElement[],

--- a/packages/core/src/testing/index.ts
+++ b/packages/core/src/testing/index.ts
@@ -1,6 +1,6 @@
 import { Cause, Effect, Exit, Layer, Scope } from "effect"
 import type { AtomRegistry } from "effect/unstable/reactivity"
-import { mount, type View } from "@verrex/core"
+import { mount, RootSink, type View } from "@verrex/core"
 
 /**
  * Services a component may require without a `layer`: the ambient `Scope`
@@ -44,7 +44,7 @@ export interface RenderResult {
   /** Close the scope (firing every finalizer) and detach the container. */
   unmount(): Promise<void>
   /**
-   * Every `Cause` that reached the root error sink, in order: a live failure no
+   * Every `Cause` that reached the root error sink (`RootSink`), in order: a live failure no
    * `Catch` caught, and any handler interrupted mid-flight by its element's
    * teardown (an interrupt-only cause). Assert `toEqual([])` to prove a handler
    * ran to completion — a stub's side effect only proves it *started*.
@@ -125,11 +125,14 @@ const renderImpl = async (
     Scope.provide(
       Effect.flatMap(Layer.build(layer), (ctx) =>
         Effect.provideContext(
-          mount(discharged, container, {
-            onError: (cause) => {
-              sinkCauses.push(cause)
-            },
-          }),
+          Effect.provideService(
+            mount(discharged, container),
+            RootSink,
+            (cause) =>
+              Effect.sync(() => {
+                sinkCauses.push(cause)
+              }),
+          ),
           ctx,
         ),
       ),


### PR DESCRIPTION
Closes #127, closes #186.

- `RootSink`: a `Context.Reference` root error sink (default logs; interrupt-only causes at debug). Override with `Effect.provideService`/`Layer.succeed` around `mount`; `mount` signature unchanged.
- `runHandlerEffect` observes exits via `onExit`, so a handler interrupted mid-flight reaches the sink as an interrupt-only cause. `Catch.report` escalates it without flipping.
- Testing harness: `ui.sinkCauses`; `event-handlers.test.ts` off Logger string-matching; new pins in `handler-scope.test.ts` (unmount, self-interrupt, under Catch).
- README: `resolve.dedupe` note for `link:` consumers.

Two review rounds (standards / spec / adversarial) applied. Follow-up not in scope: thread the element tag into the interrupt diagnostic (#186 asked for `<tag>`).