### PR TITLE
fix(runtime): fold Async arm / Catch fallback R onto the boundary (#120)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,8 @@ fetch loop live, so a dep change can recover the view — while the residual
 rides `View<Exclude<E, { _tag }>>`. (2) _Event handlers_ (#72): an intrinsic's
 `on*` prop returning `Effect<_, E, R>` stamps `E` on the element's `View<E>`
 and folds `R` into its requirements — a forgotten boundary or Layer for a
-handler is the same compile error as for construction. The remaining
+handler is the same compile error as for construction. Since #120, `Async` arms
+and `Catch` fallbacks fold their `R` too, so a handler inside an arm is covered. The remaining
 untracked live surface: a _reactive re-render_ whose Effect fails (an
 `AtomRef`-driven child re-emitting a failing Effect) is still caught only at
 _runtime_ by `Catch`'s sink, not typed.

--- a/apps/demo/src/channels.test-d.ts
+++ b/apps/demo/src/channels.test-d.ts
@@ -4,8 +4,8 @@
  * Each assertion either holds or produces a type error naming the
  * mismatched channel — this *is* the demonstration.
  */
-import type { Cause, Chunk, Option, Result, Scope } from "effect"
-import { Effect, Stream } from "effect"
+import type { Chunk, Option, Result, Scope } from "effect"
+import { Cause, Effect, Stream } from "effect"
 import { Atom, AtomRegistry, type AtomRef } from "effect/unstable/reactivity"
 import {
   Async,
@@ -297,18 +297,131 @@ const RowR = list(todos, (item) =>
 )
 assertEquals<typeof RowR, Effect.Effect<View, never, Http>>()
 
-// KNOWN EXCEPTION — Async arms and Catch fallbacks are deliberately
-// permissive (`Effect<View, any, any>`, channels not folded — "keep arms
-// pure markup"): a handler's R inside an arm is SWALLOWED, not folded. The
-// #72 guarantee does not reach inside arms; this pin makes the boundary of
-// the guarantee explicit rather than accidental.
+// Async arms and Catch fallbacks FOLD `R` (#120): a handler (or any Effect
+// child) inside an arm needing a service the fetch does not folds onto the
+// boundary's requirements — a missing Layer there is the same compile error
+// as anywhere else, not a click-time Service-not-found defect. `Scope` stays
+// excluded (arms render under the node scope, like list rows/handlers).
 declare const fetchUser: () => Effect.Effect<User, HttpError, Http>
-const ArmSwallowsR = Async(fetchUser, {
-  success: (u) => h("button", { onclick: () => auditedLog }, u.name),
+declare const themedLog: Effect.Effect<void, never, Theme>
+const ArmFoldsR = Async(fetchUser, {
+  success: (u) => h("button", { onclick: () => themedLog }, u.name),
 })
 assertEquals<
-  typeof ArmSwallowsR,
+  typeof ArmFoldsR,
+  Effect.Effect<View<HttpError>, never, Http | Theme | Scope.Scope>
+>()
+// Providing only Http leaves Theme on the requirements — a forgotten Layer
+// for an arm's handler is a compile error, no longer a click-time defect.
+const ArmProvidedHttp = Effect.provide(ArmFoldsR, HttpLive)
+assertEquals<
+  typeof ArmProvidedHttp,
+  Effect.Effect<View<HttpError>, never, Theme | Scope.Scope>
+>()
+
+// Every arm folds: `initial` (bare value), `failure` (function or tag map).
+declare const themedView: Effect.Effect<View, never, Theme>
+const InitialFoldsR = Async(fetchUser, {
+  initial: themedView,
+  failure: () => h("p", {}, "err"),
+  success: (u) => h("p", {}, u.name),
+})
+assertEquals<
+  typeof InitialFoldsR,
+  Effect.Effect<View, never, Http | Theme | Scope.Scope>
+>()
+const FailureFoldsR = Async(fetchUser, {
+  failure: () => themedView,
+  success: (u) => h("p", {}, u.name),
+})
+assertEquals<
+  typeof FailureFoldsR,
+  Effect.Effect<View, never, Http | Theme | Scope.Scope>
+>()
+const TagMapArmFoldsR = Async(fetchUser, {
+  failure: { HttpError: () => themedView },
+  success: (u) => h("p", {}, u.name),
+})
+assertEquals<
+  typeof TagMapArmFoldsR,
+  Effect.Effect<View, never, Http | Theme | Scope.Scope>
+>()
+
+// The original inference worry (a conditional arm) holds up post-#71: a
+// conditional over intrinsics/components folds each branch's R; an `any`
+// arm return is inert (guarded), not poisoning.
+const CondArm = Async(fetchUser, {
+  success: (u) => (flag ? h("p", {}, u.name) : themedView),
+})
+assertEquals<
+  typeof CondArm,
+  Effect.Effect<View<HttpError>, never, Http | Theme | Scope.Scope>
+>()
+// A component-call branch — the shape the original worry named — folds the
+// component's R and stays inferred. (Arms must still return
+// `View | Effect<View>`: `flag && <X/>` is `false | Effect`, rejected as
+// before — unchanged, unrelated to the fold.)
+const CompCondArm = Async(fetchUser, {
+  success: (u) => (flag ? UserPage({ userId: u.id }) : h("p", {}, u.name)),
+})
+assertEquals<
+  typeof CompCondArm,
+  Effect.Effect<View<HttpError>, never, Http | Theme | Scope.Scope>
+>()
+const AnyArm = Async(fetchUser, { success: () => someAny })
+assertEquals<
+  typeof AnyArm,
   Effect.Effect<View<HttpError>, never, Http | Scope.Scope>
+>()
+
+// A generic arms parameter would drop excess-property checking; NoExcess
+// re-arms it — a typo'd optional arm key is still a compile error (on the
+// call, as an overload-resolution failure) in all three forms.
+// @ts-expect-error — `intial` is not an arm
+Async(fetchUser, { intial: themedView, success: (u) => h("p", {}, u.name) })
+// @ts-expect-error — `intial` is not an arm
+Async(fetchUser, {
+  success: (u) => h("p", {}, u.name),
+  failure: () => h("p", {}, "x"),
+  intial: themedView,
+})
+// @ts-expect-error — `intial` is not an arm
+Async(fetchUser, {
+  success: (u) => h("p", {}, u.name),
+  failure: { HttpError: () => h("p", {}, "x") },
+  intial: themedView,
+})
+
+// Catch fallbacks fold too — both forms — while an arm needing only what the
+// runtime provides (Scope) or nothing adds nothing.
+declare const failingView: Effect.Effect<View, HttpError, never>
+const FallbackFoldsR = Catch(failingView, () => themedView)
+assertEquals<
+  typeof FallbackFoldsR,
+  Effect.Effect<View, never, Theme | Scope.Scope>
+>()
+// An inline handler that reads `cause` and `reset` still infers under the
+// generic H, and folds what it uses.
+const InlineFallback = Catch(failingView, (cause, reset) =>
+  Effect.gen(function* () {
+    yield* themedLog
+    return yield* h("button", { onclick: reset }, Cause.pretty(cause))
+  }),
+)
+assertEquals<
+  typeof InlineFallback,
+  Effect.Effect<View, never, Theme | Scope.Scope>
+>()
+const TagFallbackFoldsR = Catch(failingView, { HttpError: () => themedView })
+assertEquals<
+  typeof TagFallbackFoldsR,
+  Effect.Effect<View, never, Theme | Scope.Scope>
+>()
+declare const scopedView: Effect.Effect<View, never, Scope.Scope>
+const ScopedArmAddsNothing = Catch(failingView, () => scopedView)
+assertEquals<
+  typeof ScopedArmAddsNothing,
+  Effect.Effect<View, never, Scope.Scope>
 >()
 
 // A typed FAILING handler inside a Catch fallback is rejected (the fallback

--- a/packages/core/src/runtime/AGENTS.md
+++ b/packages/core/src/runtime/AGENTS.md
@@ -60,7 +60,8 @@ Public surface (from `index.ts`):
 - `VerrexLive` — deprecated no-op compat Layer (`mount` owns the registry)
 - Types: `View<E>`, `Props`, `FoldE`/`FoldLiveE`/`FoldR` (the `Tag*`
   families died with #71 — component channels are ordinary child folds),
-  `FoldPropsLiveE`/`FoldPropsR` (the props fold, #72),
+  `FoldPropsLiveE`/`FoldPropsR` (the props fold, #72), `ArmR`/`FoldArmsR`
+  (the arms fold, #120),
   `IntrinsicProps`, `HtmlEventHandlers`
 
 This is where the **channel propagation contract lives** —
@@ -118,7 +119,7 @@ and keeps its hint. If you rename a slot, update the regex.
 | `index.ts`             | Public exports + `list`, `Async`, `asyncRef`, `streamRef`, `Catch` (overloaded catch-all + tag-selective, over an internal `makeBoundary`), `Fragment`, `VerrexLive`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 | `coerce.test.ts`       | Vitest suite for `coerceAsync` / `coerceSync` (parity + the sync/async asymmetry pin)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
 | `reconcile.test.ts`    | Pure diff tests — an apply-to-array oracle (plan turns `prev` into `next`) plus exact op-sequence pins (move-minimality; index updates on shift)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
-| `types/Fold.ts`        | `ChildE`/`ChildLiveE`/`ChildR` + `FoldE`/`FoldLiveE`/`FoldR` — the channel-fold conditional types. Two error families: construction (`*E`, Effect channel) vs live (`*LiveE`, `View<E>` channel). No `Tag*` family since #71 (component tags are direct calls). Plus the props fold (#72): `FoldPropsLiveE`/`FoldPropsR` — an `on*` handler's `Effect` return contributes live `E` + `R`, via ONE cached `[E, R]` pass (`FoldPropsChannels`) with a zero-handler fast path, an `any`-guard, a bare-`on` exclusion, and AtomRef fold-through. Hard-won pin: the pair is read through a naked type param (`PairE`/`PairR`) — a non-distributive `never extends [infer E, any]` silently resolves to `unknown`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| `types/Fold.ts`        | `ChildE`/`ChildLiveE`/`ChildR` + `FoldE`/`FoldLiveE`/`FoldR` — the channel-fold conditional types. Two error families: construction (`*E`, Effect channel) vs live (`*LiveE`, `View<E>` channel). No `Tag*` family since #71 (component tags are direct calls). Plus the props fold (#72): `FoldPropsLiveE`/`FoldPropsR` — an `on*` handler's `Effect` return contributes live `E` + `R`, via ONE cached `[E, R]` pass (`FoldPropsChannels`) with a zero-handler fast path, an `any`-guard, a bare-`on` exclusion, and AtomRef fold-through. Hard-won pin: the pair is read through a naked type param (`PairE`/`PairR`) — a non-distributive `never extends [infer E, any]` silently resolves to `unknown`. Plus the arms fold (#120): `ArmR`/`FoldArmsR` — an Async arm or Catch fallback's `R` (minus `Scope`) folds onto the boundary                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | `types/Html.ts`        | `IntrinsicProps`/`HtmlEventHandlers` — typed event handlers for HTML intrinsics. Handlers return `unknown` (the honest `applyProp` contract: an `Effect` return is run, anything else ignored); the precise `E`/`R` are read off the _inferred_ props type by the props fold, not off this constraint                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
 | `types/Fold.test-d.ts` | `assertEquals` matrix — every channel-fold shape                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
 
@@ -518,19 +519,23 @@ The `from`/thunk runs under the **same dependency tracker as `h.track`**
 changes**, interrupting the stale run. A thunk that reads no refs runs once —
 deps are _discovered, not declared_.
 
-Arm channels are accepted permissively (`any`) and are not folded; that avoids a
-JSX conditional's `any`-folded channels breaking inference. **This also bounds
-the #72 handler guarantee**: a handler's `R` inside an arm (or a `Catch`
-fallback) is SWALLOWED by the arm's `any`, not folded — a missing Layer there
-surfaces only at click time, as a sink-routed defect (pinned explicitly in
-`channels.test-d.ts`). A typed _failing_ handler in an arm/fallback is at
-least rejected (the arm's success is `View<never>`) — discharge it inside
-(nest a `Catch`). **Arms must be
+**Arm `R` folds** (#120): the arms object is a generic `Arms` parameter and
+`FoldArmsR<Arms>` (types/Fold.ts) unions every arm's `R` — a function arm's
+return, a bare `initial`, and each tag-map handler — onto the result, minus
+`Scope` (arms render under the node scope via `coerceSync`). Arms render on
+the construction-captured context, so a service an arm or a handler inside it
+needs is a `mount`-time compile error, not a click-time Service-not-found
+defect. The pre-#120 "keep arms `any`" stance was an inference worry about
+conditional arms; post-#71 (component tags are direct calls) it does not
+reproduce — a conditional arm folds per branch, and an `any` return is inert
+via the `IsAny` guard (pinned in `channels.test-d.ts`). An arm's own Effect
+`E` stays permissive and its success must be `View<never>`: a typed _failing_
+handler in an arm/fallback is rejected at the arm — discharge it inside (nest
+a `Catch`). **Arms must be
 synchronous View-producers** — they render via `coerceSync` (the node's paired
 `runSyncExit`), so
 an _async_ arm effect can never resolve. A _failing_ arm effect is routed to the
 error sink (and renders `Empty`), not stringified — see "Runtime error routing".
-Keep arms pure markup.
 
 **Inline or extracted — both track.** The compiler rewrites `.value`→`h.read`
 across the whole component body, so an extracted thunk —
@@ -612,8 +617,9 @@ node's `setAmbient`). Tag-selective only catches errors in the _type_; an untype
 event-handler/reactive error needs the catch-all form.
 
 A subtree with undischarged errors won't pass `mount` — that's the thesis. (The
-fallback's own `E`/`R` are permissive `any`/not folded — keep it pure markup, like
-`Async`'s arms.)
+fallback's `R` folds — `ArmR<H>` for the catch-all, `FoldArmsR<Handlers>` for
+the tag map — like `Async`'s arms (#120); its own `E` is permissive and its
+success must be `View<never>`.)
 
 Catches **both phases** through one fallback:
 

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -21,7 +21,7 @@ import {
   makeDepSubscription,
   trackDeps,
 } from "./coerce.ts"
-import type { FoldE, FoldLiveE, FoldR } from "./types/Fold.ts"
+import type { ArmR, FoldArmsR, FoldE, FoldLiveE, FoldR } from "./types/Fold.ts"
 import { type BoundaryState, View } from "./View.ts"
 
 export * as Component from "./Component.ts"
@@ -38,6 +38,8 @@ export type {
   FoldLiveE,
   FoldPropsLiveE,
   FoldPropsR,
+  ArmR,
+  FoldArmsR,
   FoldR,
 } from "./types/Fold.ts"
 export type {
@@ -416,8 +418,11 @@ const taggedMatch = (
 
 /**
  * The arms for `Async` / `<Async>`. Each maps to an `AsyncResult` variant.
- * Channels are accepted permissively (`any`) — the arms render at the node scope
- * and their E/R are NOT folded; only `from`'s `R` is (the thesis-bearing one).
+ * An arm's `R` FOLDS onto the boundary's requirements (`FoldArmsR`, #120) —
+ * arms render on the construction-captured context, so a service an arm (or a
+ * handler inside it) needs must be provided at `mount`. An arm's own Effect
+ * `E` stays permissive and its success is `View<never>` (a typed failing
+ * handler in an arm is rejected at the arm; nest a `Catch`).
  */
 interface AsyncArmsBase<A> {
   readonly initial?: View | Effect.Effect<View, any, any>
@@ -435,6 +440,15 @@ interface AsyncArmsHandled<A, E> extends AsyncArmsBase<A> {
 /** Open form: no `failure` arm — the failure rides the live channel (`View<E>`). */
 interface AsyncArmsOpen<A> extends AsyncArmsBase<A> {
   readonly failure?: never
+}
+/**
+ * Re-arms excess-property checking for a GENERIC arms parameter: inferring
+ * `Arms` (needed to fold arm `R`, #120) turns off TS's object-literal
+ * excess check, so a typo'd optional key (`intial`) would compile and never
+ * render. Every key of `Arms` outside `Base` is forced to `never`.
+ */
+type NoExcess<Arms, Base> = Arms & {
+  readonly [K in Exclude<keyof Arms, keyof Base>]: never
 }
 
 /**
@@ -498,10 +512,15 @@ interface AsyncArmsOpen<A> extends AsyncArmsBase<A> {
  * during render (`failure: (c, retry) => { retry(); … }`) refetches in an
  * infinite loop.
  */
-export function Async<A, E, R = never>(
+export function Async<
+  A,
+  E,
+  R = never,
+  Arms extends AsyncArmsHandled<A, E> = AsyncArmsHandled<A, E>,
+>(
   from: AsyncSource<A, E, R>,
-  arms: AsyncArmsHandled<A, E>,
-): Effect.Effect<View, never, R | Scope.Scope>
+  arms: NoExcess<Arms, AsyncArmsHandled<A, E>>,
+): Effect.Effect<View, never, R | Scope.Scope | FoldArmsR<Arms>>
 export function Async<
   A,
   E,
@@ -511,18 +530,24 @@ export function Async<
     ? never
     : TagHandlers<E, [retry: () => void]>),
   R = never,
+  Arms extends AsyncArmsBase<A> = AsyncArmsBase<A>,
 >(
   from: AsyncSource<A, E, R>,
-  arms: AsyncArmsBase<A> & { readonly failure: Handlers },
+  arms: NoExcess<Arms, AsyncArmsHandled<A, E>> & { readonly failure: Handlers },
 ): Effect.Effect<
   View<Types.ExcludeTag<E, keyof Handlers & string>>,
   never,
-  R | Scope.Scope
+  R | Scope.Scope | FoldArmsR<Arms> | FoldArmsR<Handlers>
 >
-export function Async<A, E, R = never>(
+export function Async<
+  A,
+  E,
+  R = never,
+  Arms extends AsyncArmsOpen<A> = AsyncArmsOpen<A>,
+>(
   from: AsyncSource<A, E, R>,
-  arms: AsyncArmsOpen<A>,
-): Effect.Effect<View<E>, never, R | Scope.Scope>
+  arms: NoExcess<Arms, AsyncArmsOpen<A>>,
+): Effect.Effect<View<E>, never, R | Scope.Scope | FoldArmsR<Arms>>
 export function Async<A, E, R = never>(
   from: AsyncSource<A, E, R>,
   arms: AsyncArmsBase<A> & {
@@ -777,17 +802,24 @@ const makeBoundary = <R>(
  * Catches both phases — **construction** (`child`'s build Effect fails) and
  * **live** (a post-mount reactive re-render or event-handler Effect). `reset()`
  * re-runs construction. `child`'s `R` folds (construction + every reset run on
- * the mount fiber); the fallback's own `E`/`R` are not folded — keep it pure
- * markup, like `Async`'s arms. Tag-selective only catches errors in the *type*;
+ * the mount fiber); the fallback's `R` folds too (#120 — it renders on the
+ * captured context, so its services must be provided at `mount`), while its
+ * own `E` is not: the fallback must produce `View<never>` — like `Async`'s
+ * arms. Tag-selective only catches errors in the *type*;
  * an untyped event-handler or reactive error needs the catch-all form.
  */
-export function Catch<EV, EC, R>(
-  child: Effect.Effect<View<EV>, EC, R>,
-  handler: (
+export function Catch<
+  EV,
+  EC,
+  R,
+  H extends (
     cause: Cause.Cause<EC | EV>,
     reset: () => void,
   ) => View | Effect.Effect<View, any, any>,
-): Effect.Effect<View<never>, never, R | Scope.Scope>
+>(
+  child: Effect.Effect<View<EV>, EC, R>,
+  handler: H,
+): Effect.Effect<View<never>, never, R | Scope.Scope | ArmR<H>>
 export function Catch<
   EV,
   EC,
@@ -799,7 +831,7 @@ export function Catch<
 ): Effect.Effect<
   View<Types.ExcludeTag<EV, keyof Handlers & string>>,
   Types.ExcludeTag<EC, keyof Handlers & string>,
-  R | Scope.Scope
+  R | Scope.Scope | FoldArmsR<Handlers>
 >
 export function Catch(
   child: Effect.Effect<View<any>, any, any>,

--- a/packages/core/src/runtime/types/Fold.ts
+++ b/packages/core/src/runtime/types/Fold.ts
@@ -236,3 +236,33 @@ export type FoldPropsLiveE<P> = PairE<FoldPropsChannels<P>>
  * "Handler-scope semantics".
  */
 export type FoldPropsR<P> = Exclude<PairR<FoldPropsChannels<P>>, Scope.Scope>
+
+// ─── Arms fold: Async arms, Catch fallbacks, tag-map handlers (#120) ───────
+//
+// An arm/fallback renders on the node's construction-captured context, so a
+// service it (or a handler inside it) needs must be in that context — i.e.
+// provided at `mount`. Folding the arm's `R` onto the boundary's result makes
+// a missing Layer there the same compile error as everywhere else, instead
+// of a click-time Service-not-found defect. `Scope` is excluded: the arm
+// renders under the node scope (`coerceSync` provides it), like `list` rows
+// and handlers. Only `R` folds — an arm's OWN Effect `E` stays permissive and
+// its success stays `View<never>` (a typed failing handler inside an arm is
+// rejected at the arm; discharge it with a nested `Catch`).
+
+/**
+ * `R` of one arm: a function returning a View-or-Effect (its return is
+ * folded through `ChildR`) or a bare value (`initial`). `any` is inert.
+ */
+export type ArmR<F> =
+  IsAny<F> extends true
+    ? never
+    : F extends (...args: ReadonlyArray<any>) => infer Ret
+      ? IsAny<Ret> extends true
+        ? never
+        : Exclude<ChildR<Ret>, Scope.Scope>
+      : Exclude<ChildR<F>, Scope.Scope>
+
+/** Fold an arms/handlers object to the union of every arm's `R`. */
+export type FoldArmsR<Arms> = Arms extends unknown
+  ? { [K in keyof Arms]-?: ArmR<Arms[K]> }[keyof Arms]
+  : never


### PR DESCRIPTION
Arms and fallbacks render on the construction-captured context, so a
service an arm (or a handler inside it) needs must be provided at mount —
but their channels were permissive `any`, so a missing Layer surfaced only
at click time as a Service-not-found defect routed to the sink.

`ArmR`/`FoldArmsR` (types/Fold.ts) union every arm's `R` (function return,
bare `initial`, each tag-map handler) minus `Scope` onto Async's and Catch's
result. The pre-#71 inference worry (conditional arms) no longer
reproduces; pinned. Arm `E` stays permissive and its success `View<never>`.
`NoExcess` re-arms excess-property checking that a generic arms parameter
would otherwise drop.

Closes #120
